### PR TITLE
fix: 收束连接与本地代理生命周期

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           npm run test:main-integration
           npm run test:main-engine-lifecycle
+          npm run test:main-network-startup
           ./node_modules/.bin/electron e2e/campus-browser-toolbar.electron.js
           npm run test:campus-mfa-safety
           npm run test:campus-popup-mfa-safety

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
         run: npm run test:main-integration
       - name: Exercise Main with a synthetic Engine lifecycle
         run: npm run test:main-engine-lifecycle
+      - name: Exercise initially-offline Main startup recovery
+        run: npm run test:main-network-startup
       - name: Exercise campus-browser toolbar IPC
         run: ./node_modules/.bin/electron e2e/campus-browser-toolbar.electron.js
       - name: Exercise Campus Browser MFA credential boundaries

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,6 +27,12 @@ more conservative status until the discrepancy is reviewed.
 
 ## Release 1.2.3 baseline
 
+正式交付：PR #5 merge commit与tag source均为
+`5d8323d37de7c279ae70b3ec646f93791d6a3581`；main CI run `32630023985`和
+tag build/release run `32630322732`均成功。Release包含macOS arm64/x64 DMG、Windows
+x64 EXE和Linux x64 AppImage。学校真实canary与Architecture Frozen开放项继续按
+[`docs/engineering/1x-release-gate.md`](docs/engineering/1x-release-gate.md)追踪。
+
 | Area | Implementation | Current evidence | Production result and remaining evidence |
 | --- | --- | --- | --- |
 | Independent password + modern L3 engine | `I3` | Current tree `E2`; earlier restricted canary is historical evidence | Rust owns auth, tunnel, userspace TCP/UDP and loopback proxying; repeat an authorized canary after Gateway/client changes |
@@ -117,6 +123,35 @@ Each command emits one bounded line prefixed with
 OS, architecture, Electron version, power mode and whether the machine was on
 battery. These reports do not measure gateway latency, tunnel throughput, DNS
 latency or real campus-page rendering.
+
+## Future 1.3 Gateway MFA milestone
+
+1.3保留给学校Gateway首次真实启用MFA后的独立认证版本。当前generic challenge framework、
+Control v3、synthetic provider和Campus Browser网页MFA安全只证明架构可扩展，不构成1.3
+功能，也不会因为类型或UI已经存在而提前发布该版本。
+
+### Entry gate
+
+只有同时满足以下条件才启动1.3 production实现：
+
+1. 学校提供受控MFA profile、授权测试身份和可比较的官方客户端；
+2. 至少一种真实方法有脱敏的状态、字段、失败和cleanup证据；
+3. synthetic HTTPS Gateway可以覆盖Cookie/CSRF rotation、partial body、timeout/reset和logout；
+4. Password→Challenge共用一个AuthAttemptBudget，continuation不能绕过Engine预算；
+5. provider可以独立feature-disable，不修改Modern L3、DNS、SOCKS或Campus Browser核心。
+
+### Exit gate
+
+1. 只对已验证的具体方法达到至少`I3/E4`，其余方法继续fail-closed；
+2. success、reject、indeterminate、expiry、resend、cancel和cleanup-unconfirmed均有稳定结果；
+3. OTP、Cookie、TwfID、CSRF、continuation和transport token不进入Renderer持久状态、日志、
+   telemetry、clipboard或crash report；
+4. password-only路径完整回归，MFA关闭后不改变现有Transport/frontend；
+5. 同profile官方客户端parity、staff canary、rollback和跨平台package gate通过。
+
+详细状态机和activation contract见
+[`docs/architecture/mfa-architecture.md`](docs/architecture/mfa-architecture.md)。在真实证据
+出现前，1.3保持`Deferred / evidence-triggered`，项目不猜测endpoint、验证码形状或渠道映射。
 
 ## Future 2.0.0 EasyConnect compatibility contingency plan
 

