### PR TITLE
fix: clear setup write timeout on data-plane sender

### DIFF
--- a/independent/src/engine/data_plane.rs
+++ b/independent/src/engine/data_plane.rs
@@ -69,6 +69,11 @@ impl EasyConnectDataPlane {
                 .map_err(|error| Error(format!("modern send reply: {error}")))?,
             ModernCommand::Send,
         )?;
+        // The connection timeout protects setup, but the production send
+        // channel must tolerate transient backpressure while TCP retransmits.
+        // Keeping the setup write timeout would turn a temporary stall into a
+        // fatal data-plane failure.
+        send_stream.set_write_timeout(None)?;
 
         let mut receive_stream = connect_tls(
             peer,

--- a/independent/src/special_tls11.rs
+++ b/independent/src/special_tls11.rs
@@ -588,6 +588,11 @@ impl SpecialTls11Stream {
         Ok(())
     }
 
+    pub fn set_write_timeout(&self, timeout: Option<Duration>) -> Result<()> {
+        self.stream.set_write_timeout(timeout)?;
+        Ok(())
+    }
+
     pub fn read_application_data(&mut self, maximum: usize) -> Result<Zeroizing<Vec<u8>>> {
         if maximum == 0 || maximum > 16 * 1024 {
             return Err(Error(
@@ -838,5 +843,28 @@ mod tests {
             b"tunneled-packet"
         );
         server.join().unwrap();
+    }
+
+    #[test]
+    fn authenticated_stream_can_clear_setup_write_timeout() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let client_socket = TcpStream::connect(address).unwrap();
+        let (_server_socket, _) = listener.accept().unwrap();
+        client_socket
+            .set_write_timeout(Some(Duration::from_secs(7)))
+            .unwrap();
+
+        let client = SpecialTls11Stream {
+            stream: client_socket,
+            client_cipher: RecordCipher::new([23; 20], [29; 16]),
+            server_cipher: RecordCipher::new([17; 20], [19; 16]),
+        };
+        assert_eq!(
+            client.stream.write_timeout().unwrap(),
+            Some(Duration::from_secs(7))
+        );
+        client.set_write_timeout(None).unwrap();
+        assert_eq!(client.stream.write_timeout().unwrap(), None);
     }
 }


### PR DESCRIPTION
## Summary

- Clear the setup-only write timeout after the long-lived send channel is established.
- Add regression coverage for clearing the inherited socket write timeout.

## Motivation

`connect_gateway_tcp` applies the configured timeout to connection setup and socket I/O. The receive channel clears its read timeout after setup, but the send channel retains its write timeout. Under transient backpressure on macOS, this can produce `Resource temporarily unavailable (os error 35)`, mark the data plane unhealthy, and restart the engine, dropping active SSH sessions.

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`