--- a/desktop/e2e/main-engine-fixture.js
+++ b/desktop/e2e/main-engine-fixture.js
@@ -27,6 +27,8 @@ if (!Number.isSafeInteger(generation) || generation <= 0 ||
 
 const attemptFile = path.join(userData, 'synthetic-engine-attempt.txt');
 const observationFile = path.join(userData, 'synthetic-engine-observations.jsonl');
+const stableFirstAttempt = process.env.HKUSTGZ_SYNTHETIC_ENGINE_STABLE_E2E === '1';
+const dropAfterConnected = process.env.HKUSTGZ_SYNTHETIC_ENGINE_DROP_AFTER_CONNECTED_E2E === '1';
 let attempt = 1;
 try { attempt = Number(fs.readFileSync(attemptFile, 'utf8')) + 1; } catch {}
 fs.writeFileSync(attemptFile, String(attempt));
@@ -83,7 +85,7 @@ input.on('line', (line) => {
     credentialLines += 1;
     if (credentialLines !== 2) return;
     observe('credentials_received');
-    if (attempt === 1) {
+    if (attempt === 1 && !stableFirstAttempt) {
       state('connecting');
       state('authenticating');
       state('preparing_tunnel');
@@ -115,6 +117,16 @@ input.on('line', (line) => {
         setTimeout(() => {
           state('connected');
           observe('connected_candidate_sent');
+          if (dropAfterConnected) {
+            setTimeout(() => {
+              send({ type: 'network_unhealthy', reason: 'data_plane_disconnected' });
+              state('stopping');
+              listener.close(() => send(
+                { type: 'stopped', reason: 'network_unhealthy', generation },
+                () => process.exit(23),
+              ));
+            }, 750);
+          }
         }, 300);
       });
     }, 600);

--- a/desktop/e2e/main-engine-lifecycle.electron.js
+++ b/desktop/e2e/main-engine-lifecycle.electron.js
@@ -102,15 +102,26 @@ async function run() {
   })`);
   assert.equal(savedPolicy.ok, true);
 
-  const started = await invoke(control, 'window.api.connect()');
-  assert.equal(started.ok, true);
+  const opening = invoke(control, `window.api.openCampusBrowser({
+    url: 'https://waiter.example.invalid/',
+    route: 'campus',
+  })`);
+  const secondOpening = invoke(control, `window.api.openCampusBrowser({
+    url: 'https://second-waiter.example.invalid/',
+    route: 'campus',
+  })`);
   const phases = new Set();
   await waitFor(async () => {
     const state = await invoke(control, 'window.api.getState()');
     phases.add(state.phase);
-    return attemptCount() >= 2;
-  }, 'automatic retry', 12_000);
+    return state.phase === 'retry-wait';
+  }, 'retry wait', 12_000);
   assert.ok(phases.has('retry-wait'), 'the first synthetic failure must enter retry-wait');
+  const thirdOpening = invoke(control, `window.api.openCampusBrowser({
+    url: 'https://mid-retry-waiter.example.invalid/',
+    route: 'campus',
+  })`);
+  await waitFor(() => attemptCount() >= 2, 'automatic retry', 12_000);
 
   const beforeValidGeneration = Date.now() + 250;
   while (Date.now() < beforeValidGeneration) {
@@ -138,6 +149,20 @@ async function run() {
   assert.ok(connected.clientIp);
   assert.equal(await loopbackConnects(port), true,
     'listener_ready must correspond to a real owned loopback listener');
+  const opened = await opening;
+  const secondOpened = await secondOpening;
+  const thirdOpened = await thirdOpening;
+  assert.equal(opened.ok, true,
+    'one intent-bound Main waiter must remain pending through same-intent retry');
+  assert.equal(secondOpened.ok, true,
+    'concurrent opens must coalesce onto the same active connection intent');
+  assert.equal(thirdOpened.ok, true,
+    'a mid-retry open must retain the existing intent and retry budget');
+  const activeConnect = await invoke(control, 'window.api.connect()');
+  assert.equal(activeConnect.ok, true);
+  assert.equal(activeConnect.existing, true,
+    'an already-active desired connection must be reused without a new intent');
+  assert.equal(attemptCount(), 2);
 
   const oldContentsId = control.webContents.id;
   control.webContents.forcefullyCrashRenderer();

--- a/desktop/e2e/main-network-startup.electron.js
+++ b/desktop/e2e/main-network-startup.electron.js
@@ -1,0 +1,134 @@
+'use strict';
+
+// Real Electron Main startup with a synthetic offline/online signal and the
+// fixed non-routing Engine fixture. It proves that an initially-offline launch
+// retains one desired connection without spawning the Engine, then starts one
+// and only one generation after connectivity returns.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
+const { app, BrowserWindow, safeStorage } = require('electron');
+const { savePassword } = require('../lib/credential-store');
+const { saveSettings } = require('../lib/settings-store');
+
+const TEST_TIMEOUT_MS = 20_000;
+const WAIT_TIMEOUT_MS = 10_000;
+const profile = fs.mkdtempSync(path.join(os.tmpdir(), 'hkustgz-network-startup-e2e-'));
+const networkStateFile = path.join(profile, 'synthetic-network-state.txt');
+const attemptFile = path.join(profile, 'synthetic-engine-attempt.txt');
+process.env.HKUSTGZ_USER_DATA_DIR = profile;
+process.env.HKUSTGZ_SYNTHETIC_ENGINE_E2E = '1';
+process.env.HKUSTGZ_SYNTHETIC_ENGINE_STABLE_E2E = '1';
+process.env.HKUSTGZ_SYNTHETIC_NETWORK_E2E = '1';
+app.disableHardwareAcceleration();
+
+async function waitFor(condition, description, timeoutMs = WAIT_TIMEOUT_MS) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await condition();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`timed out waiting for ${description}`);
+}
+
+function attemptCount() {
+  try { return Number(fs.readFileSync(attemptFile, 'utf8')); }
+  catch { return 0; }
+}
+
+async function allocateLoopbackPort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      server.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+async function controlWindow() {
+  return waitFor(() => BrowserWindow.getAllWindows().find((candidate) => (
+    candidate.webContents.getURL().endsWith('/renderer/index.html') &&
+    !candidate.webContents.isLoading()
+  )), 'control window');
+}
+
+function invoke(window, expression) {
+  return window.webContents.executeJavaScript(`(async () => (${expression}))()`);
+}
+
+async function prepareProfile() {
+  await app.whenReady();
+  const port = await allocateLoopbackPort();
+  saveSettings(path.join(profile, 'settings.json'), {
+    username: 'synthetic-network-user',
+    port,
+    autoConnect: true,
+    autoReconnect: false,
+    strictProxyAuth: false,
+  });
+  assert.equal(savePassword(
+    path.join(profile, 'cred.bin'),
+    'synthetic-network-password',
+    safeStorage,
+    process.platform,
+  ), true, 'the Electron credential backend must be available for the startup fixture');
+  fs.writeFileSync(networkStateFile, 'offline\n', { mode: 0o600 });
+  return port;
+}
+
+async function run() {
+  await prepareProfile();
+  require('../main');
+  const control = await controlWindow();
+  await waitFor(async () => (await invoke(control, 'window.api.getState()')).phase ===
+    'connectivity-paused', 'initial offline pause');
+  assert.equal(attemptCount(), 0, 'initial offline startup must not spawn an Engine');
+
+  fs.writeFileSync(networkStateFile, 'online\n', { mode: 0o600 });
+  await waitFor(async () => {
+    const state = await invoke(control, 'window.api.getState()');
+    return state.connected && attemptCount() === 1;
+  }, 'single online Engine generation');
+
+  fs.writeFileSync(networkStateFile, 'offline\n', { mode: 0o600 });
+  await waitFor(async () => {
+    const state = await invoke(control, 'window.api.getState()');
+    return state.phase === 'connectivity-paused' && attemptCount() === 1;
+  }, 'ordinary offline pause');
+  fs.writeFileSync(networkStateFile, 'online\n', { mode: 0o600 });
+  await new Promise((resolve) => setTimeout(resolve, 2500));
+  assert.equal(attemptCount(), 1,
+    'ordinary online must not auto-reconnect when autoReconnect is false');
+  const manual = await invoke(control, 'window.api.connect()');
+  assert.equal(manual.ok, true, 'declined automatic recovery must leave manual connect usable');
+  await waitFor(async () => {
+    const state = await invoke(control, 'window.api.getState()');
+    return state.connected && attemptCount() === 2;
+  }, 'manual connection after declined ordinary recovery');
+  process.stdout.write('main initial network startup: PASS\n');
+}
+
+const hardTimeout = setTimeout(() => {
+  process.stderr.write('main initial network startup: hard timeout\n');
+  app.exit(1);
+}, TEST_TIMEOUT_MS);
+
+run().then(
+  () => { clearTimeout(hardTimeout); app.quit(); },
+  (error) => {
+    clearTimeout(hardTimeout);
+    process.stderr.write(`${error.stack || error}\n`);
+    app.exitCode = 1;
+    app.quit();
+  },
+);
+
+app.on('quit', () => {
+  try { fs.rmSync(profile, { recursive: true, force: true }); } catch {}
+});

--- a/desktop/lib/connection-state-machine.js
+++ b/desktop/lib/connection-state-machine.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { planReconnect } = require('./reconnect-policy');
+const { ConnectionWaitRegistry } = require('./connection-wait-registry');
 
 const CONNECTION_PHASE = Object.freeze({
   IDLE: 'idle',
@@ -321,14 +322,11 @@ class ConnectionStateMachine {
     this.#desiredConnected = false;
     return Object.freeze({ action: 'exhausted' });
   }
-
-  shouldStopWaiting({ hasActive = false, lastError = null } = {}) {
-    return this.#userDisconnected || (!this.isConnecting() && !hasActive && Boolean(lastError));
-  }
 }
 
 module.exports = {
   CONNECTION_PHASE,
+  ConnectionWaitRegistry,
   ConnectionStateMachine,
   connectionPresentation,
   projectConnectionStatus,

--- a/desktop/lib/connection-wait-registry.js
+++ b/desktop/lib/connection-wait-registry.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const DEFAULT_CONNECTION_WAIT_MS = 45_000;
+const MAX_CONNECTION_WAIT_MS = 10 * 60 * 1000;
+const MAX_PENDING_CONNECTION_INTENTS = 32;
+
+function validIntent(value) {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+function normalizedSnapshot(value) {
+  if (!value || !validIntent(value.intent) || typeof value.phase !== 'string' ||
+      typeof value.desiredConnected !== 'boolean') return null;
+  return Object.freeze({
+    intent: value.intent,
+    phase: value.phase,
+    desiredConnected: value.desiredConnected,
+  });
+}
+
+function outcomeFor(intent, snapshot) {
+  if (!snapshot) return null;
+  if (snapshot.intent !== intent) return false;
+  if (snapshot.phase === 'connected') return true;
+  if (!snapshot.desiredConnected) return false;
+  return null;
+}
+
+class ConnectionWaitRegistry {
+  constructor({ setTimeoutFn = setTimeout, clearTimeoutFn = clearTimeout } = {}) {
+    if (typeof setTimeoutFn !== 'function' || typeof clearTimeoutFn !== 'function') {
+      throw new TypeError('connection wait timer dependencies are invalid');
+    }
+    this.setTimeoutFn = setTimeoutFn;
+    this.clearTimeoutFn = clearTimeoutFn;
+    this.latest = null;
+    this.waiters = new Map();
+    this.disposed = false;
+  }
+
+  observe(value) {
+    if (this.disposed) return false;
+    const snapshot = normalizedSnapshot(value);
+    if (!snapshot) return false;
+    if (this.latest && snapshot.intent < this.latest.intent) return false;
+    this.latest = snapshot;
+    for (const waiter of [...this.waiters.values()]) {
+      const outcome = outcomeFor(waiter.intent, snapshot);
+      if (outcome !== null) this.settle(waiter, outcome);
+    }
+    return true;
+  }
+
+  wait(intent, { timeoutMs = DEFAULT_CONNECTION_WAIT_MS } = {}) {
+    if (!validIntent(intent) || !Number.isFinite(timeoutMs) || timeoutMs <= 0 ||
+        timeoutMs > MAX_CONNECTION_WAIT_MS) {
+      return Promise.resolve(false);
+    }
+    if (this.disposed) return Promise.resolve(false);
+    const immediate = outcomeFor(intent, this.latest);
+    if (immediate !== null) return Promise.resolve(immediate);
+    const existing = this.waiters.get(intent);
+    if (existing) return existing.promise;
+    if (this.waiters.size >= MAX_PENDING_CONNECTION_INTENTS) return Promise.resolve(false);
+
+    let resolve;
+    const promise = new Promise((done) => { resolve = done; });
+    const waiter = { intent, resolve, promise, timer: null, settled: false };
+    this.waiters.set(intent, waiter);
+    const timer = this.setTimeoutFn(() => this.settle(waiter, false), timeoutMs);
+    if (waiter.settled) {
+      try { this.clearTimeoutFn(timer); } catch {}
+      return promise;
+    }
+    waiter.timer = timer;
+    waiter.timer?.unref?.();
+    const outcome = outcomeFor(intent, this.latest);
+    if (outcome !== null) this.settle(waiter, outcome);
+    return promise;
+  }
+
+  settle(waiter, outcome) {
+    if (!waiter || waiter.settled || this.waiters.get(waiter.intent) !== waiter) return false;
+    waiter.settled = true;
+    this.waiters.delete(waiter.intent);
+    try { this.clearTimeoutFn(waiter.timer); } catch {}
+    waiter.timer = null;
+    waiter.resolve(outcome === true);
+    return true;
+  }
+
+  dispose() {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.latest = null;
+    for (const waiter of [...this.waiters.values()]) this.settle(waiter, false);
+  }
+
+  snapshot() {
+    return Object.freeze({ disposed: this.disposed, waiters: this.waiters.size });
+  }
+}
+
+module.exports = {
+  ConnectionWaitRegistry,
+  DEFAULT_CONNECTION_WAIT_MS,
+  MAX_CONNECTION_WAIT_MS,
+  MAX_PENDING_CONNECTION_INTENTS,
+  normalizedSnapshot,
+  outcomeFor,
+};

--- a/desktop/lib/connectivity-recovery.js
+++ b/desktop/lib/connectivity-recovery.js
@@ -12,12 +12,14 @@ class ConnectivityRecovery {
     getLifecycleIntent,
     shouldReconnect,
     reconnect,
+    onRecoveryDeclined = () => {},
     setTimeout: setTimer = globalThis.setTimeout,
     clearTimeout: clearTimer = globalThis.clearTimeout,
     debounceMs = RECOVERY_DEBOUNCE_MS,
   } = {}) {
     if (typeof invalidate !== 'function' || typeof getLifecycleIntent !== 'function' ||
         typeof shouldReconnect !== 'function' || typeof reconnect !== 'function' ||
+        typeof onRecoveryDeclined !== 'function' ||
         typeof setTimer !== 'function' || typeof clearTimer !== 'function') {
       throw new TypeError('connectivity recovery callbacks are required');
     }
@@ -28,6 +30,7 @@ class ConnectivityRecovery {
     this.getLifecycleIntent = getLifecycleIntent;
     this.shouldReconnect = shouldReconnect;
     this.reconnect = reconnect;
+    this.onRecoveryDeclined = onRecoveryDeclined;
     this.setTimer = setTimer;
     this.clearTimerFn = clearTimer;
     this.debounceMs = debounceMs;
@@ -38,6 +41,7 @@ class ConnectivityRecovery {
     this.pendingIntent = null;
     this.timerRecord = null;
     this.recoveryRecord = null;
+    this.initialRecoveryIntent = null;
     this.epoch = 0;
     this.disposed = false;
   }
@@ -68,6 +72,7 @@ class ConnectivityRecovery {
     this.epoch += 1;
     this.cancelTimer();
     const sameOutage = this.pending && Object.is(this.pendingIntent, intent);
+    if (!sameOutage) this.initialRecoveryIntent = null;
     this.pending = true;
     this.pendingIntent = intent;
     if (!sameOutage) {
@@ -100,6 +105,17 @@ class ConnectivityRecovery {
     return this.scheduleIfReady('network-online', explicitIntent);
   }
 
+  initialNetworkOnline(explicitIntent) {
+    if (this.disposed) return false;
+    this.offline = false;
+    const intent = this.currentIntent(explicitIntent);
+    if (!this.pending || !Object.is(this.pendingIntent, intent) || !this.isCurrentIntent(intent)) {
+      return false;
+    }
+    this.initialRecoveryIntent = intent;
+    return this.scheduleIfReady('initial-network-online', intent);
+  }
+
   scheduleIfReady(reason, explicitIntent) {
     if (this.disposed || !this.pending || this.suspended || this.offline) return false;
     const intent = this.currentIntent(explicitIntent);
@@ -110,10 +126,13 @@ class ConnectivityRecovery {
     if (this.timerRecord && Object.is(this.timerRecord.intent, intent)) return true;
 
     this.epoch += 1;
+    const effectiveReason = Object.is(this.initialRecoveryIntent, intent)
+      ? 'initial-network-online'
+      : reason;
     const record = {
       epoch: this.epoch,
       intent,
-      reason,
+      reason: effectiveReason,
       timer: null,
     };
     record.timer = this.setTimer(() => {
@@ -135,18 +154,24 @@ class ConnectivityRecovery {
     }
 
     let allowed = false;
-    try { allowed = await this.shouldReconnect(record.intent); } catch { allowed = false; }
-    if (!allowed || this.disposed || record.epoch !== this.epoch || !this.pending ||
-        this.suspended || this.offline || !Object.is(this.pendingIntent, record.intent) ||
-        !this.isCurrentIntent(record.intent)) {
+    try { allowed = await this.shouldReconnect(record.intent, record.reason); }
+    catch { allowed = false; }
+    const remainsEligible = !this.disposed && record.epoch === this.epoch && this.pending &&
+        !this.suspended && !this.offline && Object.is(this.pendingIntent, record.intent) &&
+        this.isCurrentIntent(record.intent);
+    if (!allowed || !remainsEligible) {
+      const declined = !allowed && remainsEligible;
       if (record.epoch === this.epoch) this.cancelPending();
+      if (declined) {
+        try { this.onRecoveryDeclined(record.intent, record.reason); } catch {}
+      }
       return false;
     }
-
     // Consume the outage before invoking reconnect so duplicate resume/online
     // events cannot start a second recovery while the first is in flight.
     this.pending = false;
     this.pendingIntent = null;
+    this.initialRecoveryIntent = null;
     const recovery = { epoch: record.epoch, intent: record.intent, reason: record.reason };
     this.recoveryRecord = recovery;
     try {
@@ -164,6 +189,7 @@ class ConnectivityRecovery {
     this.cancelTimer();
     this.pending = false;
     this.pendingIntent = null;
+    this.initialRecoveryIntent = null;
   }
 
   // Main calls cancel on explicit disconnect and before quit. It deliberately

--- a/desktop/lib/network-status-monitor.js
+++ b/desktop/lib/network-status-monitor.js
@@ -1,8 +1,204 @@
 'use strict';
 
+const fs = require('node:fs');
+const path = require('node:path');
+
 const DEFAULT_NETWORK_POLL_MS = 4000;
 const MIN_NETWORK_POLL_MS = 1000;
 const MAX_NETWORK_POLL_MS = 60_000;
+const DEFAULT_AUTO_CONNECT_DELAY_MS = 500;
+const DEFAULT_INITIAL_BASELINE_WAIT_MS = 15_000;
+const MAX_INITIAL_BASELINE_WAIT_MS = 60_000;
+const SYNTHETIC_NETWORK_E2E_ENV = 'HKUSTGZ_SYNTHETIC_NETWORK_E2E';
+const SYNTHETIC_NETWORK_STATE_FILE = 'synthetic-network-state.txt';
+
+// Owns the one-time hand-off from the first network sample to startup
+// auto-connect. Runtime outage recovery remains in ConnectivityRecovery; this
+// coordinator only prevents an initially-offline launch from spending its
+// retry budget before the machine has a usable network.
+class NetworkStartupCoordinator {
+  constructor({
+    monitor,
+    shouldAutoConnect,
+    pauseOffline,
+    resumeOffline,
+    connect,
+    isQuitting,
+    setTimeout: setTimer = globalThis.setTimeout,
+    clearTimeout: clearTimer = globalThis.clearTimeout,
+    delayMs = DEFAULT_AUTO_CONNECT_DELAY_MS,
+    baselineWaitMs = DEFAULT_INITIAL_BASELINE_WAIT_MS,
+  } = {}) {
+    if (!monitor || typeof monitor.start !== 'function' ||
+        typeof monitor.snapshot !== 'function' ||
+        typeof shouldAutoConnect !== 'function' || typeof pauseOffline !== 'function' ||
+        typeof resumeOffline !== 'function' || typeof connect !== 'function' ||
+        typeof isQuitting !== 'function' || typeof setTimer !== 'function' ||
+        typeof clearTimer !== 'function' || !Number.isFinite(delayMs) || delayMs < 0 ||
+        !Number.isFinite(baselineWaitMs) || baselineWaitMs <= 0 ||
+        baselineWaitMs > MAX_INITIAL_BASELINE_WAIT_MS) {
+      throw new TypeError('network startup coordinator dependencies are invalid');
+    }
+    Object.assign(this, {
+      monitor, shouldAutoConnect, pauseOffline, resumeOffline, connect, isQuitting,
+    });
+    this.setTimer = setTimer;
+    this.clearTimer = clearTimer;
+    this.delayMs = delayMs;
+    this.baselineWaitMs = baselineWaitMs;
+    this.epoch = 0;
+    this.started = false;
+    this.disposed = false;
+    this.startPromise = null;
+    this.timerRecord = null;
+    this.pausedOffline = false;
+    this.offlineContext = null;
+    this.offlineConsumed = false;
+    this.baselineWait = null;
+  }
+
+  current(epoch) {
+    return !this.disposed && epoch === this.epoch && !this.isQuitting();
+  }
+
+  eligible() {
+    if (this.isQuitting()) return false;
+    try { return this.shouldAutoConnect() === true; }
+    catch { return false; }
+  }
+
+  start() {
+    if (this.disposed) return Promise.resolve(false);
+    if (this.started) return this.startPromise;
+    this.started = true;
+    const epoch = ++this.epoch;
+    this.startPromise = this.initialize(epoch);
+    return this.startPromise;
+  }
+
+  async initialize(epoch) {
+    let started;
+    try { started = await this.monitor.start(); }
+    catch { return false; }
+    if (started !== true || !this.current(epoch) || !this.eligible()) return false;
+
+    let baseline = this.monitor.snapshot().baseline;
+    if (baseline == null) {
+      if (typeof this.monitor.waitForBaseline !== 'function') return false;
+      const waiting = this.monitor.waitForBaseline({ timeoutMs: this.baselineWaitMs });
+      this.baselineWait = waiting;
+      try { baseline = await waiting.promise; }
+      finally {
+        if (this.baselineWait === waiting) this.baselineWait = null;
+        waiting.cancel();
+      }
+      if (!this.current(epoch) || typeof baseline !== 'boolean' || !this.eligible()) return false;
+    }
+
+    if (baseline === false) {
+      let paused = null;
+      try { paused = await this.pauseOffline(); } catch {}
+      if (!this.current(epoch) || paused == null || paused === false) return false;
+      this.pausedOffline = true;
+      this.offlineContext = paused;
+      return true;
+    }
+
+    const record = { epoch, timer: null };
+    record.timer = this.setTimer(() => {
+      if (this.timerRecord !== record) return undefined;
+      this.timerRecord = null;
+      if (!this.current(epoch) || !this.eligible()) return undefined;
+      return Promise.resolve().then(() => this.connect()).catch(() => {});
+    }, this.delayMs);
+    record.timer?.unref?.();
+    this.timerRecord = record;
+    return true;
+  }
+
+  async networkOnline() {
+    if (this.disposed || !this.pausedOffline || this.offlineConsumed || this.isQuitting()) {
+      return false;
+    }
+    this.offlineConsumed = true;
+    this.pausedOffline = false;
+    const context = this.offlineContext;
+    this.offlineContext = null;
+    try { await this.resumeOffline(context); } catch {}
+    return true;
+  }
+
+  cancel() {
+    this.epoch += 1;
+    this.baselineWait?.cancel();
+    this.baselineWait = null;
+    if (this.timerRecord) {
+      try { this.clearTimer(this.timerRecord.timer); } catch {}
+    }
+    this.timerRecord = null;
+    this.pausedOffline = false;
+    this.offlineContext = null;
+    this.offlineConsumed = true;
+  }
+
+  dispose() {
+    if (this.disposed) return;
+    this.cancel();
+    this.disposed = true;
+  }
+
+  snapshot() {
+    return {
+      started: this.started,
+      disposed: this.disposed,
+      pausedOffline: this.pausedOffline,
+      timerScheduled: this.timerRecord !== null,
+    };
+  }
+}
+
+function createNetworkStartupSystem({
+  appIsPackaged,
+  environment = process.env,
+  dataDirectory,
+  fileSystem = fs,
+  isOnline,
+  onOffline,
+  onOnline,
+  shouldAutoConnect,
+  pauseOffline,
+  resumeInitialOffline,
+  connect,
+  isQuitting,
+} = {}) {
+  if (typeof appIsPackaged !== 'boolean' || !environment ||
+      typeof dataDirectory !== 'string' || !path.isAbsolute(dataDirectory) ||
+      !fileSystem || typeof isOnline !== 'function' || typeof onOffline !== 'function' ||
+      typeof onOnline !== 'function' || typeof resumeInitialOffline !== 'function') {
+    throw new TypeError('network startup system environment is invalid');
+  }
+  const synthetic = !appIsPackaged && environment[SYNTHETIC_NETWORK_E2E_ENV] === '1';
+  const stateFile = path.join(dataDirectory, SYNTHETIC_NETWORK_STATE_FILE);
+  let startup = null;
+  const monitor = new NetworkStatusMonitor({
+    isOnline: () => {
+      if (!synthetic) return isOnline();
+      try { return fileSystem.readFileSync(stateFile, 'utf8').trim() === 'online'; }
+      catch { return false; }
+    },
+    onOffline,
+    onOnline: async () => {
+      if (await startup?.networkOnline()) return true;
+      return onOnline();
+    },
+    intervalMs: synthetic ? 1000 : undefined,
+  });
+  startup = new NetworkStartupCoordinator({
+    monitor, shouldAutoConnect, pauseOffline, resumeOffline: resumeInitialOffline,
+    connect, isQuitting,
+  });
+  return Object.freeze({ monitor, startup, syntheticStateFile: synthetic ? stateFile : null });
+}
 
 class NetworkStatusMonitor {
   constructor({
@@ -35,6 +231,7 @@ class NetworkStatusMonitor {
     this.baseline = null;
     this.timerRecord = null;
     this.pollRecord = null;
+    this.baselineWaiters = new Set();
   }
 
   isCurrent(epoch) {
@@ -72,6 +269,7 @@ class NetworkStatusMonitor {
         if (this.baseline === null) {
           // Startup learns the current state without synthesizing an event.
           this.baseline = observed;
+          this.publishBaseline(observed);
         } else if (observed !== this.baseline) {
           this.baseline = observed;
           try {
@@ -101,11 +299,55 @@ class NetworkStatusMonitor {
     return true;
   }
 
+  waitForBaseline({ timeoutMs = DEFAULT_INITIAL_BASELINE_WAIT_MS } = {}) {
+    if (this.disposed || !this.running || !Number.isFinite(timeoutMs) || timeoutMs <= 0 ||
+        timeoutMs > MAX_INITIAL_BASELINE_WAIT_MS) {
+      return { promise: Promise.resolve(null), cancel() {} };
+    }
+    if (typeof this.baseline === 'boolean') {
+      return { promise: Promise.resolve(this.baseline), cancel() {} };
+    }
+    let resolve;
+    const record = { resolve: null, timer: null, settled: false };
+    const promise = new Promise((done) => { resolve = done; });
+    record.resolve = resolve;
+    this.baselineWaiters.add(record);
+    const timer = this.setTimer(() => this.settleBaselineWaiter(record, null), timeoutMs);
+    if (record.settled) {
+      try { this.clearTimer(timer); } catch {}
+    } else {
+      record.timer = timer;
+      record.timer?.unref?.();
+    }
+    return {
+      promise,
+      cancel: () => this.settleBaselineWaiter(record, null),
+    };
+  }
+
+  settleBaselineWaiter(record, value) {
+    if (!record || record.settled || !this.baselineWaiters.has(record)) return false;
+    record.settled = true;
+    this.baselineWaiters.delete(record);
+    try { this.clearTimer(record.timer); } catch {}
+    record.resolve(typeof value === 'boolean' ? value : null);
+    return true;
+  }
+
+  publishBaseline(value) {
+    for (const record of [...this.baselineWaiters]) this.settleBaselineWaiter(record, value);
+  }
+
   stop() {
-    if (!this.running) return;
+    if (!this.running) {
+      this.baseline = null;
+      this.publishBaseline(null);
+      return;
+    }
     this.running = false;
     this.epoch += 1;
     this.baseline = null;
+    this.publishBaseline(null);
     if (this.timerRecord) {
       try { this.clearTimer(this.timerRecord.timer); } catch {}
       this.timerRecord = null;
@@ -133,8 +375,15 @@ class NetworkStatusMonitor {
 }
 
 module.exports = {
+  DEFAULT_AUTO_CONNECT_DELAY_MS,
+  DEFAULT_INITIAL_BASELINE_WAIT_MS,
   DEFAULT_NETWORK_POLL_MS,
   MAX_NETWORK_POLL_MS,
+  MAX_INITIAL_BASELINE_WAIT_MS,
   MIN_NETWORK_POLL_MS,
+  NetworkStartupCoordinator,
   NetworkStatusMonitor,
+  SYNTHETIC_NETWORK_E2E_ENV,
+  SYNTHETIC_NETWORK_STATE_FILE,
+  createNetworkStartupSystem,
 };

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -56,7 +56,7 @@ const { BufferedLogWriter, readLogTail } = require('./lib/log-writer');
 const { STOP_GRACE_MS, STOP_FORCE_WAIT_MS } = require('./lib/stop-policy');
 const { AUTO_CHECK_INTERVAL_MS, checkForUpdate, isAllowedReleaseUrl, shouldAutoCheck } = require('./lib/update-check');
 const { ConnectivityRecovery } = require('./lib/connectivity-recovery');
-const { NetworkStatusMonitor } = require('./lib/network-status-monitor');
+const { createNetworkStartupSystem } = require('./lib/network-status-monitor');
 const { EphemeralProxyCredential, cleanupProxyAccessForEngineClose } = require('./lib/proxy-credential');
 const {
   ExternalProxyCredentialStore,
@@ -75,7 +75,7 @@ const { createT, effectiveLocale } = require('./lib/i18n');
 const { registerTrustedIpcHandlers } = require('./lib/ipc-handlers');
 const { RoutingPolicyTransactionQueue } = require('./lib/routing-policy-transaction');
 const { stopEngineAfterBrowserSuspend } = require('./lib/browser-engine-barrier');
-const { ConnectionStateMachine, projectConnectionStatus } = require('./lib/connection-state-machine');
+const { ConnectionStateMachine, ConnectionWaitRegistry, projectConnectionStatus } = require('./lib/connection-state-machine');
 // The campus browser is intentionally constrained to the application's
 // proxy/PAC boundary. WebRTC data channels do not require camera or microphone
 // permission and Chromium may otherwise send ICE/STUN UDP directly, bypassing
@@ -159,6 +159,8 @@ let connectInFlight = null;
 let disconnectInFlight = null;
 let reconnectInFlight = null;
 const connectionState = new ConnectionStateMachine();
+const connectionWaitRegistry = new ConnectionWaitRegistry();
+connectionWaitRegistry.observe(connectionState.snapshot());
 const MAX_ATTEMPTS = 3;
 let connectedAt = null;
 let telemetryCoordinator = null;
@@ -408,6 +410,7 @@ function engineConfigPath() {
 }
 function emit() {
   state.pacUrl = pacUrl();
+  connectionWaitRegistry.observe(connectionState.snapshot());
   // locale rides along so a language change reaches the renderer without a
   // separate channel; update rides along so an automatic check that finds a
   // new release surfaces without waiting for a full refresh. get-state stays
@@ -452,6 +455,7 @@ function killStrayEngines(resolvedEnginePath) {
 function beginLifecycleIntent() {
   // A manual connect/disconnect/reconnect always supersedes any recovery that
   // was queued for a previous sleep or network outage.
+  networkStartupCoordinator?.cancel();
   connectivityRecovery.cancel();
   return connectionState.beginConnectIntent();
 }
@@ -482,12 +486,13 @@ function invalidateForConnectivity(reason, intent) {
   }).catch(() => {});
 }
 
-async function recoverConnectivity(intent) {
+async function recoverConnectivity(intent, reason) {
   let autoReconnect;
   try {
-    autoReconnect = loadSettingsOrReport().autoReconnect !== false;
+    autoReconnect = reason === 'initial-network-online' || loadSettingsOrReport().autoReconnect !== false;
   } catch {
     connectionState.failIntent(intent);
+    emit();
     return false;
   }
   if (!connectionState.canRecover(intent, {
@@ -521,47 +526,60 @@ const connectivityRecovery = new ConnectivityRecovery({
   getLifecycleIntent: () => connectionState.currentRecoveryIntent({
     isQuitting: desktopShell?.isQuitting === true,
   }),
-  shouldReconnect: async (intent) => {
+  shouldReconnect: async (intent, reason) => {
     try {
       return connectionState.canRecover(intent, {
         isQuitting: desktopShell?.isQuitting === true,
-        autoReconnect: loadSettingsOrReport().autoReconnect !== false,
+        autoReconnect: reason === 'initial-network-online' || loadSettingsOrReport().autoReconnect !== false,
       });
     } catch {
       connectionState.failIntent(intent);
+      emit();
       return false;
     }
   },
-  reconnect: recoverConnectivity,
+  reconnect: recoverConnectivity, onRecoveryDeclined: (intent, reason) => { if (reason !== 'initial-network-online' && connectionState.failIntent(intent)) emit(); },
 });
-
-const networkStatusMonitor = new NetworkStatusMonitor({
-  isOnline: () => electronNet.isOnline(),
-  onOffline: () => connectivityRecovery.networkOffline(),
-  onOnline: () => connectivityRecovery.networkOnline(),
+const { monitor: networkStatusMonitor, startup: networkStartupCoordinator } = createNetworkStartupSystem({
+  appIsPackaged: app.isPackaged, environment: process.env, dataDirectory: DATA, fileSystem: fs,
+  isOnline: () => electronNet.isOnline(), onOffline: () => connectivityRecovery.networkOffline(),
+  onOnline: () => connectivityRecovery.networkOnline(), shouldAutoConnect: () => { const s = loadSettingsOrReport(); return s.autoConnect !== false && Boolean(s.username) && hasStoredCredential(); },
+  pauseOffline: () => { connectivityRecovery.cancel(); const intent = connectionState.beginConnectIntent(); return connectivityRecovery.networkOffline(intent) ? intent : null; },
+  resumeInitialOffline: (intent) => connectivityRecovery.initialNetworkOnline(intent), connect: () => connect(), isQuitting: () => desktopShell?.isQuitting === true,
 });
-
+function rejectConnectionWhileQuitting(intent = connectionState.snapshot().intent) {
+  if (desktopShell?.isQuitting !== true) return null;
+  connectionState.failIntent(intent); emit();
+  return { ok: false, stale: true, quitting: true, intent };
+}
 async function connect(isRetry = false, expectedIntent = null) {
-  const intent = expectedIntent === null
-    ? (isRetry ? connectionState.snapshot().intent : beginLifecycleIntent())
-    : expectedIntent;
-  if (!connectionState.canContinue(intent)) return { ok: false, stale: true };
-
-  // A connect requested while an earlier stop is draining waits for close;
-  // it never starts a second process into the exit/close interval.
+  let rejected = rejectConnectionWhileQuitting(expectedIntent ?? undefined); if (rejected) return rejected;
+  let intent = expectedIntent;
+  if (intent === null && !isRetry) {
+    if (disconnectInFlight) await disconnectInFlight;
+    rejected = rejectConnectionWhileQuitting(); if (rejected) return rejected;
+    const current = connectionState.snapshot();
+    if (current.desiredConnected) {
+      if (connectInFlight?.intent === current.intent) return connectInFlight.promise;
+      return { ok: true, existing: engineSupervisor.hasActive, pending: !engineSupervisor.hasActive, intent: current.intent };
+    }
+    intent = beginLifecycleIntent();
+  } else if (intent === null) intent = connectionState.snapshot().intent;
+  if (!connectionState.canContinue(intent)) return { ok: false, stale: true, intent };
+  // Wait for an earlier stop to drain; never start a process into its exit/close interval.
   if (disconnectInFlight) await disconnectInFlight;
-  if (!connectionState.canContinue(intent)) return { ok: false, stale: true };
-  if (engineSupervisor.hasActive) return { ok: true, existing: true };
+  rejected = rejectConnectionWhileQuitting(intent); if (rejected) return rejected;
+  if (!connectionState.canContinue(intent)) return { ok: false, stale: true, intent };
+  if (engineSupervisor.hasActive) return { ok: true, existing: true, intent };
   if (connectInFlight) {
-    await connectInFlight;
-    if (!connectionState.canContinue(intent)) return { ok: false, stale: true };
-    if (engineSupervisor.hasActive) return { ok: true, existing: true };
+    await connectInFlight.promise; rejected = rejectConnectionWhileQuitting(intent);
+    if (rejected) return rejected;
+    if (!connectionState.canContinue(intent)) return { ok: false, stale: true, intent }; if (engineSupervisor.hasActive) return { ok: true, existing: true, intent };
   }
-
-  const operation = connectOnce(isRetry, intent);
-  connectInFlight = operation;
+  const operation = (async () => ({ ...await connectOnce(isRetry, intent), intent }))();
+  const record = { intent, promise: operation }; connectInFlight = record;
   try { return await operation; }
-  finally { if (connectInFlight === operation) connectInFlight = null; }
+  finally { if (connectInFlight === record) connectInFlight = null; }
 }
 
 function handleEngineClose({ code, generation }, diagnosticTail,
@@ -1030,6 +1048,7 @@ function ensureEngineStopped() {
 }
 
 function initiateStop(wantsConnectedAfterStop) {
+  networkStartupCoordinator?.cancel();
   connectivityRecovery.cancel();
   const intent = connectionState.beginStop(wantsConnectedAfterStop);
   // Generation invalidation happens before waiting for close. Old probes,
@@ -1056,40 +1075,25 @@ async function disconnect() {
   return { ok: result.ok };
 }
 
-function waitForConnected(timeoutMs = 45000) {
-  const deadline = Date.now() + timeoutMs;
-  return new Promise((resolve) => {
-    const poll = () => {
-      if (connectionState.isConnected()) return resolve(true);
-      if (connectionState.shouldStopWaiting({
-        hasActive: engineSupervisor.hasActive,
-        lastError: state.lastError,
-      })) {
-        return resolve(false);
-      }
-      if (Date.now() >= deadline) return resolve(false);
-      setTimeout(poll, 100);
-    };
-    poll();
-  });
+function waitForConnected(intent, timeoutMs = 45000) {
+  return connectionWaitRegistry.wait(intent, { timeoutMs });
 }
 
 async function reconnect(expectedGeneration = null) {
-  if (expectedGeneration !== null && !engineSupervisor.isCurrent(expectedGeneration)) {
-    return { ok: false, stale: true };
-  }
+  let rejected = rejectConnectionWhileQuitting(); if (rejected) return rejected;
+  if (expectedGeneration !== null && !engineSupervisor.isCurrent(expectedGeneration)) return { ok: false, stale: true };
   if (reconnectInFlight && connectionState.isCurrentIntent(reconnectInFlight.intent) &&
       connectionState.snapshot().desiredConnected) {
     return reconnectInFlight.promise;
   }
   if (reconnectInFlight) await reconnectInFlight.promise;
-  if (expectedGeneration !== null && !engineSupervisor.isCurrent(expectedGeneration)) {
-    return { ok: false, stale: true };
-  }
+  rejected = rejectConnectionWhileQuitting(); if (rejected) return rejected;
+  if (expectedGeneration !== null && !engineSupervisor.isCurrent(expectedGeneration)) return { ok: false, stale: true };
 
   const { intent, stopped } = initiateStop(true);
   const operation = (async () => {
     const stopResult = await stopped;
+    const quitResult = rejectConnectionWhileQuitting(intent); if (quitResult) return quitResult;
     connectionState.stopCompleted(intent, stopResult);
     if (!stopResult.ok || stopResult.cleanExit === false) {
       connectionState.failIntent(intent);
@@ -1191,7 +1195,7 @@ async function ensureCampusReady() {
   if (connectionState.isConnected()) return true;
   const result = await connect();
   if (!result?.ok && !connectionState.isConnecting()) return false;
-  return waitForConnected();
+  return waitForConnected(result.intent);
 }
 
 campusBrowserManager = new CampusBrowserManager({
@@ -1215,8 +1219,8 @@ campusBrowserManager = new CampusBrowserManager({
   resolveRoute: (url) => domainRoutePolicy.resolve(url),
   ensureConnected: async () => {
     if (!connectionState.isConnected()) {
-      await connect();
-      if (!await waitForConnected()) {
+      const result = await connect();
+      if (!await waitForConnected(result.intent)) {
         return { ok: false, error: state.lastError || t('error.connectTimeout') };
       }
     }
@@ -1376,9 +1380,9 @@ registerSettingsCredentialIpc({
 registerCoreControlIpc({
   register: trustedHandle,
   getState: controlStateSnapshot,
-  connect: () => connect(),
+  connect: async () => { const { intent: _intent, ...result } = await connect(); return result; },
   disconnect: () => disconnect(),
-  reconnect: () => reconnect(),
+  reconnect: async () => { const { intent: _intent, ...result } = await reconnect(); return result; },
   sshConfig: () => {
     try {
       const port = socksPort();
@@ -1464,6 +1468,7 @@ desktopShell = new DesktopShell({
   openCampusBrowser: () => connectAndOpenCampusBrowser(),
   rememberCloseAction,
   disposeLifecycle: () => {
+    networkStartupCoordinator.dispose(); connectionWaitRegistry.dispose();
     connectivityRecovery.dispose();
     networkStatusMonitor.dispose();
   },
@@ -1566,12 +1571,7 @@ app.whenReady().then(() => {
   desktopShell.createWindow();
   powerMonitor.on('suspend', () => connectivityRecovery.suspend());
   powerMonitor.on('resume', () => connectivityRecovery.resume());
-  networkStatusMonitor.start().catch(() => {});
-  let settings = null;
-  try { settings = loadSettingsOrReport(); } catch {}
-  if (settings && settings.autoConnect !== false && settings.username && hasStoredCredential()) {
-    setTimeout(() => { connect().catch(() => {}); }, 500);
-  }
+  networkStartupCoordinator.start().catch(() => {});
   // Dev checkouts and CI would only ever hit the rate-limited API for no
   // benefit, so the automatic check is packaged-builds only. The settings
   // page can always trigger a manual one. Automatic checks are throttled to

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -18,6 +18,7 @@
     "test:renderer-layout": "electron e2e/resource-manager-layout.electron.js",
     "test:main-integration": "electron e2e/main-integration.electron.js",
     "test:main-engine-lifecycle": "electron e2e/main-engine-lifecycle.electron.js",
+    "test:main-network-startup": "electron e2e/main-network-startup.electron.js",
     "test:strict-proxy-auth": "electron e2e/strict-proxy-auth.electron.js",
     "start": "electron .",
     "dist": "electron-builder --publish never",

--- a/desktop/test/connection-state-machine.test.js
+++ b/desktop/test/connection-state-machine.test.js
@@ -380,15 +380,3 @@ test('only the current intent can be failed', () => {
   assert.equal(machine.failIntent(intent), true);
   assert.equal(machine.snapshot().desiredConnected, false);
 });
-
-test('wait termination derives connection progress from the FSM phase', () => {
-  const machine = new ConnectionStateMachine();
-  const intent = machine.beginConnectIntent();
-  assert.equal(machine.beginConnectAttempt(intent), true);
-  assert.equal(machine.shouldStopWaiting({ lastError: 'pending' }), false);
-  machine.failIntent(intent);
-  assert.equal(machine.shouldStopWaiting({ hasActive: true, lastError: 'x' }), false);
-  assert.equal(machine.shouldStopWaiting({ hasActive: false, lastError: 'x' }), true);
-  machine.beginStop(false);
-  assert.equal(machine.shouldStopWaiting({ connecting: true, hasActive: true }), true);
-});

--- a/desktop/test/connection-wait-registry.test.js
+++ b/desktop/test/connection-wait-registry.test.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  ConnectionWaitRegistry,
+  MAX_PENDING_CONNECTION_INTENTS,
+} = require('../lib/connection-wait-registry');
+
+class FakeTimer {
+  constructor(callback, delayMs) {
+    this.callback = callback;
+    this.delayMs = delayMs;
+    this.unrefCount = 0;
+  }
+
+  unref() { this.unrefCount += 1; }
+}
+
+class FakeTimers {
+  constructor() { this.active = new Set(); }
+
+  setTimeout(callback, delayMs) {
+    const timer = new FakeTimer(callback, delayMs);
+    this.active.add(timer);
+    return timer;
+  }
+
+  clearTimeout(timer) { this.active.delete(timer); }
+
+  fire(timer) {
+    if (!this.active.delete(timer)) return undefined;
+    return timer.callback();
+  }
+}
+
+function snapshot(intent, phase, desiredConnected = true) {
+  return { intent, phase, desiredConnected };
+}
+
+test('only the exact observed intent can satisfy a connection waiter', async () => {
+  const registry = new ConnectionWaitRegistry();
+  registry.observe(snapshot(4, 'starting'));
+  const old = registry.wait(4, { timeoutMs: 1000 });
+  registry.observe(snapshot(5, 'connected'));
+  assert.equal(await old, false, 'a newer connection cannot satisfy an old request');
+  assert.equal(await registry.wait(5, { timeoutMs: 1000 }), true);
+});
+
+test('disconnect and terminal failure resolve immediately while retry progress remains pending', async () => {
+  const registry = new ConnectionWaitRegistry();
+  registry.observe(snapshot(7, 'starting'));
+  const retrying = registry.wait(7, { timeoutMs: 1000 });
+  registry.observe(snapshot(7, 'retry-wait'));
+  let settled = false;
+  retrying.then(() => { settled = true; });
+  await Promise.resolve();
+  assert.equal(settled, false);
+  registry.observe(snapshot(7, 'idle', false));
+  assert.equal(await retrying, false);
+
+  registry.observe(snapshot(8, 'starting'));
+  const disconnected = registry.wait(8, { timeoutMs: 1000 });
+  registry.observe(snapshot(9, 'stopping', false));
+  assert.equal(await disconnected, false);
+});
+
+test('each waiter owns one deadline timer and timeout resolves false', async () => {
+  const timers = new FakeTimers();
+  const registry = new ConnectionWaitRegistry({
+    setTimeoutFn: timers.setTimeout.bind(timers),
+    clearTimeoutFn: timers.clearTimeout.bind(timers),
+  });
+  registry.observe(snapshot(11, 'authenticating'));
+  const waiting = registry.wait(11, { timeoutMs: 3210 });
+  assert.equal(timers.active.size, 1);
+  const [timer] = timers.active;
+  assert.equal(timer.delayMs, 3210);
+  assert.equal(timer.unrefCount, 1);
+  timers.fire(timer);
+  assert.equal(await waiting, false);
+  assert.equal(timers.active.size, 0);
+});
+
+test('dispose clears every timer and makes current and future waits false', async () => {
+  const timers = new FakeTimers();
+  const registry = new ConnectionWaitRegistry({
+    setTimeoutFn: timers.setTimeout.bind(timers),
+    clearTimeoutFn: timers.clearTimeout.bind(timers),
+  });
+  registry.observe(snapshot(13, 'preparing-tunnel'));
+  const first = registry.wait(13, { timeoutMs: 1000 });
+  const second = registry.wait(13, { timeoutMs: 1000 });
+  assert.equal(first, second, 'same-intent callers share one outcome promise');
+  assert.equal(timers.active.size, 1, 'same-intent callers share one deadline timer');
+  registry.dispose();
+  assert.equal(await first, false);
+  assert.equal(await second, false);
+  assert.equal(timers.active.size, 0);
+  assert.equal(await registry.wait(13, { timeoutMs: 1000 }), false);
+});
+
+test('pending intent capacity fails the next waiter closed and dispose clears every timer', async () => {
+  const timers = new FakeTimers();
+  const registry = new ConnectionWaitRegistry({
+    setTimeoutFn: timers.setTimeout.bind(timers),
+    clearTimeoutFn: timers.clearTimeout.bind(timers),
+  });
+  const pending = Array.from({ length: MAX_PENDING_CONNECTION_INTENTS }, (_, index) => (
+    registry.wait(index + 1, { timeoutMs: 1000 })
+  ));
+  assert.equal(timers.active.size, MAX_PENDING_CONNECTION_INTENTS);
+  assert.equal(await registry.wait(MAX_PENDING_CONNECTION_INTENTS + 1, { timeoutMs: 1000 }), false);
+  assert.equal(timers.active.size, MAX_PENDING_CONNECTION_INTENTS);
+  registry.dispose();
+  assert.deepEqual(await Promise.all(pending), Array(MAX_PENDING_CONNECTION_INTENTS).fill(false));
+  assert.equal(timers.active.size, 0);
+});

--- a/desktop/test/connectivity-recovery.test.js
+++ b/desktop/test/connectivity-recovery.test.js
@@ -168,6 +168,34 @@ test('explicit disconnect or quit intent never auto-recovers', async () => {
   assert.deepEqual(state.reconnects, []);
 });
 
+test('a current ordinary recovery rejected by policy is explicitly settled', async () => {
+  const declined = [];
+  const { recovery, timers } = harness({
+    shouldReconnect: async () => false,
+    onRecoveryDeclined: (intent, reason) => declined.push([intent, reason]),
+  });
+  recovery.suspend();
+  recovery.resume();
+  const [timer] = timers.ids();
+  assert.equal(await timers.fire(timer), false);
+  assert.deepEqual(declined, [[1, 'resume']]);
+  assert.equal(recovery.snapshot().pending, false);
+});
+
+test('stale or cancelled recovery never settles a replacement intent', async () => {
+  const declined = [];
+  const { recovery, state, timers } = harness({
+    shouldReconnect: async () => false,
+    onRecoveryDeclined: (intent, reason) => declined.push([intent, reason]),
+  });
+  recovery.networkOffline();
+  recovery.networkOnline();
+  const [timer] = timers.ids();
+  state.intent = 2;
+  assert.equal(await timers.fire(timer), false);
+  assert.deepEqual(declined, []);
+});
+
 test('an availability change while shouldReconnect is pending invalidates its decision', async () => {
   const timers = new FakeTimers();
   let resolveDecision;
@@ -216,4 +244,59 @@ test('constructor rejects incomplete or unsafe scheduler contracts', () => {
     reconnect() {},
     debounceMs: -1,
   }), /debounce/);
+});
+
+test('initial network availability carries one startup-only recovery reason', async () => {
+  const timers = new FakeTimers();
+  const checks = [];
+  const reconnects = [];
+  const recovery = new ConnectivityRecovery({
+    invalidate() {},
+    getLifecycleIntent: () => 9,
+    shouldReconnect: async (intent, reason) => {
+      checks.push([intent, reason]);
+      return reason === 'initial-network-online';
+    },
+    reconnect: async (intent, reason) => { reconnects.push([intent, reason]); },
+    setTimeout: timers.setTimeout.bind(timers),
+    clearTimeout: timers.clearTimeout.bind(timers),
+    debounceMs: 10,
+  });
+
+  recovery.networkOffline(9);
+  assert.equal(recovery.initialNetworkOnline(9), true);
+  const [startupTimer] = timers.ids();
+  assert.equal(await timers.fire(startupTimer), true);
+  assert.deepEqual(checks, [[9, 'initial-network-online']]);
+  assert.deepEqual(reconnects, [[9, 'initial-network-online']]);
+
+  recovery.networkOffline(9);
+  assert.equal(recovery.networkOnline(9), true);
+  const [ordinaryTimer] = timers.ids();
+  assert.equal(await timers.fire(ordinaryTimer), false);
+  assert.deepEqual(checks.at(-1), [9, 'network-online']);
+  assert.deepEqual(reconnects, [[9, 'initial-network-online']],
+    'the startup bypass must not enable later automatic reconnect');
+});
+
+test('startup-only recovery reason survives an overlapping suspend until resume', async () => {
+  const timers = new FakeTimers();
+  const reconnects = [];
+  const recovery = new ConnectivityRecovery({
+    invalidate() {},
+    getLifecycleIntent: () => 12,
+    shouldReconnect: async (_intent, reason) => reason === 'initial-network-online',
+    reconnect: async (intent, reason) => { reconnects.push([intent, reason]); },
+    setTimeout: timers.setTimeout.bind(timers),
+    clearTimeout: timers.clearTimeout.bind(timers),
+    debounceMs: 10,
+  });
+  recovery.networkOffline(12);
+  recovery.suspend(12);
+  assert.equal(recovery.initialNetworkOnline(12), false,
+    'network availability alone cannot resume while the machine is suspended');
+  assert.equal(recovery.resume(12), true);
+  const [timer] = timers.ids();
+  assert.equal(await timers.fire(timer), true);
+  assert.deepEqual(reconnects, [[12, 'initial-network-online']]);
 });

--- a/desktop/test/main-connection-wait-boundary.test.js
+++ b/desktop/test/main-connection-wait-boundary.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const source = fs.readFileSync(path.join(__dirname, '..', 'main.js'), 'utf8');
+
+test('Main connection waits are event-driven, intent-bound, and disposed on quit', () => {
+  assert.match(source, /connectionWaitRegistry\.observe\(connectionState\.snapshot\(\)\)/);
+  assert.match(source, /function waitForConnected\(intent,/);
+  assert.match(source, /connectionWaitRegistry\.wait\(intent,/);
+  assert.match(source, /waitForConnected\(result\.intent\)/);
+  assert.match(source, /connect: async \(\) => \{ const \{ intent: _intent, \.\.\.result \} = await connect\(\); return result; \}/,
+    'the internal wait correlation must not cross the Renderer IPC boundary');
+  assert.match(source, /reconnect: async \(\) => \{ const \{ intent: _intent, \.\.\.result \} = await reconnect\(\); return result; \}/);
+  assert.match(source, /networkStartupCoordinator\.dispose\(\); connectionWaitRegistry\.dispose\(\)/);
+  assert.doesNotMatch(source, /setTimeout\(poll,\s*100\)/,
+    'the old detached 100ms polling loop must not return');
+});
+
+test('settings failures publish terminal intent state to pending waiters', () => {
+  const recovery = source.slice(
+    source.indexOf('async function recoverConnectivity('),
+    source.indexOf('const connectivityRecovery ='),
+  );
+  const policy = source.slice(
+    source.indexOf('shouldReconnect: async'),
+    source.indexOf('reconnect: recoverConnectivity'),
+  );
+  assert.match(recovery, /catch \{\s*connectionState\.failIntent\(intent\);\s*emit\(\);/);
+  assert.match(policy, /catch \{\s*connectionState\.failIntent\(intent\);\s*emit\(\);/);
+});
+
+test('connect and reconnect fail closed around quit and coalesce before creating an intent', () => {
+  const quitGate = source.slice(
+    source.indexOf('function rejectConnectionWhileQuitting('),
+    source.indexOf('async function connect('),
+  );
+  const connectBody = source.slice(
+    source.indexOf('async function connect('),
+    source.indexOf('\nfunction handleEngineClose('),
+  );
+  const reconnectBody = source.slice(
+    source.indexOf('async function reconnect('),
+    source.indexOf('// ---------- PAC file'),
+  );
+  assert.match(quitGate, /desktopShell\?\.isQuitting !== true/);
+  assert.match(quitGate, /connectionState\.failIntent\(intent\); emit\(\)/);
+  assert.match(connectBody, /rejectConnectionWhileQuitting\(expectedIntent \?\? undefined\)/);
+  assert.match(connectBody, /if \(disconnectInFlight\) await disconnectInFlight;[\s\S]*rejectConnectionWhileQuitting/);
+  assert.match(connectBody, /if \(current\.desiredConnected\)[\s\S]*current\.intent/);
+  assert.match(reconnectBody, /rejectConnectionWhileQuitting\(\)/);
+  assert.match(reconnectBody, /const stopResult = await stopped;[\s\S]*rejectConnectionWhileQuitting\(intent\)/);
+});

--- a/desktop/test/network-status-monitor.test.js
+++ b/desktop/test/network-status-monitor.test.js
@@ -2,9 +2,12 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
+const { ConnectionStateMachine } = require('../lib/connection-state-machine');
 const {
   DEFAULT_NETWORK_POLL_MS,
+  NetworkStartupCoordinator,
   NetworkStatusMonitor,
+  createNetworkStartupSystem,
 } = require('../lib/network-status-monitor');
 
 function deferred() {
@@ -122,6 +125,30 @@ test('sync errors and non-boolean samples are ignored without changing the basel
   assert.deepEqual(fixture.events, ['online']);
 });
 
+test('baseline wait is event-driven, bounded, and cancellable', async () => {
+  const fixture = monitorFor([undefined, true]);
+  await fixture.monitor.start();
+  const waiting = fixture.monitor.waitForBaseline({ timeoutMs: 12_000 });
+  assert.equal(fixture.timers.ids().length, 2,
+    'one monitor poll and one baseline deadline are owned');
+  const pollTimer = fixture.timers.ids().find((id) => (
+    fixture.timers.record(id).delayMs === DEFAULT_NETWORK_POLL_MS
+  ));
+  await fixture.timers.fire(pollTimer);
+  assert.equal(await waiting.promise, true);
+  assert.equal(fixture.timers.ids().length, 1,
+    'the baseline deadline is cleared and only the next monitor poll remains');
+
+  fixture.monitor.stop();
+  const cancelledFixture = monitorFor([undefined]);
+  await cancelledFixture.monitor.start();
+  const cancelled = cancelledFixture.monitor.waitForBaseline({ timeoutMs: 12_000 });
+  cancelled.cancel();
+  assert.equal(await cancelled.promise, null);
+  assert.equal(cancelledFixture.timers.ids().length, 1,
+    'cancel removes its deadline without stopping the monitor itself');
+});
+
 test('every recursive timer uses the reviewed default interval and is unrefed', async () => {
   const fixture = monitorFor([true, true]);
   await fixture.monitor.start();
@@ -236,4 +263,204 @@ test('constructor bounds the polling interval and dispose prevents restart', asy
   fixture.monitor.dispose();
   assert.equal(await fixture.monitor.start(), false);
   assert.equal(fixture.reads, 0);
+});
+
+test('initial offline startup pauses one desired intent and connects exactly once after online', async () => {
+  const timers = new FakeTimers();
+  const monitor = {
+    start: async () => true,
+    snapshot: () => ({ baseline: false }),
+  };
+  const events = [];
+  const connection = new ConnectionStateMachine();
+  let startupIntent = null;
+  let quitting = false;
+  const startup = new NetworkStartupCoordinator({
+    monitor,
+    shouldAutoConnect: () => true,
+    pauseOffline: () => {
+      startupIntent = connection.beginConnectIntent();
+      events.push('paused');
+      return connection.pauseForConnectivity(startupIntent);
+    },
+    resumeOffline: async () => {
+      assert.equal(connection.resumeConnectivity(startupIntent), true);
+      events.push('connected');
+    },
+    connect: async () => { events.push('unexpected-direct-connect'); },
+    isQuitting: () => quitting,
+    setTimeout: timers.setTimeout.bind(timers),
+    clearTimeout: timers.clearTimeout.bind(timers),
+  });
+
+  assert.equal(await startup.start(), true);
+  assert.deepEqual(events, ['paused']);
+  assert.deepEqual(timers.ids(), [], 'offline startup must not schedule an Engine start');
+  assert.equal(startup.snapshot().pausedOffline, true);
+  assert.equal(connection.snapshot().desiredConnected, true);
+  assert.equal(connection.snapshot().phase, 'connectivity-paused');
+
+  assert.equal(await startup.networkOnline(), true);
+  assert.deepEqual(events, ['paused', 'connected']);
+  assert.equal(connection.snapshot().phase, 'starting');
+  assert.equal(await startup.networkOnline(), false, 'the initial outage is consumed exactly once');
+  assert.deepEqual(timers.ids(), []);
+
+  quitting = true;
+  startup.dispose();
+});
+
+test('manual cancellation or quit makes an initial network continuation inert', async () => {
+  for (const action of ['cancel', 'quit']) {
+    const timers = new FakeTimers();
+    const baseline = deferred();
+    let connects = 0;
+    let pauses = 0;
+    let quitting = false;
+    const startup = new NetworkStartupCoordinator({
+      monitor: {
+        start: () => baseline.promise,
+        snapshot: () => ({ baseline: false }),
+      },
+      shouldAutoConnect: () => true,
+      pauseOffline: () => { pauses += 1; return true; },
+      resumeOffline: async () => { connects += 1; },
+      connect: async () => { connects += 1; },
+      isQuitting: () => quitting,
+      setTimeout: timers.setTimeout.bind(timers),
+      clearTimeout: timers.clearTimeout.bind(timers),
+    });
+    const started = startup.start();
+    if (action === 'cancel') startup.cancel();
+    else quitting = true;
+    baseline.resolve(true);
+    assert.equal(await started, false);
+    assert.equal(pauses, 0);
+    assert.equal(connects, 0);
+    assert.deepEqual(timers.ids(), []);
+  }
+});
+
+test('initial online startup preserves one delayed auto-connect and cancellation revokes it', async () => {
+  for (const cancelBeforeFire of [false, true]) {
+    const timers = new FakeTimers();
+    let connects = 0;
+    const startup = new NetworkStartupCoordinator({
+      monitor: {
+        start: async () => true,
+        snapshot: () => ({ baseline: true }),
+      },
+      shouldAutoConnect: () => true,
+      pauseOffline: () => { throw new Error('online startup cannot pause'); },
+      resumeOffline: () => { throw new Error('online startup cannot resume'); },
+      connect: async () => { connects += 1; },
+      isQuitting: () => false,
+      setTimeout: timers.setTimeout.bind(timers),
+      clearTimeout: timers.clearTimeout.bind(timers),
+    });
+    assert.equal(await startup.start(), true);
+    const [timer] = timers.ids();
+    assert.ok(timer);
+    const queued = timers.callback(timer);
+    if (cancelBeforeFire) startup.cancel();
+    await queued();
+    assert.equal(connects, cancelBeforeFire ? 0 : 1);
+    assert.equal(await startup.start(), true, 'startup remains single-flight');
+    assert.equal(connects, cancelBeforeFire ? 0 : 1);
+  }
+});
+
+test('startup-only and ordinary online transitions use distinct recovery callbacks', async () => {
+  for (const initialOffline of [false, true]) {
+    let initialResumes = 0;
+    let runtimeResumes = 0;
+    const system = createNetworkStartupSystem({
+      appIsPackaged: true,
+      environment: {},
+      dataDirectory: '/tmp',
+      isOnline: () => !initialOffline,
+      onOffline() {},
+      onOnline: () => { runtimeResumes += 1; return true; },
+      shouldAutoConnect: () => initialOffline,
+      pauseOffline: () => 19,
+      resumeInitialOffline: (intent) => {
+        assert.equal(intent, 19);
+        initialResumes += 1;
+        return true;
+      },
+      connect() {},
+      isQuitting: () => false,
+    });
+    await system.startup.start();
+    await system.monitor.onOnline();
+    assert.equal(initialResumes, initialOffline ? 1 : 0);
+    assert.equal(runtimeResumes, initialOffline ? 0 : 1);
+    system.startup.dispose();
+    system.monitor.dispose();
+  }
+});
+
+test('unknown initial network samples wait for one bounded valid baseline', async () => {
+  const baseline = deferred();
+  const timers = new FakeTimers();
+  let connects = 0;
+  let waits = 0;
+  let waitCancelled = 0;
+  const startup = new NetworkStartupCoordinator({
+    monitor: {
+      start: async () => true,
+      snapshot: () => ({ baseline: null }),
+      waitForBaseline: () => {
+        waits += 1;
+        return { promise: baseline.promise, cancel: () => { waitCancelled += 1; } };
+      },
+    },
+    shouldAutoConnect: () => true,
+    pauseOffline: () => 1,
+    resumeOffline: () => true,
+    connect: async () => { connects += 1; },
+    isQuitting: () => false,
+    setTimeout: timers.setTimeout.bind(timers),
+    clearTimeout: timers.clearTimeout.bind(timers),
+  });
+  const started = startup.start();
+  await Promise.resolve();
+  assert.equal(waits, 1);
+  assert.deepEqual(timers.ids(), [], 'unknown is not treated as an online sample');
+  baseline.resolve(true);
+  assert.equal(await started, true);
+  assert.equal(waitCancelled, 1);
+  const [timer] = timers.ids();
+  await timers.fire(timer);
+  assert.equal(connects, 1);
+});
+
+test('auto-connect becoming ineligible during baseline wait creates no intent or timer', async () => {
+  const baseline = deferred();
+  const timers = new FakeTimers();
+  let eligible = true;
+  let pauses = 0;
+  let connects = 0;
+  const startup = new NetworkStartupCoordinator({
+    monitor: {
+      start: async () => true,
+      snapshot: () => ({ baseline: null }),
+      waitForBaseline: () => ({ promise: baseline.promise, cancel() {} }),
+    },
+    shouldAutoConnect: () => eligible,
+    pauseOffline: () => { pauses += 1; return 1; },
+    resumeOffline: () => true,
+    connect: () => { connects += 1; },
+    isQuitting: () => false,
+    setTimeout: timers.setTimeout.bind(timers),
+    clearTimeout: timers.clearTimeout.bind(timers),
+  });
+  const started = startup.start();
+  await Promise.resolve();
+  eligible = false;
+  baseline.resolve(false);
+  assert.equal(await started, false);
+  assert.equal(pauses, 0);
+  assert.equal(connects, 0);
+  assert.deepEqual(timers.ids(), []);
 });

--- a/desktop/test/release-assets.test.js
+++ b/desktop/test/release-assets.test.js
@@ -147,3 +147,16 @@ test('macOS native release binaries cannot depend on Homebrew libraries', () => 
   assert.match(packageVerifier, /assertMacSystemOnlyDylibs\(executable\)/u);
   assert.match(packageVerifier, /packaged macOS native executable depends on a non-system dylib/u);
 });
+
+test('initially-offline Main recovery is a named ordinary and tag-build Electron gate', () => {
+  assert.equal(
+    manifest.scripts['test:main-network-startup'],
+    'electron e2e/main-network-startup.electron.js',
+  );
+  assert.match(ciWorkflow, /npm run test:main-network-startup/u);
+  const macIntegration = workflow.slice(
+    workflow.indexOf('- name: Exercise real Electron integration and browser soak'),
+    workflow.indexOf('- name: Build independent engines (mac)'),
+  );
+  assert.match(macIntegration, /npm run test:main-network-startup/u);
+});

--- a/docs/adr/0002-controlled-direct-exit.md
+++ b/docs/adr/0002-controlled-direct-exit.md
@@ -35,6 +35,17 @@ dialer, bind the decision to policy revision/generation, and revalidate on
 redirect or new connection. It must preserve browser Cookie/SSO continuity and
 must not silently fall back to campus routing.
 
+## Alternatives
+
+| Alternative | Decision |
+| --- | --- |
+| Keep Chromium `DIRECT` forever | Accepted only as the explicitly documented 1.x limitation; insufficient for a stronger 2.0 resolved-address claim |
+| Send partner/public sites through Campus L3 | Rejected as a default: it breaks sites that reject the campus path and violates explicit Direct policy |
+| Intercept global/system DNS | Rejected: expands privilege and system-mutation scope without owning Chromium's final socket |
+| Proxy all public traffic through one generic local forwarder | Deferred unless it can preserve browser Session, TLS, redirects, downloads and streaming without becoming a second browser stack |
+| TUN or route injection | Rejected for this problem; disproportionate privilege and rollback cost, and does not by itself define safe Direct resolution |
+| Electron/Chromium supported connection hook | Preferred if a future supported API can bind resolution and dialing while retaining one persistent Session |
+
 ## Reopen criteria
 
 Promote the deferred work when one of these is true:
@@ -51,3 +62,35 @@ The 1.x risk is explicit and bounded but not eliminated. Users should add only
 domains they trust to direct rules. Campus routing, local listeners, system DNS,
 routes and proxies remain unchanged. Release notes must not describe 1.x direct
 routing as resolved-address isolated.
+
+## Security
+
+- Current 1.x checks unsafe literal addresses and URL forms before route selection, but deliberately makes
+  no post-resolution guarantee for an ordinary hostname.
+- Direct rules remain explicit school defaults or local user decisions; a page cannot silently create a
+  new persistent rule.
+- Browser sandbox, context isolation, permission denial and local-service navigation guards remain active
+  on both routes.
+- A future ControlledDirectExit must validate every IPv4/IPv6 answer, redirects and new connections;
+  mixed safe/unsafe answers, rebinding, IPv4-mapped IPv6 and policy-generation changes fail closed.
+- Resolution or dial failure must not silently downgrade to Campus, system proxy or a different Exit.
+
+## Rollback
+
+Current 1.x adds no new component, privilege or persistent state, so rollback is documentation/policy
+reversion only. A future ControlledDirectExit must be independently feature-gated. If disabled or rolled
+back, it must close its resolver/dialer, invalidate its generation and return a typed Exit-unavailable
+result; it may restore the explicitly documented 1.x Chromium `DIRECT` behavior only through a reviewed
+version decision, never silently during an active request.
+
+## Evidence
+
+- `desktop/lib/campus-browser.js` and routing policy tests prove URL/literal prechecks, explicit route
+  ownership and fail-closed Campus request gating.
+- JS/PAC differential tests prove current domain decision consistency, not resolved-address isolation.
+- Campus Engine SOCKS/HTTP destination policy covers the tunnel path only and does not prove Chromium
+  `DIRECT` safety.
+- `docs/engineering/1x-release-gate.md` retains the accepted limitation and the still-missing real
+  Direct/SAML canary evidence.
+- No current test owns Chromium's ordinary direct DNS resolution and socket, which is the reason the 2.0
+  capability remains `I0/E1` rather than implemented.

--- a/docs/architecture/2.0-capability-matrix.md
+++ b/docs/architecture/2.0-capability-matrix.md
@@ -40,6 +40,10 @@
 - HKUST(GZ) Connect implementation固定为
   `6efca3c2b762a9b2b47f74b11b965b2c126e5c91`，并由本轮
   [`1x-release-gate.md`](../engineering/1x-release-gate.md)追踪；文档提交不改变该实现树；
+- 正式v1.2.3 delivery commit和tag source为
+  `5d8323d37de7c279ae70b3ec646f93791d6a3581`；main CI `32630023985`及tag
+  build/release `32630322732`通过，四个正式资产已发布。该交付事实提升release/package
+  evidence，不提升任何缺少学校canary的Gateway capability；
 - zju-connect固定为`4c4b41fee599646efc1463ecf080590724b24f28`，证据与限制见
   [`2026-08-23-zju-current-comparison-plan.md`](../audits/2026-08-23-zju-current-comparison-plan.md)；
 - EasyConnect没有可提交或可重分发的固定包快照。本表中的`Historical Observed`仅来自
@@ -64,7 +68,8 @@
 | Campus Browser | Historical Observed：官方集成UI | 无同等产品面 | `I3/E3` single Session/PAC/credential safety package；真实导航/SSO E4待补 | 20-tab p95<100 ms；SSO flow 20/20 |
 | Domain routing | Unknown：官方资源策略未复核 | rules/TUN | `I3/E2` Campus/Direct rules production | 100k JS/PAC/Exit corpus mismatch=0 |
 | Controlled DirectExit | Unknown：官方内部行为未复核 | 不等价 | `I0/E1`；当前仅Chromium `DIRECT`风险接受 | rebinding/private resolved IP deny=100% |
-| Multi-Exit | Unknown | 多 backend/route | `I0/E1`；无统一Exit model | Direct/L3/WebVPN typed capability，无隐式 fallback |
+| Multi-Exit semantics | Unknown | 多 backend/route | `I0/E1`；无统一Exit model | Direct/L3/WebVPN typed capability，无隐式 fallback |
+| Multi-Exit detection/selection | Unknown | explicit/auto source wiring | `I0/E1`；2.0设计Deferred，1.x只用system route | 两个受控候选后再实现；Gateway RTT/failure/stability评分，Auto hysteresis和manual fail-closed |
 | Underlay binding | Unknown：官方行为需观察 | explicit/auto source wiring | `I0/E1` | 三平台 explicit；绑定失败 unbound fallback=0 |
 | Multi-line | Hypothesis | node selection source wiring | `I2/E2` offline endpoint parse；无production selection | sticky/hysteresis；默认切线重新认证 |
 | Loop prevention | Unknown | 部分 underlay/TUN | `I3/E2` local destination与Gateway `.no_proxy()`；无underlay identity | graph cycle test=100%；self recursion=0 |

--- a/docs/architecture/2.0-vision.md
+++ b/docs/architecture/2.0-vision.md
@@ -152,7 +152,49 @@ Data Plane，由 Desktop 新 generation 重新认证。
 Multi-line 只有在确认 endpoint discovery、auth/data endpoint 关系和 token portability 后
 实现；默认切线重新认证。
 
-## 7. Loop prevention
+## 7. Multi-Exit Detection（Deferred / evidence-triggered）
+
+Multi-Exit Detection描述本机到校园Gateway的候选underlay，不等于Routing Engine的
+Direct/L3/WebVPN Exit，也不等于Gateway内部multi-line。当前1.x不枚举、测速或自动切换
+underlay；系统默认路由仍是唯一production策略。
+
+只有真实设备证明“始终online但到校园Gateway的路径质量明显分化”后，2.0才引入有界发现：
+
+```text
+UnderlayCandidate
+  identity
+  kind: wifi | ethernet | explicit_local_proxy | other_reviewed
+  interfaceName
+  sourceAddress / addressFamily
+  bindCapability
+
+UnderlayObservation
+  gatewayConnectTime
+  campusGatewayRtt
+  loss / jitter (when measurable without privileged capture)
+  recentFailureRate
+  stabilityWindow
+  observedAt
+```
+
+设计约束：
+
+- 评分以校园Gateway的connect time、RTT、failure rate和历史稳定性为主，不用普通公网
+  speed test替代；
+- public IP和country/region只允许作为用户主动诊断的辅助信息，不进入默认选择主分数，
+  不长期保存精确地址；
+- `Auto`必须有sticky window、hysteresis和有界并行探测，不能在一次抖动后切换；
+- 用户可以选择`System Default`或一个经过验证的explicit candidate；manual override绑定失败
+  必须fail-closed，不能静默回退；
+- UI展示候选来源、最近校园Gateway RTT、稳定性和证据时间，不把“检测到”写成“可用”；
+- candidate变化递增underlay generation并销毁旧Session/token/socket，禁止跨出口迁移；
+- 不扫描无关本机进程，不读取第三方proxy secret，不修改系统DNS、route或proxy；
+- 自动选择、local-proxy underlay和地理信息各自需要独立threat model、contract test和ADR。
+
+启动实现前至少需要：两个可控候选出口、同一Gateway的重复测量、可复现的路径质量差异、
+三平台bind能力调查和loop-prevention canary。否则本节保持设计占位，不进入production。
+
+## 8. Loop prevention
 
 1. Gateway control plane 永不进入 Campus frontend；
 2. Gateway HTTP 默认不继承环境代理；
@@ -164,7 +206,7 @@ Multi-line 只有在确认 endpoint discovery、auth/data endpoint 关系和 tok
 8. future TUN 必须 bypass/protect Gateway 和 local control socket；
 9. update/telemetry 路径必须显式归类。
 
-## 8. Campus Browser
+## 9. Campus Browser
 
 保留：一个持久 Session、按域名切换、SSO/Cookie/POST 连续性、切换前 request gate、
 失败时 fail-closed。
@@ -177,13 +219,13 @@ Multi-line 只有在确认 endpoint discovery、auth/data endpoint 关系和 tok
 - 错误区分 DNS、policy denied、Exit unavailable、TLS 和网站自身失败；
 - route choice 记录域名/规则元数据，不记录完整敏感 URL。
 
-## 9. TUN decision
+## 10. TUN decision
 
 TUN 默认 Deferred，详见 [`../adr/0001-tun-mode.md`](../adr/0001-tun-mode.md)。它只在
 proxy-first 无法解决的重要场景、underlay loop guard 已验证且三平台可撤销方案成熟后
 作为可选 Ingress 开发。
 
-## 10. Performance
+## 11. Performance
 
 建立固定机器、固定网络、固定版本的可重复基准：
 
@@ -197,7 +239,7 @@ proxy-first 无法解决的重要场景、underlay loop guard 已验证且三平
 “更快”必须同时记录环境、样本数、分位数和置信边界，不以一次截图或 synthetic
 loopback 代替真实 Gateway。
 
-## 11. Security
+## 12. Security
 
 - standard PKI + narrow vendor leaf binding；
 - no implicit environment proxy；
@@ -209,7 +251,7 @@ loopback 代替真实 Gateway。
 - signed/reversible privileged component only when a separately approved feature requires it；
 - unsupported capability fail-closed。
 
-## 12. Observability
+## 13. Observability
 
 每个结构化事件允许：connection correlation、state transition、Exit、decision source、
 policy revision、underlay identity、retry count 和 stable failure code。
@@ -217,7 +259,7 @@ policy revision、underlay identity、retry count 和 stable failure code。
 默认禁止：完整 URL/query、hostname 明细、Cookie/token、OTP、凭据和原始认证 body。
 诊断模式必须用户主动开启、自动到期、仍执行 secret redaction。
 
-## 13. Promotion order
+## 14. Promotion order
 
 ```text
 1.x Architecture Frozen

--- a/docs/engineering/1x-convergence-plan.md
+++ b/docs/engineering/1x-convergence-plan.md
@@ -16,10 +16,10 @@
 | C5 Typed errors | Auth、credential、Data Plane retry已typed；legacy AUTH_FAILED不再归责密码；log I/O可见 | 其余旧Unclassified跨域继续下降 |
 | C6 Lifecycle regression | Real Electron Main全链E2E；feature-gated真实Rust Engine 100轮post-Transport netstack/listener/stop/join/port-release soak | 真实Gateway lifecycle与30分钟persistent资源soak |
 | C7 Package exactness | Exact native manifest、strict mac verification、macOS system-only dylib门、三平台launch smoke在exact SHA `6efca3c`通过；所有builder显式`--publish never` | Developer ID/notarization；后续版本继续执行exact-tag source reconciliation |
-| C8 Initially-offline startup | commit `a6d4069`等待首个网络sample；离线只保留一个paused intent，online后按autoConnect exactly once恢复；ordinary policy拒绝后仍可手动连接 | 本地Desktop/Electron/exact-tree secret通过；remote CI与真机cold-offline canary待补 |
-| C9 UDP association ownership | commit `a6d4069`把upload/download relay纳入父future结构化取消作用域 | 本地Rust全量回归通过；remote CI及真实UDP socket/port回收增强测试待补 |
-| C10 Browser connection wait ownership | commit `a6d4069`使用intent-bound事件驱动registry替代100 ms轮询，并对retry/paused/quit建立明确收束 | 本地并发open/coalescing、quit/timeout和Main lifecycle回归通过；remote CI待补 |
-| C11 Quit connection gate | commit `a6d4069`在connect/reconnect入口及每个异步stop/wait边界检查quit owner，晚到请求只能fail-closed | 本地source contract、Main integration/lifecycle与三并发open回归通过；remote CI待补 |
+| C8 Initially-offline startup | commit `a6d4069`等待首个网络sample；离线只保留一个paused intent，online后按autoConnect exactly once恢复；ordinary policy拒绝后仍可手动连接 | 本地与PR #6 CI/Electron通过；真机cold-offline canary待补 |
+| C9 UDP association ownership | commit `a6d4069`把upload/download relay纳入父future结构化取消作用域 | 本地与PR #6 Rust CI通过；真实UDP socket/port回收增强测试待补 |
+| C10 Browser connection wait ownership | commit `a6d4069`使用intent-bound事件驱动registry替代100 ms轮询，并对retry/paused/quit建立明确收束 | 本地与PR #6并发open/coalescing、quit/timeout和Main lifecycle CI通过 |
+| C11 Quit connection gate | commit `a6d4069`在connect/reconnect入口及每个异步stop/wait边界检查quit owner，晚到请求只能fail-closed | 本地与PR #6 source contract、Main integration/lifecycle及三并发open回归通过 |
 
 本表只描述本地实现，不替代下方P0远端和真实环境门。
 

--- a/docs/engineering/1x-convergence-plan.md
+++ b/docs/engineering/1x-convergence-plan.md
@@ -16,9 +16,10 @@
 | C5 Typed errors | Auth、credential、Data Plane retry已typed；legacy AUTH_FAILED不再归责密码；log I/O可见 | 其余旧Unclassified跨域继续下降 |
 | C6 Lifecycle regression | Real Electron Main全链E2E；feature-gated真实Rust Engine 100轮post-Transport netstack/listener/stop/join/port-release soak | 真实Gateway lifecycle与30分钟persistent资源soak |
 | C7 Package exactness | Exact native manifest、strict mac verification、macOS system-only dylib门、三平台launch smoke在exact SHA `6efca3c`通过；所有builder显式`--publish never` | Developer ID/notarization；后续版本继续执行exact-tag source reconciliation |
-| C8 Initially-offline startup | Post-release tree等待首个网络sample；离线只保留一个paused intent，online后按autoConnect exactly once恢复 | 合并前Desktop/Electron、exact-tree secret与remote CI；真机cold-offline canary |
-| C9 UDP association ownership | Post-release tree把upload/download relay纳入父future结构化取消作用域 | 合并前Rust全量回归；真实UDP socket/port回收增强测试 |
-| C10 Browser connection wait ownership | Post-release tree使用intent-bound事件驱动registry替代100 ms轮询 | 合并前并发open/coalescing、quit/timeout和Main lifecycle回归 |
+| C8 Initially-offline startup | commit `a6d4069`等待首个网络sample；离线只保留一个paused intent，online后按autoConnect exactly once恢复；ordinary policy拒绝后仍可手动连接 | 本地Desktop/Electron/exact-tree secret通过；remote CI与真机cold-offline canary待补 |
+| C9 UDP association ownership | commit `a6d4069`把upload/download relay纳入父future结构化取消作用域 | 本地Rust全量回归通过；remote CI及真实UDP socket/port回收增强测试待补 |
+| C10 Browser connection wait ownership | commit `a6d4069`使用intent-bound事件驱动registry替代100 ms轮询，并对retry/paused/quit建立明确收束 | 本地并发open/coalescing、quit/timeout和Main lifecycle回归通过；remote CI待补 |
+| C11 Quit connection gate | commit `a6d4069`在connect/reconnect入口及每个异步stop/wait边界检查quit owner，晚到请求只能fail-closed | 本地source contract、Main integration/lifecycle与三并发open回归通过；remote CI待补 |
 
 本表只描述本地实现，不替代下方P0远端和真实环境门。
 

--- a/docs/engineering/1x-convergence-plan.md
+++ b/docs/engineering/1x-convergence-plan.md
@@ -1,7 +1,9 @@
 # 1.x Convergence Plan
 
-目标：把当前 1.2.3 review branch 收束成 Architecture Frozen 基线。每批只解决一个主行为，
-保持 password-only、SOCKS/HTTP、DNS、Campus Browser 和无系统网络污染不变量。
+目标：以已发布的v1.2.3为1.x收束基线，继续关闭Architecture Frozen的真实环境与治理证据。
+每批只解决一个主行为，保持password-only、SOCKS/HTTP、DNS、Campus Browser和无系统
+网络污染不变量。PR #5已merge为`5d8323d`，main CI `32630023985`和tag build/release
+`32630322732`均成功；发布完成不等于Architecture Frozen已经完成。
 
 ## Current implementation snapshot
 
@@ -13,22 +15,27 @@
 | C4 Serving shutdown | Outer service drain + three-socket shutdown + runner/bridge bounded join；exact-SHA三平台package/smoke通过 | Real Gateway canary and long soak |
 | C5 Typed errors | Auth、credential、Data Plane retry已typed；legacy AUTH_FAILED不再归责密码；log I/O可见 | 其余旧Unclassified跨域继续下降 |
 | C6 Lifecycle regression | Real Electron Main全链E2E；feature-gated真实Rust Engine 100轮post-Transport netstack/listener/stop/join/port-release soak | 真实Gateway lifecycle与30分钟persistent资源soak |
-| C7 Package exactness | Exact native manifest、strict mac verification、macOS system-only dylib门、三平台launch smoke在exact SHA `6efca3c`通过；所有builder显式`--publish never` | Developer ID/notarization与正式release source reconciliation |
+| C7 Package exactness | Exact native manifest、strict mac verification、macOS system-only dylib门、三平台launch smoke在exact SHA `6efca3c`通过；所有builder显式`--publish never` | Developer ID/notarization；后续版本继续执行exact-tag source reconciliation |
+| C8 Initially-offline startup | Post-release tree等待首个网络sample；离线只保留一个paused intent，online后按autoConnect exactly once恢复 | 合并前Desktop/Electron、exact-tree secret与remote CI；真机cold-offline canary |
+| C9 UDP association ownership | Post-release tree把upload/download relay纳入父future结构化取消作用域 | 合并前Rust全量回归；真实UDP socket/port回收增强测试 |
+| C10 Browser connection wait ownership | Post-release tree使用intent-bound事件驱动registry替代100 ms轮询 | 合并前并发open/coalescing、quit/timeout和Main lifecycle回归 |
 
 本表只描述本地实现，不替代下方P0远端和真实环境门。
 
-## P0 — Release/governance blockers
+## P0 — Architecture Frozen governance and evidence blockers
 
-这些不一定是 runtime bug，但不完成就不能发布：
+这些不一定是runtime bug。v1.2.3维护者已明确接受其中的外部证据边界并完成发布；但在
+它们关闭前，不能宣称`1.x Architecture Frozen`：
 
 1. [完成] 用户授权后push review branch并建立PR #5；
 2. [完成] exact review SHA的ordinary CI、macOS Electron、Windows sidecar DACL、Rust全部通过；
 3. [完成] 同一SHA的macOS arm64/x64、Windows x64、Linux x64 clean package通过；
 4. [完成] 三平台unpacked launch smoke、package exact manifest与macOS dylib closure通过；
-5. `main` required checks、review、latest-commit、no-force-push生效；
-6. 授权环境完成 password-only、HPC DNS、Clash/SSH、sleep/wake/network switch canary；
-7. capability ledger区分 implementation与 evidence；
-8. 上述完成前不 tag、不 release、不复用旧 `desktop/release`。
+5. [完成] 最终review、merge、main exact-commit CI、tag source reconciliation与唯一publisher通过；
+6. [未完成] `main` required checks和no-force-push branch rule生效；
+7. [未完成] 授权环境完成password-only、HPC DNS、Clash/SSH、sleep/wake/network switch canary；
+8. [完成] capability ledger区分implementation与evidence；
+9. [永久规则] 任何后续release都必须从其exact tag clean build，不复用旧`desktop/release`。
 
 ## P1 — Architecture Frozen blockers
 

--- a/docs/engineering/1x-engineering-audit.md
+++ b/docs/engineering/1x-engineering-audit.md
@@ -8,13 +8,15 @@
 正式交付事实：PR #5以merge commit
 `5d8323d37de7c279ae70b3ec646f93791d6a3581`进入`main`；`v1.2.3`精确指向该commit。
 main push CI run `32630023985`和tag build/release run `32630322732`均成功，四个正式资产
-已由唯一release job发布。实现快照`6efca3c`之后只增加发布策略和文档收口，不新增
-Gateway production capability；正式包的源码身份以tag commit `5d8323d`为准。
+已由唯一release job发布。在v1.2.3 tag lineage中，从实现快照`6efca3c`到`5d8323d`
+只增加发布策略和文档收口，不新增Gateway production capability；正式包的源码身份以
+tag commit `5d8323d`为准。
 
-Post-release convergence说明：A-24～A-29来自`5d8323d`之后的独立复核。正在整改的
-startup recovery、UDP relay ownership和connection waiter当前只属于未提交、未发布的本地
-工作树；它们不属于`6efca3c`实现快照或已发布v1.2.3。在获得exact commit、secret/static/
-test gates、review和远端CI前，本文只把它们标为本地post-release证据。
+Post-release convergence说明：A-24～A-30来自`5d8323d`之后的独立复核。startup recovery、
+UDP relay ownership、connection waiter与quit gate的实现固定为
+`a6d40691d6fb8fe18b4a2260ae6f5adea6b34a7c`；它们不属于`6efca3c`实现快照或已发布
+v1.2.3。该commit已完成本地secret/static/test gates与四轮独立review，但尚未获得远端CI、
+merge或package证据，因此仍只标为post-release branch evidence。
 
 审计基线：`0470ca306f1658ec2444ed63ebe703b3b0ec7e59`
 （`codex/v1.2.3-hardening`）。审计开始时 `origin/main` 为
@@ -382,7 +384,7 @@ branch protection/required checks。维护者明确接受这些边界作为v1.2.
   立即false。所有`desiredConnected`进展（含retry-wait、connectivity-paused、stopping）
   coalesce到当前intent，不重置backoff/attempt budget；注册表有32个pending-intent硬上限。
 - **Priority**：P2；post-release tree的unit、source contract和三个并发Browser open跨retry
-  Main E2E已覆盖，exact commit/remote CI仍待建立。
+  Main E2E已覆盖，exact implementation commit与本地gates已建立；remote CI/merge待补。
 
 ### A-27 — terminal connection outcome is not fully owned by the FSM
 
@@ -432,8 +434,8 @@ branch protection/required checks。维护者明确接受这些边界作为v1.2.
 - **Recommended fix / implemented fix**：`connect/reconnect`入口及每个异步stop/wait边界调用同一
   fail-closed quit gate；它终止当前desired intent并立即发布snapshot，且内部intent继续不越过
   Renderer IPC。contract与Main lifecycle回归锁定no new intent/attempt语义。
-- **Priority**：Architecture Frozen前；post-release convergence tree已实现，exact commit/
-  remote CI仍待建立。
+- **Priority**：Architecture Frozen前；post-release convergence tree已实现，exact
+  implementation commit与本地gates已建立；remote CI/merge待补。
 
 ## 5. Technical debt that is not a rewrite mandate
 
@@ -454,7 +456,7 @@ branch protection/required checks。维护者明确接受这些边界作为v1.2.
 ## 7. Convergence disposition
 
 已发布v1.2.3实现提交：`6efca3c`；正式交付/tag提交：`5d8323d`。A-01～A-23按该固定
-发布证据处置；A-24～A-29是单独的post-release本地工作树审计，不得反向归入v1.2.3。
+发布证据处置；A-24～A-30是单独的post-release branch审计，不得反向归入v1.2.3。
 本表只关闭有对应层级代码和测试证据的问题；远端、平台和学校环境证据仍保持开放。
 
 | Finding | Disposition | Current evidence |
@@ -510,10 +512,11 @@ branch protection/required checks。维护者明确接受这些边界作为v1.2.
 - 正式Release为`v1.2.3`，包含两个DMG、一个EXE和一个AppImage；资产digest记录在
   [`1x-release-gate.md`](1x-release-gate.md)。
 
-### Unpublished post-release convergence verification
+### Post-release convergence commit verification
 
-以下结果只适用于当前本地工作树，不归入v1.2.3；exact commit、远端CI和package证据仍待
-提交后建立：
+以下结果只适用于implementation commit
+`a6d40691d6fb8fe18b4a2260ae6f5adea6b34a7c`，不归入v1.2.3；远端CI、merge和package
+证据仍未建立：
 
 - Rust no-default production suite：262 passed，0 failed，2个显式性能门ignored；fmt、
   all-target Clippy `-D warnings`通过。
@@ -526,8 +529,9 @@ branch protection/required checks。维护者明确接受这些边界作为v1.2.
   （`autoConnect=true`、`autoReconnect=false`）Electron E2E均通过。
 - 新startup E2E已经进入ordinary CI和tag build contract；synthetic network/Engine fixture仅限
   non-packaged测试，且不在package files中。
-- JS syntax与`git diff --check`通过；exact staged/tree secret gate、独立最终review、远端CI
-  和任何新package尚待后续提交边界完成。
+- JS syntax、`git diff --check`与exact tree secret gate通过。四轮独立review分别覆盖Rust
+  UDP cancellation、Desktop startup/wait/quit竞态、交付文档和最终组合回归；最终结论为GO，
+  除A-27～A-29已记录债务外未发现新的合并阻断。远端CI、merge和任何新package仍待补。
 
 当前未发现仍成立的本地代码级P0/P1；远端CI、正式tag原生包与Windows sidecar DACL
 也已通过，v1.2.3已经发布。Architecture Frozen仍为NO；真实HPC/Gateway、Clash/SSH、

--- a/docs/engineering/1x-engineering-audit.md
+++ b/docs/engineering/1x-engineering-audit.md
@@ -5,6 +5,17 @@
 收束实现与package候选快照：`6efca3c2b762a9b2b47f74b11b965b2c126e5c91`。
 第2节保留的是审计开始时的历史基线；第7节记录整改后的当前结论，不能用旧计数覆盖新证据。
 
+正式交付事实：PR #5以merge commit
+`5d8323d37de7c279ae70b3ec646f93791d6a3581`进入`main`；`v1.2.3`精确指向该commit。
+main push CI run `32630023985`和tag build/release run `32630322732`均成功，四个正式资产
+已由唯一release job发布。实现快照`6efca3c`之后只增加发布策略和文档收口，不新增
+Gateway production capability；正式包的源码身份以tag commit `5d8323d`为准。
+
+Post-release convergence说明：A-24～A-29来自`5d8323d`之后的独立复核。正在整改的
+startup recovery、UDP relay ownership和connection waiter当前只属于未提交、未发布的本地
+工作树；它们不属于`6efca3c`实现快照或已发布v1.2.3。在获得exact commit、secret/static/
+test gates、review和远端CI前，本文只把它们标为本地post-release证据。
+
 审计基线：`0470ca306f1658ec2444ed63ebe703b3b0ec7e59`
 （`codex/v1.2.3-hardening`）。审计开始时 `origin/main` 为
 `0ae0d33de0c3056f3f95f4a70154b74f7518f715`，本地分支尚无远端 PR。
@@ -23,12 +34,11 @@ stale cancel、Engine-owned challenge budgets、浏览器 OTP 防误存、严格
 post-Transport子进程回归均已建立。后者是feature-gated、无外部路由的测试接缝，不证明
 真实Gateway认证、Modern L3或校园转发。
 
-远端PR CI、Windows proxy-sidecar DACL与当前SHA三平台原生产物现已通过。尚不能宣布
-Architecture Frozen 的原因已收窄为学校真实canary、30分钟packaged资源soak、`main`
-branch protection/required checks、最终维护者review、merge/tag/release source reconciliation。
-因此Architecture Frozen仍未完成，但维护者已明确接受这些外部证据边界并授权v1.2.3
-候选进入merge/tag clean-build流程。它仍是patch release；本轮没有新增真实认证方式或
-用户功能。
+远端PR CI、Windows proxy-sidecar DACL、main push CI以及同一tag的三平台原生产物和
+唯一release job现已通过，merge/tag/release source reconciliation已经闭环。尚不能宣布
+Architecture Frozen 的原因已收窄为学校真实canary、30分钟packaged资源soak以及`main`
+branch protection/required checks。维护者明确接受这些边界作为v1.2.3发布风险后，版本已
+正式发布。它仍是patch release；本轮没有新增真实认证方式或用户功能。
 
 ## 2. Baseline evidence
 
@@ -44,6 +54,8 @@ branch protection/required checks、最终维护者review、merge/tag/release so
 | Main/MFA/popup/strict proxy/auth-pipe Electron | PASS |
 | Remote CI for this branch | PASS：`32628684472`、`32628684427` |
 | Current v1.2.3 macOS/Windows/Linux artifacts | PASS：`32628682638`，exact SHA `6efca3c` |
+| Main post-merge CI | PASS：`32630023985`，exact SHA `5d8323d` |
+| Tagged build and release | PASS：`32630322732`；tag `v1.2.3` -> `5d8323d`；4 assets |
 | Real HKUST canary for this exact tree | Missing |
 
 本地synthetic/offline与三平台package结果不等于真实Gateway、所有Windows私有文件类别或
@@ -298,7 +310,8 @@ branch protection/required checks、最终维护者review、merge/tag/release so
 - **Severity**：P1 external proxy availability。
 - **Impact**：隧道和Campus Browser仍可能正常，但已复制的Clash/SSH配置会突然找不到本地
   凭据文件，直到再次显式生成。
-- **Fix**：generation-scoped内存凭据仍按旧generation清理；共享sidecar只有Supervisor与
+- **Root cause**：共享sidecar没有与拥有它的Engine generation一起参与close判定。
+- **Recommended fix / implemented fix**：generation-scoped内存凭据仍按旧generation清理；共享sidecar只有Supervisor与
   FSM generation均为current时才删除。行为测试覆盖两类stale close均0次unlink、current
   close恰好1次unlink。
 - **Priority**：v1.2.3发布前。
@@ -308,7 +321,9 @@ branch protection/required checks、最终维护者review、merge/tag/release so
 - **Evidence**：popup被`setImmediate`延迟创建；原实现直接调用`createTab`。Electron原生
   View构造、挂载或窗口关闭竞态抛出时可成为Main未捕获异常，并保留credential reservation。
 - **Severity**：P2 Desktop stability / credential-flow liveness。
-- **Fix**：popup外层使用`try/finally`；`createTab`事务拥有固定window、partial View/Tab、
+- **Impact**：Main可能退出，且popup credential reservation无法归还，阻塞同一登录flow。
+- **Root cause**：异步原生View创建没有一个拥有所有partial resource的事务边界。
+- **Recommended fix / implemented fix**：popup外层使用`try/finally`；`createTab`事务拥有固定window、partial View/Tab、
   credential flow与previous active tab，任何失败均回滚并返回固定用户提示。故障注入验证
   `addChildView`抛出后仅保留原tab、reservation/popups均为0、候选密码仍只在owner。
 - **Priority**：v1.2.3发布前。
@@ -318,10 +333,107 @@ branch protection/required checks、最终维护者review、merge/tag/release so
 - **Evidence**：electron-builder 26在tag环境可能把未指定publish policy的命令解释为
   `onTag`，与仓库设计的tag-only release job形成双publisher路径。
 - **Severity**：P1 release correctness / authority boundary。
-- **Fix**：package scripts、mac matrix直接命令和local rebuild全部显式`--publish never`；
+- **Impact**：同一tag可能有两个上传者，造成重复资产、权限扩大或不同源码/产物竞争。
+- **Root cause**：构建命令依赖electron-builder的隐式tag发布默认值。
+- **Recommended fix / implemented fix**：package scripts、mac matrix直接命令和local rebuild全部显式`--publish never`；
   contract test锁定。run `32628682638`全日志无implicit publishing或上传尝试，唯一
   `contents: write`仍只在tag条件release job。
 - **Priority**：合并/tag前。
+
+### A-24 — initially-offline startup could exhaust retries before the network returned
+
+- **Evidence**：`NetworkStatusMonitor`原先把首个`false`只保存为静默baseline，而Main在
+  启动500 ms后独立auto-connect；初始Engine失败并耗尽retry后，后续`false→true`没有一个
+  pending outage可恢复。
+- **Severity**：P1 availability / lifecycle correctness。
+- **Impact**：用户在无网状态启动应用，随后恢复Wi-Fi，界面仍不会按已保存的auto-connect
+  意图连接，必须手动操作或重启。
+- **Root cause**：网络baseline学习和startup auto-connect由两个无序owner分别启动。
+- **Recommended fix / implemented fix**：`NetworkStartupCoordinator`等待首个sample；初始离线
+  时只建立一个`connectivity-paused` intent，不spawn Engine；online后exactly once恢复同一
+  intent。startup-only恢复服从`autoConnect`，但不会绕过之后普通故障的`autoReconnect`
+  设置；手动intent和quit使旧continuation失效。
+- **Priority**：Architecture Frozen前。unit与真实Main synthetic Electron回归覆盖
+  `offline → paused/0 attempts → online/1 attempt`及后续drop不自动重连。
+
+### A-25 — UDP ASSOCIATE relay tasks could detach from their parent connection
+
+- **Evidence**：`SocksServer::handle_udp_associate`原先分别`tokio::spawn`上传和下载relay；
+  外层connection task被abort时，两个`JoinHandle`直接drop会让relay继续运行到runtime退出。
+- **Severity**：P2 resource lifecycle。
+- **Impact**：正常serving shutdown缺少UDP relay完成证据，未来进程内重连或长寿命runtime
+  可能暂时保留socket/task。
+- **Root cause**：子任务没有abort-on-drop owner，也不在父future的结构化并发作用域内。
+- **Recommended fix / implemented fix**：父future直接pin并`select!`两个方向及control close；
+  父任务drop/abort或任一方向结束时其余pending I/O同步drop。回归测试在两个方向都active后
+  abort父任务，并验证两个drop guard都执行。
+- **Priority**：Architecture Frozen前的P2收束。
+
+### A-26 — Browser connection waiters were polling and not bound to an intent
+
+- **Evidence**：审计时`main.js::waitForConnected`每次调用建立100 ms轮询，最长45秒；它只看
+  当前全局connected/error，没有捕获发起请求时的connection intent/generation。
+- **Severity**：P2 lifecycle / navigation correctness。
+- **Impact**：旧“打开校园网站”请求可在用户断开并开始新intent后被新连接错误满足；并发
+  请求产生多组不能主动取消的timer。
+- **Root cause**：等待语义没有生命周期owner，FSM transition也没有发布等待完成事件。
+- **Recommended fix / implemented fix**：使用intent-bound、事件驱动的
+  `ConnectionWaitRegistry`；同intent共享一个promise/timer，disconnect/stale/fail/quit/timeout
+  立即false。所有`desiredConnected`进展（含retry-wait、connectivity-paused、stopping）
+  coalesce到当前intent，不重置backoff/attempt budget；注册表有32个pending-intent硬上限。
+- **Priority**：P2；post-release tree的unit、source contract和三个并发Browser open跨retry
+  Main E2E已覆盖，exact commit/remote CI仍待建立。
+
+### A-27 — terminal connection outcome is not fully owned by the FSM
+
+- **Evidence**：`ConnectionStateMachine::snapshot`拥有phase/intent/generation，但稳定terminal
+  outcome仍部分保存在Main的`state.lastError`；Browser/settings/recovery notice虽已分域，
+  connection failure投影仍跨两个owner组合。
+- **Severity**：P2 maintainability / diagnostics。
+- **Impact**：未来增加认证或underlay状态时，等待条件、retry和用户文案可能再次从可变字符串
+  推导生命周期。
+- **Root cause**：FSM先收束phase，尚未收束`{code, secondaryCode, intent, generation}`结果。
+- **Recommended fix**：FSM持有稳定、无本地化文本的`lastOutcome`；projection层再映射用户文案，
+  Browser/settings/log notice继续独立。
+- **Priority**：后续1.x渐进式P2，不做一次性Main重写。
+
+### A-28 — legacy error and architecture ratchets remain intentionally incomplete
+
+- **Evidence**：Rust仍保留`ErrorKind::Unclassified`和旧`Error(String)`路径；pre-hello/legacy
+  Desktop fallback仍解析stderr。Desktop architecture gate检查cycle和顶层layer，但允许任意
+  `lib/* → lib/*`，而`ec-engine.rs`、`socks.rs`和`dns.rs`仍较大。
+- **Severity**：P2 maintainability；当前结构化production fatal path已有稳定code。
+- **Impact**：触达旧路径时，英文或底层库变化仍可能降低诊断稳定性；CI尚不能阻止所有领域
+  内反向依赖。
+- **Root cause**：为避免高风险机械重写，迁移采用只降不升ratchet。
+- **Recommended fix**：API hello后禁止stderr参与控制决策，旧模块按触达补typed source；为
+  `desktop/lib`建立小型ownership map/edge allowlist，只沿真实生命周期拆分大文件。
+- **Priority**：P2持续维护，不是回滚当前基线的理由。
+
+### A-29 — online-to-online interface changes have no direct generation signal
+
+- **Evidence**：当前`NetworkStatusMonitor`只比较`net.isOnline()`布尔值；Wi-Fi/AP、Ethernet或
+  default-route变化但机器始终online时，不会直接使Engine generation失效。
+- **Severity**：P2 availability；尚无本校稳定复现。
+- **Impact**：只能等待SOCKS health连续失败后被动恢复，切换延迟和失败原因不够可解释。
+- **Root cause**：1.x没有受控的underlay identity/default-route fingerprint adapter。
+- **Recommended fix**：先以平台只读adapter产生有界route/source-interface fingerprint，变化时
+  走现有generation invalidation；自动出口探测仍留在2.0并受独立证据门约束。
+- **Priority**：P2 evidence-triggered；需要synthetic transition与真机切换canary。
+
+### A-30 — late connection requests could race application quit
+
+- **Evidence**：`DesktopShell::requestQuit`先标记`isQuitting`并开始异步disconnect；审计时
+  `connect/reconnect`入口及其await后的continuation只检查intent，没有统一检查quit状态。
+- **Severity**：P1 process lifecycle。
+- **Impact**：控制Renderer在quit窗口内的晚到请求可能在旧Engine停完后创建新intent并spawn
+  Engine，而cleanup不会再执行第二轮stop，造成退出后子进程残留风险。
+- **Root cause**：quit owner只取消已有资源，没有成为所有未来connection entry的否决条件。
+- **Recommended fix / implemented fix**：`connect/reconnect`入口及每个异步stop/wait边界调用同一
+  fail-closed quit gate；它终止当前desired intent并立即发布snapshot，且内部intent继续不越过
+  Renderer IPC。contract与Main lifecycle回归锁定no new intent/attempt语义。
+- **Priority**：Architecture Frozen前；post-release convergence tree已实现，exact commit/
+  remote CI仍待建立。
 
 ## 5. Technical debt that is not a rewrite mandate
 
@@ -341,8 +453,9 @@ branch protection/required checks、最终维护者review、merge/tag/release so
 
 ## 7. Convergence disposition
 
-当前实现提交：`6efca3c`。本表只关闭有当前代码和测试证据的问题；远端、平台和学校
-环境证据仍保持开放。
+已发布v1.2.3实现提交：`6efca3c`；正式交付/tag提交：`5d8323d`。A-01～A-23按该固定
+发布证据处置；A-24～A-29是单独的post-release本地工作树审计，不得反向归入v1.2.3。
+本表只关闭有对应层级代码和测试证据的问题；远端、平台和学校环境证据仍保持开放。
 
 | Finding | Disposition | Current evidence |
 | --- | --- | --- |
@@ -364,13 +477,20 @@ branch protection/required checks、最终维护者review、merge/tag/release so
 | A-16 route evaluator drift | Partially fixed | deterministic 1,024-case JS/PAC differential；versioned IR与100k corpus保留2.0 |
 | A-17 underlay change observation | Deferred evidence-triggered | `.no_proxy()`已关闭HTTP环境递归；explicit underlay保留2.0 |
 | A-18 documentation drift | Fixed | ROADMAP/compatibility/architecture使用Implementation+Evidence双轴 |
-| A-19 remote governance | Partially closed | PR #5、ordinary CI、Windows sidecar DACL和三平台exact-SHA package已完成；`main` protection仍404，最终review/merge/tag/source reconciliation与学校canary仍开放 |
+| A-19 remote governance | Closed for v1.2.3 delivery; Architecture Frozen governance remains open | PR #5、final review、merge、main CI、exact tag、三平台tag build和唯一release job已完成；`main` protection仍关闭，学校canary仍开放 |
 | A-20 Homebrew liblzma leakage | Fixed with package gate | vendored static liblzma；真实`otool -L` system-only门；修复前v1.2.2与v1.2.3 arm64 package证据已作废；run `32628682638`双架构package gate通过 |
 | A-21 stale close sidecar deletion | Fixed | generation-aware proxy cleanup；stale Supervisor/FSM均0次unlink，current close恰好1次；PR review thread已resolve |
 | A-22 popup creation exception | Fixed | 事务式View/Tab/credential-flow回滚；native addChild故障注入和真实popup MFA E2E通过 |
 | A-23 implicit builder publish | Fixed | 所有builder显式`--publish never`；唯一tag release job持有write；manual run无隐式上传 |
+| A-24 initially-offline startup | Fixed in post-release convergence tree | 首个网络sample决定pause或延迟auto-connect；`autoReconnect=false`的Main E2E仍只执行一次startup连接，随后drop不重连 |
+| A-25 detached UDP relay | Fixed in post-release convergence tree | upload/download直接由parent future监督；active parent abort测试验证两个方向同步drop |
+| A-26 unowned Browser connection wait | Fixed in post-release convergence tree | 同intent共享一个有界wait promise/timer；stale/disconnect/quit/timeout回归替代轮询，并发Browser open复用当前intent |
+| A-27 FSM terminal outcome split | Open P2 | phase已权威；稳定lastOutcome仍需从Main字符串状态迁入FSM |
+| A-28 legacy errors/domain edge ratchet | Accepted incremental P2 | 新结构化路径受门禁；旧`Unclassified`、stderr fallback和`lib/*`edge按触达继续收束 |
+| A-29 online-to-online interface change | Deferred evidence-triggered | 当前仍由health failure被动恢复；显式fingerprint与真机canary后再启用 |
+| A-30 late connection during quit | Fixed in post-release convergence tree | connect/reconnect入口和每个await后统一quit gate；desired intent终止，不能spawn新Engine或建立waiter |
 
-### Current local verification
+### Released v1.2.3 verification
 
 - Rust production feature set：261 passed，0 failed，2个显式release性能门默认ignored；
   lifecycle test feature：263 passed，0 failed，2 ignored；fmt和Clippy `-D warnings`通过。
@@ -384,10 +504,32 @@ branch protection/required checks、最终维护者review、merge/tag/release so
 - Electron：Main integration/lifecycle、toolbar、auth control、same-window/popup MFA、strict proxy、layout、20-tab、routing restart、idle全部通过。
 - Offline performance：SOCKS 18/18，最大p95 1.293 ms；netstack 27/27，最大p95 6.020 ms；均不是Gateway吞吐证据。
 - 每批精确暂存及最终本地候选HEAD secret gate通过；未来remote merge/tag candidate
-  仍须对其exact tree重新执行。
+  已在PR、main和tag流水线对对应exact tree重新执行。
+- main push CI `32630023985`在merge commit `5d8323d`通过；tag run `32630322732`的
+  macOS arm64/x64、Windows x64、Linux x64 build/verifier/smoke和唯一release job全部通过。
+- 正式Release为`v1.2.3`，包含两个DMG、一个EXE和一个AppImage；资产digest记录在
+  [`1x-release-gate.md`](1x-release-gate.md)。
 
-当前未发现仍成立的本地代码级P0/P1；远端CI、current-SHA原生包与Windows sidecar DACL
-也已通过。Architecture Frozen仍为NO；真实HPC/Gateway、Clash/SSH、校园SSO、sleep/wake、
-网络切换、系统网络before/after、30分钟packaged soak与`main` protection继续作为未验证
-边界披露。维护者已授权v1.2.3 Release Candidate GO；正式发布仍以merge commit精确tag、
-tag run三平台及唯一release job成功、资产/说明复核为条件。
+### Unpublished post-release convergence verification
+
+以下结果只适用于当前本地工作树，不归入v1.2.3；exact commit、远端CI和package证据仍待
+提交后建立：
+
+- Rust no-default production suite：262 passed，0 failed，2个显式性能门ignored；fmt、
+  all-target Clippy `-D warnings`通过。
+- Feature-gated真实`ec-engine` non-routing post-Transport lifecycle：100/100轮通过，新增
+  UDP parent-abort回归包含在上述262项production suite内。
+- Desktop：549 total，548 passed，0 failed，1个Windows-only DACL测试在macOS跳过；
+  `npm audit --audit-level=high`为0 vulnerabilities。
+- Desktop graph：198 files / 250 edges / 0 cycles；Main 1596行/35直接依赖；Renderer 524行。
+- Main integration、同intent retry + 两个并发Campus Browser waiter、initially-offline startup
+  （`autoConnect=true`、`autoReconnect=false`）Electron E2E均通过。
+- 新startup E2E已经进入ordinary CI和tag build contract；synthetic network/Engine fixture仅限
+  non-packaged测试，且不在package files中。
+- JS syntax与`git diff --check`通过；exact staged/tree secret gate、独立最终review、远端CI
+  和任何新package尚待后续提交边界完成。
+
+当前未发现仍成立的本地代码级P0/P1；远端CI、正式tag原生包与Windows sidecar DACL
+也已通过，v1.2.3已经发布。Architecture Frozen仍为NO；真实HPC/Gateway、Clash/SSH、
+校园SSO、sleep/wake、网络切换、系统网络before/after、30分钟packaged soak与`main`
+protection继续作为工程证据边界保留，不因发布完成而改写为已验证。

--- a/docs/engineering/1x-engineering-audit.md
+++ b/docs/engineering/1x-engineering-audit.md
@@ -15,8 +15,10 @@ tag commit `5d8323d`为准。
 Post-release convergence说明：A-24～A-30来自`5d8323d`之后的独立复核。startup recovery、
 UDP relay ownership、connection waiter与quit gate的实现固定为
 `a6d40691d6fb8fe18b4a2260ae6f5adea6b34a7c`；它们不属于`6efca3c`实现快照或已发布
-v1.2.3。该commit已完成本地secret/static/test gates与四轮独立review，但尚未获得远端CI、
-merge或package证据，因此仍只标为post-release branch evidence。
+v1.2.3。该commit已完成本地secret/static/test gates与四轮独立review；PR #6 code+docs head
+`2ffe928cd12ca564a5160a07372db5967cf67133`的ordinary CI run `32641232584`和compatibility
+run `32641232560`通过。merge和cross-platform package仍无证据，因此仍只标为
+post-release branch evidence。
 
 审计基线：`0470ca306f1658ec2444ed63ebe703b3b0ec7e59`
 （`codex/v1.2.3-hardening`）。审计开始时 `origin/main` 为
@@ -515,8 +517,8 @@ branch protection/required checks。维护者明确接受这些边界作为v1.2.
 ### Post-release convergence commit verification
 
 以下结果只适用于implementation commit
-`a6d40691d6fb8fe18b4a2260ae6f5adea6b34a7c`，不归入v1.2.3；远端CI、merge和package
-证据仍未建立：
+`a6d40691d6fb8fe18b4a2260ae6f5adea6b34a7c`，不归入v1.2.3；其远端PR CI已建立，merge和
+cross-platform package证据仍未建立：
 
 - Rust no-default production suite：262 passed，0 failed，2个显式性能门ignored；fmt、
   all-target Clippy `-D warnings`通过。
@@ -531,7 +533,11 @@ branch protection/required checks。维护者明确接受这些边界作为v1.2.
   non-packaged测试，且不在package files中。
 - JS syntax、`git diff --check`与exact tree secret gate通过。四轮独立review分别覆盖Rust
   UDP cancellation、Desktop startup/wait/quit竞态、交付文档和最终组合回归；最终结论为GO，
-  除A-27～A-29已记录债务外未发现新的合并阻断。远端CI、merge和任何新package仍待补。
+  除A-27～A-29已记录债务外未发现新的合并阻断。
+- PR #6 head `2ffe928`的CI run `32641232584`：Desktop、macOS Electron、Windows DACL、
+  Engine fmt/Clippy/tests、100轮lifecycle、性能门与原生binary build全部通过；compatibility run
+  `32641232560`的offline tests通过，真实Gateway job在PR场景按设计skip。
+- merge和任何新package仍待补；上述CI不把a6d改写为v1.2.3或已发布功能。
 
 当前未发现仍成立的本地代码级P0/P1；远端CI、正式tag原生包与Windows sidecar DACL
 也已通过，v1.2.3已经发布。Architecture Frozen仍为NO；真实HPC/Gateway、Clash/SSH、

--- a/docs/engineering/1x-release-gate.md
+++ b/docs/engineering/1x-release-gate.md
@@ -1,12 +1,18 @@
 # 1.x Architecture Frozen and Release Gate
 
-状态：代码/package候选GO，正式发布以合并commit的tag build成功为条件。勾选项只表示
-当前固定证据；未勾选项作为明确披露的证据边界，不得由“应该能工作”替代。
+状态：v1.2.3已正式发布；1.x Architecture Frozen仍为NO。勾选项只表示当前固定证据；
+未勾选项继续作为工程证据边界，不得由“应该能工作”替代。
 
 实现与package候选证据基线：`6efca3c2b762a9b2b47f74b11b965b2c126e5c91`；后续纯文档
 提交不改变该实现树。若再修改production代码，必须重新固定SHA并重跑相应门禁。
+正式交付commit为`5d8323d37de7c279ae70b3ec646f93791d6a3581`；它的production
+实现与`6efca3c`一致，并包含后续发布策略与文档收口。`v1.2.3`精确指向该merge commit。
 本轮产品版本仍为v1.2.3：新增内容属于补丁级稳定性、诊断、回归和交付门禁，不是新的
 production Gateway能力。
+
+本文件的v1.2.3发布勾选只冻结tag `5d8323d`的证据。当前post-release convergence
+工作树中的startup recovery、UDP relay ownership和connection waiter修改不属于v1.2.3，
+在获得独立commit、exact-tree gates、review和远端CI以前也不是新的发布候选。
 
 ## 1. Source and governance
 
@@ -15,8 +21,12 @@ production Gateway能力。
 - [x] Review branch已push；PR #5包含候选实现提交，package run的source SHA与其一致。
 - [x] PR #5包含全部候选改动，自动review意见已处理并resolve。
 - [x] 最终维护者review完成，并已明确授权合并与发布v1.2.3。
-- [ ] `main` required checks、latest commit、review和no-force-push已启用。
-- [ ] 合并commit、tag和release source SHA一致。
+- [x] PR #5以merge commit`5d8323d`进入`main`，merge tree与最终PR head一致。
+- [x] main exact-commit CI run`32630023985`通过。
+- [x] `v1.2.3`精确指向`5d8323d`；tag build/release run`32630322732`通过。
+- [ ] `main` required checks和no-force-push branch rule已启用；final review与latest-commit
+  main CI已由上方独立证据闭环。
+- [x] 合并commit、tag、tag workflow和Release source SHA一致。
 
 ## 2. Architecture and state
 
@@ -119,6 +129,7 @@ v1.2.3的GO/NO-GO，也不能因为已有generic fixture而提前勾选：
   DACL test通过。
 - [x] 候选SHA ordinary PR CI jobs全部绿色（runs `32628684472`、`32628684427`；
   live compatibility在PR场景按设计skip）。
+- [x] merge commit `5d8323d`的main push CI run `32630023985`全部绿色。
 - [ ] `main`已将相应jobs配置为required checks。
 
 ## 9. Package and platform
@@ -151,6 +162,20 @@ v1.2.3的GO/NO-GO，也不能因为已有generic fixture而提前勾选：
 | Windows artifact | `9490498992`；artifact ZIP digest `sha256:7dc9243ae52dbb241af2175b427c51813db4382f2c60fc6c9ad0dd29988e32ec` |
 | Linux artifact | `9490456479`；artifact ZIP digest `sha256:389e0183fd3ae1210ac0b48b4b42837ffb8996eb77b0dc13d8345673f19d961f` |
 
+### Formal tagged release evidence
+
+| Evidence | Result |
+| --- | --- |
+| Merge/source | `main` merge commit `5d8323d37de7c279ae70b3ec646f93791d6a3581` |
+| Tag | annotated `v1.2.3` peels exactly to `5d8323d37de7c279ae70b3ec646f93791d6a3581` |
+| Main CI | run `32630023985`；desktop、desktop-electron、Windows DACL、Engine全部success |
+| Tag build/release | run `32630322732`；macOS、Windows、Linux和唯一release job全部success |
+| macOS arm64 DMG | `hkustgzconnect-1.2.3-mac-arm64.dmg`；`sha256:0002cf90d1b49fe7a4d771e1fcad847b9d7883d82859de9273683660bcab269f` |
+| macOS x64 DMG | `hkustgzconnect-1.2.3-mac-x64.dmg`；`sha256:4013d52bbc0644227af29aadc75530b3ba135e32578afb702fd724312b5c92dd` |
+| Windows x64 EXE | `hkustgzconnect-1.2.3-win-x64.exe`；`sha256:e9068b5183239afcd38818617e4b6a51f17f883535933f19e362a8d5845760fa` |
+| Linux x64 AppImage | `hkustgzconnect-1.2.3-linux-x86_64.AppImage`；`sha256:71dad3553d8e84fa97f5d86201f8075de6a7f8dc0a2bb74ff8e38fc1482e38a2` |
+| Release | <https://github.com/heeh02/HKUST-GZ-Connect/releases/tag/v1.2.3>；published 2026-08-23 |
+
 ## 10. Documentation and capability truth
 
 - [x] 根项目架构宪法存在。
@@ -160,21 +185,22 @@ v1.2.3的GO/NO-GO，也不能因为已有generic fixture而提前勾选：
 - [x] `independent/ARCHITECTURE.md`与DNS TCP和shutdown当前行为一致。
 - [x] ROADMAP/compatibility matrix统一Implementation+Evidence状态。
 - [x] 用户README只说明真实可用功能，并明确Gateway MFA和真实环境证据边界。
-- [ ] Release notes准确披露签名、公证、平台和未验证边界。
+- [x] 公开Release说明聚焦用户可感知的修复和完善；签名、公证、真实canary与长期soak等
+  工程证据边界保留在本gate，不要求复制到公开Release说明。
 
 ## 11. Release decision
 
 代码、package和发布链审查已经通过。维护者于2026-08-23明确接受以下未验证边界作为
 v1.2.3发布风险，而不是把它们改写为已验证：真实Gateway/HPC/Clash/SSH/SAML canary、
 30分钟packaged soak、`main` branch protection、Developer ID/notarization与Windows
-Authenticode。Release notes必须逐项披露。
+Authenticode。这些边界由工程gate持续追踪，不要求公开Release说明逐项展开。
 
-正式发布仍必须满足：PR以merge commit进入`main`；`v1.2.3`精确指向该merge commit；
-同一tag run三平台build/verifier/smoke及唯一release job全部成功；Release资产和说明复核完成。
+正式发布要求已经满足：PR以merge commit进入`main`；`v1.2.3`精确指向该merge commit；
+同一tag run三平台build/verifier/smoke及唯一release job全部成功；四个正式资产已复核。
 
 当前结论：
 
 ```text
 1.x Architecture Frozen: NO
-v1.2.3 Release Candidate: GO (conditional on tagged clean build)
+v1.2.3 Release: PUBLISHED (tagged clean build PASS)
 ```

--- a/docs/engineering/1x-release-gate.md
+++ b/docs/engineering/1x-release-gate.md
@@ -12,8 +12,9 @@ production Gateway能力。
 
 本文件的v1.2.3发布勾选只冻结tag `5d8323d`的证据。post-release convergence commit
 `a6d40691d6fb8fe18b4a2260ae6f5adea6b34a7c`中的startup recovery、UDP relay ownership、
-connection waiter和quit gate不属于v1.2.3；其本地exact-tree gates与review已通过，但在
-获得远端CI、merge和单独版本决策以前不是新的发布候选。
+connection waiter和quit gate不属于v1.2.3；其本地exact-tree gates、review以及PR #6
+ordinary CI `32641232584`与compatibility offline run `32641232560`已通过，但在获得merge、
+cross-platform package和单独版本决策以前不是新的发布候选。
 
 ## 1. Source and governance
 

--- a/docs/engineering/1x-release-gate.md
+++ b/docs/engineering/1x-release-gate.md
@@ -10,9 +10,10 @@
 本轮产品版本仍为v1.2.3：新增内容属于补丁级稳定性、诊断、回归和交付门禁，不是新的
 production Gateway能力。
 
-本文件的v1.2.3发布勾选只冻结tag `5d8323d`的证据。当前post-release convergence
-工作树中的startup recovery、UDP relay ownership和connection waiter修改不属于v1.2.3，
-在获得独立commit、exact-tree gates、review和远端CI以前也不是新的发布候选。
+本文件的v1.2.3发布勾选只冻结tag `5d8323d`的证据。post-release convergence commit
+`a6d40691d6fb8fe18b4a2260ae6f5adea6b34a7c`中的startup recovery、UDP relay ownership、
+connection waiter和quit gate不属于v1.2.3；其本地exact-tree gates与review已通过，但在
+获得远端CI、merge和单独版本决策以前不是新的发布候选。
 
 ## 1. Source and governance
 

--- a/independent/src/engine/socks.rs
+++ b/independent/src/engine/socks.rs
@@ -3,6 +3,7 @@ use crate::engine::netstack::VirtualNetstack;
 use crate::engine::proxy::{NameResolver, resolve_authority, resolve_host, validate_domain};
 use crate::engine::socks_auth::ProxyAuthentication;
 use crate::{Error, Result};
+use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
@@ -256,21 +257,35 @@ impl SocksServer {
         let client_endpoint = Arc::new(RwLock::new(None::<SocketAddr>));
         send_reply(&mut control, 0, Some(local_address)).await?;
 
-        let mut upload = tokio::spawn(relay_udp_upload(
+        let upload = relay_udp_upload(
             Arc::clone(&local),
             Arc::clone(&tunnel),
             Arc::clone(&client_endpoint),
             Arc::clone(&self.resolver),
-        ));
-        let mut download = tokio::spawn(relay_udp_download(local, tunnel, client_endpoint));
-        let result = tokio::select! {
-            result = wait_for_control_close(&mut control) => result,
-            result = &mut upload => relay_task_result(result, "upload"),
-            result = &mut download => relay_task_result(result, "download"),
-        };
-        upload.abort();
-        download.abort();
-        result
+        );
+        let download = relay_udp_download(local, tunnel, client_endpoint);
+        supervise_udp_associate(&mut control, upload, download).await
+    }
+}
+
+async fn supervise_udp_associate<U, D>(
+    control: &mut TcpStream,
+    upload: U,
+    download: D,
+) -> Result<()>
+where
+    U: Future<Output = Result<()>>,
+    D: Future<Output = Result<()>>,
+{
+    // Keep both relay directions inside this parent future. Dropping or
+    // aborting the connection task therefore drops their pending socket I/O
+    // immediately instead of detaching independently spawned Tokio tasks.
+    tokio::pin!(upload);
+    tokio::pin!(download);
+    tokio::select! {
+        result = wait_for_control_close(control) => result,
+        result = &mut upload => relay_future_result(result, "upload"),
+        result = &mut download => relay_future_result(result, "download"),
     }
 }
 
@@ -341,16 +356,12 @@ async fn wait_for_control_close(control: &mut TcpStream) -> Result<()> {
     }
 }
 
-fn relay_task_result(
-    result: std::result::Result<Result<()>, tokio::task::JoinError>,
-    direction: &str,
-) -> Result<()> {
+fn relay_future_result(result: Result<()>, direction: &str) -> Result<()> {
     match result {
-        Ok(Ok(())) => Err(Error(format!(
+        Ok(()) => Err(Error(format!(
             "SOCKS5 UDP {direction} relay stopped unexpectedly"
         ))),
-        Ok(Err(error)) => Err(error),
-        Err(_) => Err(Error(format!("SOCKS5 UDP {direction} relay task failed"))),
+        Err(error) => Err(error),
     }
 }
 
@@ -870,6 +881,50 @@ mod tests {
         let client = TcpStream::connect(address).await.unwrap();
         let (server, _) = listener.accept().await.unwrap();
         (client, server)
+    }
+
+    #[tokio::test]
+    async fn active_udp_associate_parent_abort_drops_both_relay_directions() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct RelayDrop(Arc<AtomicUsize>);
+        impl Drop for RelayDrop {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        async fn pending_relay(
+            started: tokio::sync::oneshot::Sender<()>,
+            dropped: Arc<AtomicUsize>,
+        ) -> Result<()> {
+            let _drop = RelayDrop(dropped);
+            let _ = started.send(());
+            std::future::pending().await
+        }
+
+        let (control_peer, mut control) = connected_pair().await;
+        let dropped = Arc::new(AtomicUsize::new(0));
+        let (upload_started, upload_ready) = tokio::sync::oneshot::channel();
+        let (download_started, download_ready) = tokio::sync::oneshot::channel();
+        let upload = pending_relay(upload_started, Arc::clone(&dropped));
+        let download = pending_relay(download_started, Arc::clone(&dropped));
+
+        let associate =
+            tokio::spawn(
+                async move { supervise_udp_associate(&mut control, upload, download).await },
+            );
+        tokio::time::timeout(Duration::from_secs(1), async {
+            upload_ready.await.unwrap();
+            download_ready.await.unwrap();
+        })
+        .await
+        .expect("both UDP relay directions must become active");
+
+        associate.abort();
+        assert!(associate.await.unwrap_err().is_cancelled());
+        assert_eq!(dropped.load(Ordering::SeqCst), 2);
+        drop(control_peer);
     }
 
     fn rfc1929_packet(username: &[u8], password: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
## 背景

这是 v1.2.3 发布后的 1.x 工程收束，不增加新的 Gateway 能力，也不修改版本号或现有 Release。

独立复核确认了三个实际生命周期缺口：

- 应用冷启动即离线时会提前耗尽重试，网络恢复后不自动连接；
- 校园浏览器等待连接使用无 intent 的轮询，并发打开、重试、退出时可能互相干扰；
- SOCKS UDP ASSOCIATE 的双向 relay 可能脱离父连接生命周期。

## 修改

- 增加首个网络 baseline 与 startup auto-connect 协调：初始离线不启动 Engine，online 后只恢复一次；普通 autoReconnect=false 仍不自动恢复，但保留手动连接能力。
- 增加 intent-bound、事件驱动的 ConnectionWaitRegistry；并发校园页面复用同一 intent 和等待任务，不重置 retry/backoff；quit 期间 connect/reconnect 全部 fail-closed。
- 将 UDP upload/download relay 纳入父 future 的结构化取消作用域。
- ordinary CI 与 tag build 都加入 initially-offline Main Electron 回归。
- 同步 v1.2.3 正式发布证据、1.3 MFA entry/exit gate、2.0 Multi-Exit Detection 设计和 ControlledDirectExit ADR。

## 本地验证

- Desktop: 549 total, 548 passed, 0 failed, 1 Windows-only skipped
- Rust production suite: 262 passed, 0 failed, 2 explicit performance gates ignored
- Rust post-Transport lifecycle: 100/100 rounds passed
- Main integration, retry/concurrent waiter, initially-offline and manual-recovery Electron E2E: PASS
- Architecture: 198 files, 250 edges, 0 cycles, Main 1596 lines / 35 direct deps, Renderer 524 lines
- npm audit high: 0 vulnerabilities
- Exact HEAD Git-tree secret gate: PASS
- JS syntax, Rust fmt/Clippy, Markdown links and diff check: PASS

## 边界

- 不实现或宣称真实学校 Gateway MFA；未知认证继续 fail-closed。
- 不引入 TUN、系统 DNS/路由/代理修改或新的 EasyConnect 私有依赖。
- 不修改 v1.2.3 公开 Release 说明和资产。