### PR TITLE
docs: 定义 Campus Workspace 2.0 产品与架构路线

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ runtime.toml
 .hkustgzconnect/
 
 # ---- generated engine binaries (built from independent/ by CI / setup) ----
-zju-connect
-zju-connect.exe
+/zju-connect
+/zju-connect.exe
 desktop/engine/*
 !desktop/engine/.gitkeep
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -161,6 +161,10 @@ point if an optional EasyConnect feature is enabled later. It is not a 2.0.0
 release commitment, and none of the Partial entries below is advertised as a
 working user feature.
 
+2.0准备阶段的证据、clean-room、架构接缝与分阶段PR计划见
+[`docs/plans/2.0-preparation-execution-plan.md`](docs/plans/2.0-preparation-execution-plan.md)。
+该计划当前只授权研究和架构准备，不授权production功能或Release。
+
 The trigger for implementation is evidence that the school has enabled a
 specific capability on a controlled test profile. Work should then cover only
 that capability, compare it with the supported official client, and pass the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -165,6 +165,10 @@ working user feature.
 [`docs/plans/2.0-preparation-execution-plan.md`](docs/plans/2.0-preparation-execution-plan.md)。
 该计划当前只授权研究和架构准备，不授权production功能或Release。
 
+2.0产品目标扩展为多学校profile：登录页提供reviewed学校preset及`Other`自定义HTTPS
+Gateway。自定义Gateway先进行无凭据兼容性探测和身份确认，再进入profile隔离的账号登录；
+不得通过猜协议并自动提交密码实现“通用兼容”。
+
 The trigger for implementation is evidence that the school has enabled a
 specific capability on a controlled test profile. Work should then cover only
 that capability, compare it with the supported official client, and pass the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -153,27 +153,37 @@ Control v3、synthetic provider和Campus Browser网页MFA安全只证明架构�
 [`docs/architecture/mfa-architecture.md`](docs/architecture/mfa-architecture.md)。在真实证据
 出现前，1.3保持`Deferred / evidence-triggered`，项目不猜测endpoint、验证码形状或渠道映射。
 
-## Future 2.0.0 EasyConnect compatibility contingency plan
+## Campus Connect 2.0 product roadmap
 
-This section is deliberately inactive in the 1.x maintenance line. It records
-what the code can and cannot do today so the school has a reviewed starting
-point if an optional EasyConnect feature is enabled later. It is not a 2.0.0
-release commitment, and none of the Partial entries below is advertised as a
-working user feature.
+The 1.x line remains maintenance-only. 2.0 preparation is now an active,
+incremental product program, but the capability rows below remain evidence
+gated and none of the Partial entries is advertised as a working user feature.
 
 2.0准备阶段的证据、clean-room、架构接缝与分阶段PR计划见
 [`docs/plans/2.0-preparation-execution-plan.md`](docs/plans/2.0-preparation-execution-plan.md)。
 该计划当前只授权研究和架构准备，不授权production功能或Release。
 
-2.0产品目标扩展为多学校profile：登录页提供reviewed学校preset及`Other`自定义HTTPS
-Gateway。自定义Gateway先进行无凭据兼容性探测和身份确认，再进入profile隔离的账号登录；
+2.0产品目标是 **Campus Workspace + Secure Access Runtime**：普通用户从资源搜索、收藏、最近
+访问和通知进入，连接按资源需要自动触发；高级用户展开SSH、代理、转发、Underlay和Headless。
+数据层从一开始区分`SchoolProfile → CampusAccount → WorkspaceScope`。
+
+普通学校选择器只展示reviewed profiles。`Other`自定义HTTPS Gateway放在高级设置，并在第二个
+reviewed school完成后才开放；它仍需无凭据探测、身份确认和独立profile/account workspace，
 不得通过猜协议并自动提交密码实现“通用兼容”。
 
-The trigger for implementation is evidence that the school has enabled a
-specific capability on a controlled test profile. Work should then cover only
-that capability, compare it with the supported official client, and pass the
-promotion checklist below before its evidence level changes or it is marked
-Supported.
+产品、账户和资源定义见
+[`docs/product/2.0-product-definition.md`](docs/product/2.0-product-definition.md)、
+[`docs/adr/0004-profile-account-workspace-scope.md`](docs/adr/0004-profile-account-workspace-scope.md)和
+[`docs/architecture/resource-domain-model.md`](docs/architecture/resource-domain-model.md)。
+
+Profile/account isolation, RoutingPolicyIR and the local Resource Workspace may progress from current-source and
+synthetic evidence without claiming a new Gateway capability. The trigger for each proprietary authentication,
+resource-catalogue or transport capability remains evidence that a controlled school profile enables it. That
+work covers one capability, compares with the supported official client and passes the promotion checklist before
+its evidence level changes or it is marked Supported.
+
+The table below tracks evidence-gated Gateway capabilities; it does not replace the P1–P8 product/foundation
+order in the Revision 4 execution plan.
 
 | Order | Capability | Implementation / evidence | What exists now | Required next evidence/work |
 | ---: | --- | --- | --- | --- |

--- a/docs/adr/0003-multi-school-profile-and-custom-gateway.md
+++ b/docs/adr/0003-multi-school-profile-and-custom-gateway.md
@@ -1,0 +1,455 @@
+# ADR-0003: Multi-school profiles and custom Gateway onboarding
+
+- Status: Proposed for 2.0 preparation
+- Decision owner: project maintainer
+- Production activation: not authorized by this ADR alone
+
+## Context
+
+The current application has one HKUST(GZ) Gateway, account, Engine config, Browser partition, routing store,
+credential vault and branding context. Replacing constants with a text field would create severe confused-deputy
+risks: one school's password, Cookies, certificate pins or routes could be used against another Gateway.
+
+2.0 must allow:
+
+1. a reviewed HKUST(GZ) preset;
+2. future reviewed school presets;
+3. `Other`, where the user enters a Gateway domain/port locally.
+
+Entering a domain must be simple, but it must not cause the application to guess protocol endpoints and submit
+credentials automatically.
+
+## Decision
+
+Adopt one active `SchoolProfile` at a time. Each profile owns an exact `GatewayOrigin`, closed
+`ProtocolFamily`, Browser/routing policy and an isolated data namespace.
+
+### Product identity versus school branding
+
+The application has one stable product identity for executable, updater, safeStorage/Keychain and userData.
+School name/logo/theme are bounded runtime presentation values.
+
+The final neutral product name and app ID migration require a separate branding/OS-identity ADR. Multi-school
+storage migration must not be combined with an app-ID/Keychain identity change.
+
+### SchoolProfile
+
+```text
+SchoolProfileInternal
+  schemaVersion
+  profileId
+  profileRevision
+  evidenceClass: builtin-reviewed | custom-local
+
+  branding
+    localizedSchoolName
+    shortName
+    bundledAssetKey?
+    constrainedTheme?
+
+  gateway
+    GatewayOrigin
+    ProtocolFamily
+    engineConfigRef?
+
+  browser
+    homeUrl?
+    campusDomains[]
+    directPartnerDomains[]
+    builtinResources[]
+    healthTargets[]
+
+  policy
+    reviewedPrivateGatewayAllowed
+    reviewedDnsFallback[]
+
+SchoolProfileView
+  profileId / profileRevision / evidenceClass
+  localizedSchoolName / shortName / bundledAssetKey?
+  normalizedGatewayOrigin
+  sanitizedCompatibility
+```
+
+Profile safety:
+
+- `profileId` is a registry-created ASCII slug or opaque hash, never raw user input;
+- paths, HTML, CSS, JavaScript and arbitrary asset URLs are forbidden;
+- `engineConfigRef` can reference only a packaged manifest entry;
+- profile capability expectations cannot enable unsupported code;
+- no username, password, Cookie, pin or user rule appears in a profile;
+- custom profiles cannot provide private DNS fallback, system mutation or Gateway-driven updates;
+- only `SchoolProfileView` may cross into a Renderer. Engine config references, private DNS, health targets and
+  internal policy remain in Main/Rust;
+- a `custom-local` profile always carries a visible **Unverified custom Gateway** badge. A user label cannot
+  claim reviewed/official status or select a school logo.
+
+### GatewayOrigin
+
+```text
+GatewayOrigin
+  scheme = https
+  normalized ASCII hostname or explicitly reviewed IP literal
+  explicit/default port
+  root path only
+  no username/password/query/fragment
+```
+
+Default destination policy rejects loopback, link-local, multicast and unspecified targets. A reviewed built-in
+profile may explicitly allow a private Gateway. A local custom profile does not receive that exception by
+default.
+
+`GatewayOrigin` and `ProtocolFamily` are immutable after profile creation. Entering a different origin/port or
+choosing another family creates a new random/opaque profile ID and a new data namespace; it never mutates or
+copies the old profile. This makes credential re-consent structural rather than a best-effort flag.
+
+The first family accepts only an HTTPS origin at `/`. A Gateway deployed under a URL path is reported as
+unsupported until a separately reviewed protocol variant defines path joining, redirect and origin-binding
+semantics. The UI accepts only `host[:port]`, not a URL path.
+
+### ProtocolFamily
+
+Profiles select only closed compiled variants, beginning with:
+
+```text
+easyconnect-password-modern-l3-v1
+```
+
+Future variants are added only with provider/backend code and evidence. A JSON string cannot dynamically load
+a Rust provider, endpoint script or plugin.
+
+### PublicProbeSpec
+
+Gateway discovery has a closed compiled request contract; it is not inferred from user input or profile JSON:
+
+```text
+PublicProbeSpec
+  probeFamilyId
+  exact root-bound relative path
+  method = GET | HEAD
+  fixed non-secret headers
+  redirect = deny
+  cookieStore = none
+  status/contentType/bodySize/deadline bounds
+  sanitized response classifier
+  maximum candidate attempts
+```
+
+The first release compiles exactly one reviewed EasyConnect public probe spec. Custom/profile data cannot provide
+its path, method, headers, parser or candidate list. Future families add a separately reviewed compiled spec and
+synthetic fixture. A probe result identifies only a candidate public authentication surface; the
+`ProtocolFamily` factory independently constructs credential-bearing endpoints after confirmation.
+
+## Custom Gateway onboarding
+
+Proposed login surface:
+
+```text
+Campus Connect
+
+School / Organization   [ HKUST(GZ) ▾ ]
+
+When Other is selected:
+School label (optional) [________________]
+Gateway domain / port   [vpn.example.edu:443]
+                        [Check compatibility]
+
+Compatibility
+  HTTPS identity: valid / invalid
+  Public auth surface: recognized candidate / unsupported / unknown
+  Tunnel capability: requires authenticated runtime confirmation
+  Reported version: sanitized value
+
+                        [Confirm this Gateway]
+
+Account                 [________________]
+Password                [________________]
+                        [Connect]
+```
+
+Credential fields remain hidden/disabled until compatibility and explicit Gateway confirmation succeed.
+
+The `Other` flow is:
+
+```text
+enter school label (optional) + Gateway domain/port
+  → canonicalize HTTPS GatewayOrigin
+  → credential-free bounded GatewayProbeDialer
+  → resolve and validate every bounded CNAME/A/AAAA answer
+  → bind the socket to one validated address while retaining hostname SNI/PKI
+  → verify the connected peer address equals the pinned address
+  → standard PKI/hostname verification
+  → no redirect / no environment proxy / bounded body and timeout
+  → classify only a recognized public authentication surface
+  → destroy the one-shot probe client and all probe Cookies
+  → show normalized origin, reported version and candidate family
+  → explicit user confirmation
+  → consume a Main-owned confirmation nonce
+  → create a custom-local profile with a new opaque ID and isolated stores
+  → only then show username/password
+```
+
+Rules:
+
+- no password is sent during discovery;
+- no automatic trial of multiple credential-bearing providers;
+- unknown/aTrust-only/new protocol returns a sanitized compatibility report and remains unsupported;
+- certificate failure is not bypassed; a Browser certificate pin cannot authorize Gateway TLS;
+- discovery output never contains raw response bodies, Cookies, tokens or internal resource targets;
+- a failed probe can be saved only as an inactive local draft without credentials or auto-connect;
+- the probe uses a fresh client with Cookie persistence disabled. Its socket, resolver result, response buffer
+  and any `Set-Cookie` state are destroyed and never promoted into `GatewaySession`;
+- every bounded CNAME hop and all resolved IPv4/IPv6 answers must pass the destination policy. Mixed
+  public/private answers, loopback, link-local, multicast, unspecified and IPv4-mapped unsafe addresses fail
+  closed; the connector uses the validated address directly and verifies the actual peer address matches it;
+- every credential-bearing Gateway connection resolves through the same reviewed dial boundary again. DNS
+  rebinding after confirmation cannot turn a public custom Gateway into a private/local destination;
+- public discovery proves only a candidate authentication surface. It cannot claim Modern L3, WebVPN, campus
+  DNS or resource availability; those remain unknown until an authenticated runtime `CapabilitySnapshot`;
+- Main returns a one-use, short-lived `GatewayConfirmation` bound to nonce + exact origin + candidate family +
+  draft opaque profile identity + probe time. Editing any field, expiry, replay, Renderer restart or
+  profile-switch invalidates it;
+- profile creation consumes that exact confirmation. The Renderer cannot authorize a different origin with a
+  previously displayed success boolean.
+
+This preserves the requested “Other → enter domain” experience without turning the login page into an SSRF or
+credential-forwarding oracle.
+
+### Credential-bearing launch boundary
+
+Before reading or decrypting a VPN credential, Main must complete this exact order:
+
+```text
+snapshot active profile + profile epoch
+  → registry lookup and schema/hash validation
+  → canonical GatewayOrigin and destination policy
+  → closed ProtocolFamily factory selection
+  → build/validate Engine launch config
+  → prove config origin/family/profile revision matches the credential binding
+  → revalidate custom Gateway address policy
+  → only now decrypt the bound credential
+  → synchronously spawn the matching Engine generation
+```
+
+Custom profiles cannot provide arbitrary endpoint JSON. The compiled `ProtocolFamily` factory constructs an
+owner-only Engine config from the confirmed origin and one reviewed fixed endpoint template. The config is
+bounded, fsynced and bound to profile ID/revision; a mismatch fails before credential decryption. Custom
+profiles receive no reviewed static DNS fallback, routes, resources, updater or system mutation. Authenticated
+Gateway-provided DNS may be accepted only through the selected provider's existing verified parser/policy.
+
+Every outer Gateway socket used by a custom profile—discovery, authentication, configuration, authenticated
+resource retrieval, logout, session keepalive/update, token, address-control, send and receive—must use the same
+`GatewayConnectorGeneration`. Any authenticated server-provided outer endpoint is canonicalized and passes the
+same public-address/peer-binding policy before a socket is opened. A custom profile cannot use server
+configuration to expand the outer underlay to a private or local destination. Campus/private destinations
+carried *inside* the authenticated L3 tunnel are a separate policy domain and are not rejected by this
+outer-Gateway rule.
+
+## ProfileRegistry
+
+Initial registry is packaged and read-only:
+
+```text
+profiles/
+  manifest.json
+  hkustgz/
+    school-profile.json
+    engine-config.json
+    branding assets
+```
+
+Custom profiles are local user records and do not become trusted presets. Community submissions require code
+review and school-specific evidence before entering the packaged registry.
+
+The registry merges packaged reviewed profiles with owner-only local custom records, but never upgrades a local
+record's `custom-local` evidence class. Custom profile IDs are random opaque values; `custom-local` is a trust
+class, not a shared profile ID.
+
+A future online registry requires a separate ADR covering detached signatures, pinned signing key, expiry,
+rollback protection, origin-change re-consent and offline packaged fallback.
+
+## Data isolation
+
+```text
+userData/
+  global/
+    settings.json
+    proxy-credential.bin
+    proxy-helper-credential.txt
+    engine-owner.json
+    update-state.json
+
+  profiles/<opaqueProfileKey>/
+    settings.json
+    vpn-credentials.bin
+    credential-transaction.json
+    campus-credentials.json
+    campus-certificate-trust.json
+    routing-rules.json
+    routing.pac
+    browser-routing.pac
+    engine.log
+```
+
+VPN credentials bind to:
+
+```text
+profileId + GatewayOrigin + ProtocolFamily + opaque accountId
+```
+
+Website credentials and certificate pins bind to profile plus exact HTTPS origin. Server resources bind to
+profile, authenticated-session generation and catalogue revision/expiry.
+
+Only one profile/Engine may be active in the first multi-school release.
+
+`SchoolProfileInternal` is never serialized wholesale to UI state or logs. Renderer state uses
+`SchoolProfileView`; default diagnostics use only an opaque profile correlation ID, evidence class, protocol
+family and stable error code. Gateway hostnames, private DNS and health targets do not enter default logs.
+
+## Browser partition
+
+Each profile owns a persistent partition derived from a bounded opaque key. Raw profile IDs are not placed in
+partition paths.
+
+HKUST retains the existing `persist:hkustgz-campus-browser` partition as a compatibility alias, preserving
+Cookies/localStorage/SSO without copying Browser data. New profiles never see this partition.
+
+Within one profile, Campus and Direct continue to share one partition for Cookie/POST/SAML continuity. Across
+profiles, Cookies, storage, password vault and certificate trust are strictly isolated.
+
+## Active profile switch transaction
+
+```text
+increment profile epoch
+  → close Browser request gate
+  → cancel auth/certificate/credential/navigation continuations
+  → close old profile tabs/views/connections
+  → stop old Engine and confirm cleanup
+  → destroy proxy sidecar/generation secrets
+  → clear old server resources/notices
+  → activate new profile stores/routing/branding/partition
+  → optionally connect new profile
+```
+
+Every continuation binds connection intent + profile epoch + Engine generation. Old Engine closes, health
+probes, retries, route transactions and MFA responses cannot affect the new profile.
+
+If old Engine cleanup is unconfirmed, switching fails closed and no new Engine starts on the same port.
+
+Profile activation is also a persistent transaction. Its owner-only switch journal records old/new opaque
+profile IDs and revisions, the stop result, store-validation result and final commit marker. `activeProfileId`
+is committed only after old Engine cleanup is confirmed and every new store/config/partition reference is
+validated. A crash recovery chooses a proven all-old or all-new active context; uncertainty starts with no
+active Engine and requires user recovery. An in-memory profile epoch alone is never crash authority.
+
+If cleanup fails after the epoch advances, the old Browser remains gated and the new profile is not activated.
+The coordinator does not decrement the epoch or silently resume the old profile; the user may retry cleanup or
+quit.
+
+## Legacy HKUST migration
+
+The first migration creates a built-in `hkustgz` profile while preserving current behavior and data.
+
+Order:
+
+1. finish existing credential/settings journal recovery;
+2. create a new migration journal with old/new paths and digests;
+3. write global and HKUST profile settings;
+4. decrypt old VPN credential only in memory and re-encrypt into the profile vault;
+5. move routing, website passwords, certificate trust and custom resources into HKUST only;
+6. retain the legacy Browser partition alias;
+7. fsync and commit the migration marker;
+8. retain the old encrypted VPN credential for exactly one release as the sole legacy rollback secret; mark it
+   imported so the new path cannot import it twice;
+9. durably retire the old certificate trust file and backup, routing rules/PAC and website-credential vault at
+   commit. These authorization/secret stores are never rollback sources;
+10. keep only non-authorizing legacy settings/resources as one-release rollback input, then remove them with
+    the retained encrypted VPN credential in a later version.
+
+Migration is idempotent and fault-injected. It must never create a username/password mismatch, lose a proven
+credential, restore a revoked certificate pin or copy HKUST data into every profile.
+
+The rollback strategy is therefore singular: before the migration commit, recovery restores the complete old
+layout; after commit, the new HKUST profile is authoritative. A one-release legacy adapter may use only the
+retained encrypted VPN credential and existing HKUST Browser partition. It does not restore old certificate
+pins, direct-route grants or website credentials. Losing a historical authorization grant is safer than
+resurrecting one the user revoked. "All-old/all-new" is evaluated after journal recovery, not between individual
+filesystem renames.
+
+The retained VPN blob has an owner-only `LegacyCredentialRollbackState` of `active | retired`, bound to exact
+`hkustgz` profile ID, original Gateway origin, initial protocol family and credential digest. It is never an
+ordinary auto-connect fallback. Only an explicit one-release rollback adapter may read it while state is
+`active` and every binding still matches.
+
+The first successful password replacement, logout/credential-clear, account removal or HKUST profile reset must
+durably retire the legacy state and unlink/fsync the old blob before reporting that credential mutation as
+successful. Retirement failure fails the mutation; it cannot leave a UI-success/new-vault state with a reusable
+legacy password. Crash tests cover pre-retire, unlink/fsync failure, new-vault commit, concurrent logout and
+repeated restart. Any still-active rollback blob is unconditionally retired at the documented one-release
+deadline.
+
+## Custom profile homepage, health and deletion
+
+A custom profile starts with no proactive school-controlled request fields: no homepage URL, builtin resource,
+direct-partner rule, health target or static DNS fallback. New tabs show an app-owned neutral start page until
+the user locally adds a resource. The existing HKUST homepage and health targets are never inherited.
+
+With no reviewed health targets, site-based health rounds are disabled. Engine-native data-plane/lifecycle
+health remains authoritative; the application never substitutes an arbitrary public hostname. User-added
+resources do not automatically become health targets.
+
+GatewayOrigin/ProtocolFamily edits create a new profile, but users may delete an inactive custom profile. A
+delete transaction must reject the active/builtin profile, close and clear its Electron partition, delete VPN
+and website credentials, pins, rules, PACs, resources and logs, fsync the namespace removal, and remove the
+registry record last. Failure leaves an inactive non-auto-connect tombstone for retry; it never leaves a
+partially deleted profile eligible for connection.
+
+Custom profiles never own a legacy rollback credential. The built-in HKUST profile cannot enter this delete API;
+its retained one-release blob is governed only by `LegacyCredentialRollbackState`. If Chromium partition cleanup
+fails, the custom profile registry record remains as an inactive tombstone and cannot be removed or connected.
+
+## Alternatives
+
+| Alternative | Decision |
+| --- | --- |
+| Replace HKUST constants with one editable server field | Rejected: no credential/Browser/routing isolation |
+| Automatically guess protocols by submitting the password | Rejected: credential forwarding and lockout risk |
+| One Browser partition for all schools | Rejected: Cookie/site-password/pin cross-profile leak |
+| One app build/app ID per school | Rejected as default: fragments updates, Keychain and maintenance |
+| Signed remote profile marketplace immediately | Deferred until packaged profiles and migration are stable |
+| Multiple simultaneous school tunnels | Deferred; first release permits one active profile |
+
+## Security and privacy
+
+- exact Gateway origin is shown before credential entry;
+- standard PKI is mandatory;
+- profile branding cannot inject executable content;
+- custom profile defaults are minimal/fail-closed;
+- secret and route files remain owner-only/ACL protected;
+- only opaque profile correlation, evidence class, protocol family and stable error code enter default logs;
+  Gateway hostname, full URL/query and credentials do not;
+- compatibility reports are sanitized and user-reviewed before sharing.
+
+## Rollback
+
+Profile foundation ships behind one HKUST-compatible registry entry first. Before migration commit, journal
+recovery restores the legacy layout. After commit, the new HKUST profile is authoritative; a one-release legacy
+adapter may use only the retained encrypted VPN credential and Browser partition, never retired pins/rules/site
+credentials. Rollback never submits a credential to a changed Gateway or merges profile namespaces.
+
+## Evidence and acceptance
+
+Before adding a second real school:
+
+- two synthetic profiles prove password/Cookie/pin/rule/resource/event isolation;
+- 100 profile switches leave no PID/port/timer/view/credential residue;
+- every migration write/fsync/rename failure yields all-old or all-new state;
+- legacy credential retirement is coupled to logout/password replacement/account clear and never reappears on
+  restart or ordinary auto-connect;
+- HKUST password/Modern L3/Campus Browser behavior remains unchanged;
+- custom Gateway probe sends no credentials and rejects invalid TLS/origin/protocol;
+- custom discovery/auth rejects rebinding, mixed/unsafe answers and confirmation replay; probe Cookies are never
+  observed in authentication;
+- public probe never advertises L3/DNS/resource support before authenticated runtime confirmation;
+- no custom new-tab or health request reaches HKUST or an arbitrary public hostname by default;
+- three-platform package verifier validates the exact profile manifest;
+- the new school completes official parity and staff canary.

--- a/docs/adr/0003-multi-school-profile-and-custom-gateway.md
+++ b/docs/adr/0003-multi-school-profile-and-custom-gateway.md
@@ -14,7 +14,11 @@ risks: one school's password, Cookies, certificate pins or routes could be used 
 
 1. a reviewed HKUST(GZ) preset;
 2. future reviewed school presets;
-3. `Other`, where the user enters a Gateway domain/port locally.
+3. later, an Advanced `Other` flow where the user enters a Gateway domain/port locally.
+
+The ordinary selector initially shows reviewed profiles only. The P5 connector foundation is implemented first,
+a second reviewed school proves profile/account isolation in P10, and only P11 may expose `Other` as experimental
+and unverified.
 
 Entering a domain must be simple, but it must not cause the application to guess protocol endpoints and submit
 credentials automatically.
@@ -23,6 +27,10 @@ credentials automatically.
 
 Adopt one active `SchoolProfile` at a time. Each profile owns an exact `GatewayOrigin`, closed
 `ProtocolFamily`, Browser/routing policy and an isolated data namespace.
+
+User identity and Browser/workspace data are further scoped by `CampusAccount` and `WorkspaceScope` under
+[`ADR-0004`](0004-profile-account-workspace-scope.md). This ADR owns deployment/Gateway trust; ADR-0004 owns
+same-school account separation.
 
 ### Product identity versus school branding
 
@@ -134,17 +142,17 @@ PublicProbeSpec
   maximum candidate attempts
 ```
 
-The first release compiles exactly one reviewed EasyConnect public probe spec. Custom/profile data cannot provide
+P11 compiles exactly one reviewed EasyConnect public probe spec. Custom/profile data cannot provide
 its path, method, headers, parser or candidate list. Future families add a separately reviewed compiled spec and
 synthetic fixture. A probe result identifies only a candidate public authentication surface; the
 `ProtocolFamily` factory independently constructs credential-bearing endpoints after confirmation.
 
-## Custom Gateway onboarding
+## Advanced custom Gateway onboarding (P11)
 
 Proposed login surface:
 
 ```text
-Campus Connect
+Campus Connect · Advanced settings
 
 School / Organization   [ HKUST(GZ) ▾ ]
 
@@ -184,7 +192,7 @@ enter school label (optional) + Gateway domain/port
   → show normalized origin, reported version and candidate family
   → explicit user confirmation
   → consume a Main-owned confirmation nonce
-  → create a custom-local profile with a new opaque ID and isolated stores
+  → create a custom-local profile + primary account workspace with new opaque IDs and isolated stores
   → only then show username/password
 ```
 
@@ -219,12 +227,12 @@ credential-forwarding oracle.
 Before reading or decrypting a VPN credential, Main must complete this exact order:
 
 ```text
-snapshot active profile + profile epoch
+snapshot active profile/account + active-context epoch
   → registry lookup and schema/hash validation
   → canonical GatewayOrigin and destination policy
   → closed ProtocolFamily factory selection
   → build/validate Engine launch config
-  → prove config origin/family/profile revision matches the credential binding
+  → prove config origin/family/profile/account credential revisions match the credential binding
   → revalidate custom Gateway address policy
   → only now decrypt the bound credential
   → synchronously spawn the matching Engine generation
@@ -279,27 +287,38 @@ userData/
     update-state.json
 
   profiles/<opaqueProfileKey>/
-    settings.json
-    vpn-credentials.bin
-    credential-transaction.json
-    campus-credentials.json
-    campus-certificate-trust.json
-    routing-rules.json
-    routing.pac
-    browser-routing.pac
-    engine.log
+    profile-settings.json
+    profile-state.json
+    accounts/<opaqueAccountKey>/
+      account.json
+      vpn-credential.bin
+      credential-transaction.json
+      deletion-tombstone.json?
+      workspace/
+        workspace-state.json
+        campus-credentials.json
+        campus-certificate-trust.json
+        local-resources.json
+        favorites.json
+        recent-resources.json
+        routing-rules.json
+        routing.pac
+        browser-routing.pac
+        engine.log
 ```
 
 VPN credentials bind to:
 
 ```text
-profileId + GatewayOrigin + ProtocolFamily + opaque accountId
+profileId + profileCredentialBindingRevision + GatewayOrigin + ProtocolFamily
++ opaque accountKey + accountCredentialRevision
 ```
 
-Website credentials and certificate pins bind to profile plus exact HTTPS origin. Server resources bind to
-profile, authenticated-session generation and catalogue revision/expiry.
+Website credentials and certificate pins bind to profile + account + exact HTTPS origin. Server resources bind
+to profile and authenticated-session generation; user views/favorites/recent bind to account workspace.
 
-Only one profile/Engine may be active in the first multi-school release.
+Only one profile/account/Engine may be active in the first multi-school release. Account/workspace storage and
+switching follow ADR-0004.
 
 `SchoolProfileInternal` is never serialized wholesale to UI state or logs. Renderer state uses
 `SchoolProfileView`; default diagnostics use only an opaque profile correlation ID, evidence class, protocol
@@ -307,39 +326,40 @@ family and stable error code. Gateway hostnames, private DNS and health targets 
 
 ## Browser partition
 
-Each profile owns a persistent partition derived from a bounded opaque key. Raw profile IDs are not placed in
-partition paths.
+Each account workspace owns a persistent partition derived from bounded opaque profile/account keys. Raw IDs are
+not placed in partition paths.
 
-HKUST retains the existing `persist:hkustgz-campus-browser` partition as a compatibility alias, preserving
-Cookies/localStorage/SSO without copying Browser data. New profiles never see this partition.
+HKUST `primary` retains the existing `persist:hkustgz-campus-browser` partition as a compatibility alias,
+preserving Cookies/localStorage/SSO without copying Browser data. No other profile/account sees this partition.
 
-Within one profile, Campus and Direct continue to share one partition for Cookie/POST/SAML continuity. Across
-profiles, Cookies, storage, password vault and certificate trust are strictly isolated.
+Within one account workspace, Campus and Direct continue to share one partition for Cookie/POST/SAML continuity.
+Across profiles or accounts, Cookies, storage, password vault and certificate trust are strictly isolated.
 
-## Active profile switch transaction
+## Active context switch transaction
 
 ```text
-increment profile epoch
+increment active context epoch
   → close Browser request gate
   → cancel auth/certificate/credential/navigation continuations
-  → close old profile tabs/views/connections
+  → close old account workspace tabs/views/connections
   → stop old Engine and confirm cleanup
   → destroy proxy sidecar/generation secrets
-  → clear old server resources/notices
-  → activate new profile stores/routing/branding/partition
-  → optionally connect new profile
+  → clear old account server resources/notices
+  → validate destination profile + primary account + workspace
+  → atomically commit exact profile/account pair
+  → optionally connect the destination account
 ```
 
-Every continuation binds connection intent + profile epoch + Engine generation. Old Engine closes, health
-probes, retries, route transactions and MFA responses cannot affect the new profile.
+Every continuation binds connection intent + active-context epoch + Engine generation and is checked against the
+exact profile/account pair. Old Engine closes, health probes, retries, route transactions and MFA responses
+cannot affect the new context.
 
 If old Engine cleanup is unconfirmed, switching fails closed and no new Engine starts on the same port.
 
-Profile activation is also a persistent transaction. Its owner-only switch journal records old/new opaque
-profile IDs and revisions, the stop result, store-validation result and final commit marker. `activeProfileId`
-is committed only after old Engine cleanup is confirmed and every new store/config/partition reference is
-validated. A crash recovery chooses a proven all-old or all-new active context; uncertainty starts with no
-active Engine and requires user recovery. An in-memory profile epoch alone is never crash authority.
+Activation uses ADR-0004's owner-only switch journal. It records old/new opaque profile and account identities,
+revisions/epochs, stop result, store validation and final commit marker. Active profile and account become
+authoritative together only after cleanup and destination validation. Crash uncertainty starts no Engine or
+Browser workspace; an in-memory profile/account epoch is never crash authority.
 
 If cleanup fails after the epoch advances, the old Browser remains gated and the new profile is not activated.
 The coordinator does not decrement the epoch or silently resume the old profile; the user may retry cleanup or
@@ -347,16 +367,17 @@ quit.
 
 ## Legacy HKUST migration
 
-The first migration creates a built-in `hkustgz` profile while preserving current behavior and data.
+The first migration creates built-in `hkustgz` plus its `primary` account/workspace while preserving current
+behavior and data. ADR-0004 is authoritative for account paths and credential envelopes.
 
 Order:
 
 1. finish existing credential/settings journal recovery;
 2. create a new migration journal with old/new paths and digests;
-3. write global and HKUST profile settings;
-4. decrypt old VPN credential only in memory and re-encrypt into the profile vault;
-5. move routing, website passwords, certificate trust and custom resources into HKUST only;
-6. retain the legacy Browser partition alias;
+3. write global settings, HKUST profile metadata and the primary account reference;
+4. decrypt old VPN credential only in memory and re-encrypt into the primary account envelope;
+5. move routing, website passwords, certificate trust and custom resources into the primary workspace;
+6. retain the legacy Browser partition alias for that primary workspace only;
 7. fsync and commit the migration marker;
 8. retain the old encrypted VPN credential for exactly one release as the sole legacy rollback secret; mark it
    imported so the new path cannot import it twice;
@@ -376,7 +397,8 @@ resurrecting one the user revoked. "All-old/all-new" is evaluated after journal 
 filesystem renames.
 
 The retained VPN blob has an owner-only `LegacyCredentialRollbackState` of `active | retired`, bound to exact
-`hkustgz` profile ID, original Gateway origin, initial protocol family and credential digest. It is never an
+`hkustgz` profile ID, migrated primary account key, original Gateway origin, initial protocol family and
+credential digest. It is never an
 ordinary auto-connect fallback. Only an explicit one-release rollback adapter may read it while state is
 `active` and every binding still matches.
 
@@ -438,18 +460,22 @@ credentials. Rollback never submits a credential to a changed Gateway or merges 
 
 ## Evidence and acceptance
 
-Before adding a second real school:
+Before adding a second reviewed school:
 
-- two synthetic profiles prove password/Cookie/pin/rule/resource/event isolation;
-- 100 profile switches leave no PID/port/timer/view/credential residue;
+- two profiles × two accounts prove password/Cookie/pin/rule/resource/event isolation;
+- 100 profile/account switches leave no PID/port/timer/view/credential residue;
 - every migration write/fsync/rename failure yields all-old or all-new state;
 - legacy credential retirement is coupled to logout/password replacement/account clear and never reappears on
   restart or ordinary auto-connect;
 - HKUST password/Modern L3/Campus Browser behavior remains unchanged;
+- three-platform package verifier validates the exact profile manifest;
+- the new school completes official parity and staff canary.
+
+Before P11 exposes Advanced custom onboarding:
+
+- the second reviewed school has passed the preceding gate;
 - custom Gateway probe sends no credentials and rejects invalid TLS/origin/protocol;
 - custom discovery/auth rejects rebinding, mixed/unsafe answers and confirmation replay; probe Cookies are never
   observed in authentication;
 - public probe never advertises L3/DNS/resource support before authenticated runtime confirmation;
-- no custom new-tab or health request reaches HKUST or an arbitrary public hostname by default;
-- three-platform package verifier validates the exact profile manifest;
-- the new school completes official parity and staff canary.
+- no custom new-tab or health request reaches a reviewed school or arbitrary public hostname by default.

--- a/docs/adr/0004-profile-account-workspace-scope.md
+++ b/docs/adr/0004-profile-account-workspace-scope.md
@@ -1,0 +1,530 @@
+# ADR-0004: School profile, campus account and workspace scope
+
+- Status: Proposed for 2.0 preparation
+- Decision owner: project maintainer
+- Production activation: not authorized by this ADR alone
+- Parent decision: [`ADR-0003`](0003-multi-school-profile-and-custom-gateway.md)
+
+## Context
+
+ADR-0003 establishes one active school profile at a time and requires profile-scoped credentials, Browser
+state, certificate decisions and routing. That is sufficient to prevent one school's state from entering
+another school, but it does not permanently separate deployment identity from user identity.
+
+One school or Gateway may legitimately be used with more than one identity: student and staff accounts, a
+maintainer test account, a replacement account, or different users of one computer. If mutable user state is
+written directly under `profiles/<profileKey>/`, adding a second account later would require another high-risk
+credential, Chromium partition, certificate and routing migration.
+
+The current 1.x implementation is entirely flat:
+
+| Current owner | Current path/module | Current content |
+| --- | --- | --- |
+| app | `desktop/main.js` userData constants | one settings, credential, PAC, log and owner set |
+| settings | `desktop/lib/settings-store.js` | username, connection policy, route domains and custom resources |
+| VPN credential | `desktop/lib/credential-store.js` | one encrypted password blob |
+| Browser | `desktop/lib/browser-session-manager.js` | one fixed persistent Campus partition |
+| site credentials | `desktop/lib/campus-credential-vault.js` | one encrypted exact-origin vault |
+| certificate trust | `desktop/lib/campus-certificate-trust.js` | one exact-origin/fingerprint grant set |
+| routing | `desktop/lib/routing-rule-store.js` | one user rule document |
+| resources | `desktop/lib/campus-resources.js` | reviewed builtins plus one custom-resource list |
+
+The initial 2.0 UI still needs only one primary account per profile. The on-disk and lifecycle boundary must,
+however, be account-ready from the first P3 migration.
+
+## Decision
+
+Adopt three distinct domains:
+
+```text
+SchoolProfile
+  └── CampusAccount
+        └── WorkspaceScope
+```
+
+The first implementation permits exactly one enabled `primary` account for each profile. It nevertheless uses
+opaque account and workspace keys and stores account-owned state below:
+
+```text
+profiles/<profileKey>/accounts/<accountKey>/
+```
+
+This ADR is a compatible refinement of ADR-0003. It does not weaken profile isolation, immutable
+`GatewayOrigin`/`ProtocolFamily`, custom-Gateway confirmation, or the single-active-Engine decision. The
+profile-level layout in ADR-0003 remains valid for deployment-owned data; this ADR is authoritative for every
+account-owned leaf before P3 is implemented.
+
+## Domain model
+
+### SchoolProfile
+
+`SchoolProfile` describes a reviewed or custom-local deployment. It owns no user identity or user grant.
+
+```text
+SchoolProfileInternal
+  profileId / opaque profileKey / profileRevision
+  profileCredentialBindingRevision
+  evidenceClass
+  immutable GatewayOrigin
+  immutable ProtocolFamily
+  provider/config references
+  reviewed branding, DNS and Browser defaults
+  builtin resource descriptors
+
+SchoolProfileView
+  profileId / profileRevision / evidenceClass
+  bounded display name and asset key
+  normalized Gateway origin for explicit display
+  sanitized compatibility
+```
+
+Changing origin or protocol creates a new profile and copies no account or workspace. ADR-0003 remains the
+authority for profile registry trust and safe custom-Gateway onboarding.
+
+### CampusAccount
+
+`CampusAccount` is a local identity slot bound to exactly one immutable profile deployment.
+
+```text
+CampusAccountInternal
+  schemaVersion
+  accountKey                 opaque random key; never username-derived
+  accountRevision
+  accountCredentialRevision
+  role = primary             first release only
+  state = enabled | disabled | deleting | tombstoned
+  profileId / profileRevision
+  GatewayOrigin binding
+  ProtocolFamily binding
+  workspaceKey               opaque random key
+  activeCredentialVersion?
+  createdAt / updatedAt
+
+CampusAccountView
+  accountHandle              short-lived Main-issued UI correlation
+  role
+  state
+  bounded user-chosen label?
+  hasCredential
+  isActive
+```
+
+`accountKey` and `workspaceKey` remain persistent filesystem/store owners and never cross to Renderer.
+`accountHandle` is non-persistent, sender + active-context-bound and invalidated whenever the Renderer, profile
+or account context changes. Main resolves and revalidates it; it is never accepted as a path component.
+
+The username is an authentication identifier and is stored inside the encrypted VPN credential envelope, not
+in plaintext account metadata, logs or ordinary Renderer state. A user-chosen account label is optional,
+bounded plain text and never used as a credential or filesystem key. Renderer views do not expose the raw
+username by default; the login/edit flow may hold it only for the explicit credential operation.
+
+The first release enforces:
+
+- at most one enabled account per profile;
+- that account has role `primary`;
+- no add-account or account-switch UI;
+- profile activation selects its primary account or remains disconnected when none is usable.
+
+These constraints are product policy, not storage assumptions. Future multiple-account support can relax them
+without moving state.
+
+### VPN credential envelope
+
+Username and password commit as one encrypted object:
+
+```text
+VpnCredentialEnvelope
+  schemaVersion
+  profileId / profileCredentialBindingRevision
+  accountKey / accountCredentialRevision
+  exact GatewayOrigin
+  exact ProtocolFamily
+  credentialVersion
+  username
+  password
+  updatedAt
+```
+
+The envelope has no `Debug`/diagnostic representation containing username or password. Main validates active
+profile, account, origin, family, config digest and epochs before secure-store decryption, following ADR-0003's
+credential-bearing launch order. Username and password are never committed independently. A failure cannot
+produce an account label/username paired with another credential.
+
+The credential-binding revisions change only when a security identity boundary changes: Gateway origin,
+ProtocolFamily, account credential identity or an explicit credential reset. Branding, builtin-resource,
+favorite/recent and ordinary account-metadata revisions do not invalidate a valid credential.
+
+ADR-0003's `LegacyCredentialRollbackState` remains profile- and account-binding authority for the one-release
+HKUST rollback blob. The migrated blob binds to the newly created HKUST primary `accountKey`; password
+replacement, logout/credential clear, account removal or profile reset retires it before success.
+
+### WorkspaceScope
+
+`WorkspaceScope` owns mutable user experience and authorization state for one `CampusAccount`.
+
+```text
+WorkspaceScope
+  profileId / profileRevision
+  accountKey / accountRevision
+  workspaceKey
+  activeContextEpoch
+
+  Browser partition
+  website credential vault
+  certificate trust grants
+  favorites
+  recent resources
+  local resource descriptors
+  user routing rules and PACs
+  authenticated/server resource projection
+  active Gateway session and notices
+  account-scoped diagnostics
+```
+
+Reviewed builtin resources and deployment DNS/default policy remain profile-owned. The account workspace owns
+favorites, recent entries, locally added resources, user route overrides and authenticated server resources,
+because their visibility or authorization may differ by account.
+
+Favorites and recent history store opaque resource handles plus bounded display timestamps, not full Browser
+navigation history. An arbitrary recent URL is reduced to a reviewed/local resource handle or a sanitized HTTPS
+origin with no query, fragment, SAML assertion, OAuth code or other one-time material.
+
+## Persistent layout
+
+```text
+userData/
+  global/
+    settings.json
+    proxy-credential.bin
+    proxy-helper-credential.txt
+    engine-owner.json
+    update-state.json
+    active-context-switch.json?
+
+  profiles/<profileKey>/
+    profile-settings.json
+    profile-state.json
+    accounts/
+      <accountKey>/
+        account.json
+        vpn-credential.bin
+        credential-transaction.json
+        deletion-tombstone.json?
+        workspace/
+          workspace-state.json
+          campus-credentials.json
+          campus-certificate-trust.json
+          routing-rules.json
+          routing.pac
+          browser-routing.pac
+          local-resources.json
+          favorites.json
+          recent-resources.json
+          engine.log
+```
+
+`profileKey`, `accountKey` and `workspaceKey` are registry/generated bounded opaque values. Raw profile IDs,
+Gateway hosts, usernames and labels are never path components. All directories/files retain current no-follow,
+single-link, owner-only or Windows current-user ACL requirements.
+
+App-global local proxy credentials remain global because they authorize the one active loopback listener, not a
+school identity. Their plaintext sidecar remains short-lived and is destroyed on any profile/account/context
+transition. The sidecar and Engine owner record bind the current active-context epoch and Engine generation.
+
+## Browser partition and local website state
+
+Each account owns one persistent Browser partition derived from its opaque `workspaceKey`, for example:
+
+```text
+persist:campus-workspace-<bounded opaque digest>
+```
+
+The partition name is deterministic for that workspace but cannot disclose a username or accept raw path data.
+Campus and Direct continue to share the account's one partition, preserving same-account Cookie, POST and SAML
+continuity. Different accounts under the same school do not share Cookies, localStorage, IndexedDB, cache,
+downloads state, service workers or permission state.
+
+The existing `persist:hkustgz-campus-browser` partition is adopted only by the migrated HKUST primary account.
+It is never opened by another profile/account and is not copied.
+
+Website credentials and certificate grants are additionally account-scoped even though each entry remains
+exact-origin bounded. A pin or saved website password confirmed by account A cannot authorize or autofill the
+same origin in account B.
+
+## Active context and lifecycle
+
+The runtime authority is an active context, not a profile alone:
+
+```text
+ActiveContext
+  profileKey / profileRevision
+  accountKey / accountRevision
+  workspaceKey
+  profileEpoch
+  accountEpoch
+  activeContextEpoch
+  connectionIntent
+  Engine generation?
+```
+
+Every asynchronous continuation that can mutate state binds the required current context, including:
+
+- Engine output/close and retry;
+- connectivity and health recovery;
+- AuthTransaction respond/resend/cancel;
+- resource catalogue and session notice refresh;
+- routing/PAC transactions;
+- Browser navigation, popup, credential candidate and certificate prompt;
+- download completion/error presentation;
+- telemetry and log notification.
+
+A single monotonic `activeContextEpoch` may be the implementation correlation, provided tests prove it changes
+for every profile or account transition and the profile/account identities are still checked at persistence and
+credential boundaries.
+
+### Profile switch
+
+A profile switch selects the destination profile's primary account and uses ADR-0003's persistent switch
+journal. It closes/gates the old account workspace, cancels all continuations, confirms old Engine cleanup,
+destroys generation credentials, validates the destination account stores/partition, then commits the new
+`profileKey + accountKey` pair. Missing, disabled, deleting or corrupt primary account state leaves the new
+profile selected but disconnected and does not decrypt a credential.
+
+### Account switch
+
+Multiple-account switching is disabled in the first release. The coordinator contract is nevertheless fixed:
+
+```text
+increment activeContextEpoch
+  -> close Browser request gate
+  -> cancel account-bound Auth/cert/credential/navigation/download continuations
+  -> close old tabs/views/connections
+  -> stop old Engine and confirm cleanup
+  -> destroy proxy sidecar/generation secrets
+  -> clear account session/resources/notices
+  -> validate destination account stores and partition
+  -> commit active profile/account pair
+  -> optionally authenticate/connect
+```
+
+An account switch never migrates a live Gateway session, Cookie, MFA transaction, transport token, server
+resource grant or Browser tab. Unconfirmed cleanup blocks the destination account. The coordinator does not
+decrement epochs or silently reopen the old workspace.
+
+### Persistent switch recovery
+
+The owner-only active-context journal records old/new profile and account keys/revisions, the intended context
+epoch, Engine stop result, destination validation result and one commit marker. `activeProfileId` and
+`activeAccountKey` become authoritative together at the single commit point. On crash recovery:
+
+- a proven pre-commit journal restores the all-old context;
+- a proven committed journal activates the all-new context;
+- ambiguous/corrupt/transiently unreadable state starts no Engine and opens no Browser workspace;
+- stale owned Engine cleanup completes before any credential is decrypted.
+
+## Settings and ownership split
+
+### Global
+
+- active profile/account reference;
+- product locale, close behavior, start-at-login and updater state;
+- one loopback listener port and strict local-proxy authentication policy.
+
+### Profile
+
+- immutable deployment reference/revision;
+- reviewed profile defaults and bounded local profile presentation;
+- primary account key;
+- profile availability/confirmation state.
+
+### Account/workspace
+
+- auto-connect/reconnect and retry preference;
+- encrypted VPN identity/credential;
+- site credentials and certificate grants;
+- user routing rules and local resources;
+- favorites/recent resource handles;
+- account Browser preferences and diagnostics.
+
+Profile defaults may seed a new account once; later profile updates do not overwrite mutable account choices or
+copy account data.
+
+## Migration from the current flat HKUST layout
+
+P3 creates the account hierarchy immediately; there is no intermediate production layout with mutable user
+state directly under `profiles/<profileKey>/`.
+
+Migration order:
+
+1. finish the existing `credential-settings-transaction.json` recovery before reading settings or credential;
+2. generate and journal one HKUST opaque `profileKey`, primary `accountKey` and `workspaceKey`;
+3. snapshot/digest all old and destination paths;
+4. write global settings and HKUST profile metadata, including the primary account reference;
+5. atomically decrypt the old username/password pair in memory and re-encrypt one bound
+   `VpnCredentialEnvelope` under the primary account;
+6. move custom resources, routing rules/PAC, site credential vault, certificate trust and log into that account;
+7. initialize empty favorites/recent documents and adopt the legacy HKUST Browser partition alias;
+8. fsync destination files/directories and write the migration commit marker;
+9. apply ADR-0003's post-commit retirement rules for legacy pins, rules/PAC and website vault;
+10. retain/retire the legacy VPN rollback blob only through its account-bound
+    `LegacyCredentialRollbackState`.
+
+After journal recovery, state is all-old or all-new. The new profile/account pair is not visible as active until
+its credential envelope binding and every authoritative account store can be verified. A corrupt authorization
+store fails closed; historical backup cannot resurrect a revoked pin/direct rule.
+
+The one-release rollback adapter binds the retained VPN blob to the exact migrated profile/account/origin/family
+and never reads it for ordinary auto-connect. Any successful credential mutation retires it as required by
+ADR-0003. Rollback may reuse the legacy HKUST Browser partition but never retired certificate, routing or site
+credential stores.
+
+## Logout, reset and deletion
+
+These operations are deliberately distinct:
+
+- **Logout / clear VPN credential** stops the account Engine/session and removes the VPN credential envelope.
+  It retains Browser partition, favorites, recent entries, local resources, site credentials, pins and routing
+  unless the user separately chooses workspace clearing. It also retires the legacy rollback blob before
+  reporting success.
+- **Clear workspace** requires an inactive account and clears the Browser partition, site vault, pins, local
+  resources, favorites/recent and user routes. It does not remove the profile or VPN credential unless
+  explicitly combined in one separately journaled reset operation.
+- **Remove account** is disabled for the only primary account in the first release, except as part of allowed
+  custom-profile deletion. Future account removal requires it to be inactive, tombstones it first, clears its
+  partition and all account files, fsyncs deletion, then removes the account registry entry last.
+- **Delete custom profile** follows ADR-0003 and recursively removes/tombstones every account workspace before
+  removing the profile record. Builtin HKUST cannot enter this API. Failure leaves a non-connectable,
+  non-auto-connect tombstone; no partial account can be rediscovered as primary.
+
+Chromium partition cleanup failure blocks account/profile removal. A deleted account key and workspace key are
+never reused.
+
+## Session, resources and routing
+
+The Rust `AuthenticatedGatewaySession`, MFA transaction, Modern token, Data Plane, DNS result and Engine
+generation belong to one `CampusAccount` active context. They cannot be transferred between accounts, even
+when both accounts share a Gateway origin.
+
+Profile-reviewed builtin resources are immutable deployment input. Authenticated server resources bind account
+key + authenticated-session generation + catalogue revision/expiry. Local resources, favorites and recent
+entries belong to the workspace. Renderer sees sanitized resource views and non-authorizing opaque
+`resourceHandle` values, never raw authorization fields, Cookie-bearing URLs or hidden query parameters.
+`LaunchHandle` remains Main-owned and is prepared/consumed only after an explicit launch request; it never enters
+Renderer state.
+
+Routing policy compilation combines profile reviewed defaults with only the active account's custom resources
+and user rules. `RoutingPolicyIR` and its decision envelope include profile/account revisions and active-context
+epoch. No account's direct rule, PAC source or inherited navigation route is visible in another workspace.
+
+## Renderer and IPC boundary
+
+Only bounded views cross from Main:
+
+```text
+SchoolProfileView
+CampusAccountView
+WorkspaceView
+  favorite/recent/resource display views
+  route/certificate summaries
+  connection/capability presentation
+```
+
+The Renderer never receives:
+
+- VPN password or decrypted username record;
+- secure-storage ciphertext;
+- Gateway Cookie, CSRF, TwfID, token or MFA continuation;
+- raw profile/config/DNS/provider state;
+- site-vault password;
+- complete Browser history or sensitive URL query/fragment;
+- filesystem/partition keys or paths.
+
+Every mutating IPC carries an opaque current account/workspace correlation generated by Main and is revalidated
+against the sender, active-context epoch and store owner. Renderer-supplied profile/account/path values never
+select a credential file.
+
+The correlation is `accountHandle`, never `accountKey` or `workspaceKey`. Handles are recreated after Renderer
+reload and invalidated on any context transition.
+
+## Logging and privacy
+
+Account logs remain three-day bounded and redacted. Default diagnostics may record opaque profile/account
+correlation, protocol family, connection generation, state transition and stable error code. They do not record
+username, user label, Gateway hostname, Browser hostname, resource URL, query, Cookie, pin decision response or
+credential presence detail beyond a bounded state such as `configured | missing | unavailable`.
+
+Opening a log from the UI is explicitly scoped to the active account. Cross-account aggregate diagnostics, if
+added later, expose counts/stable codes only and require user action.
+
+## Compatibility and non-goals
+
+- ADR-0003 remains authoritative for safe custom Gateway discovery, immutable profile identity and one active
+  Engine.
+- Existing password + Modern L3 behavior, local proxy security and product app identity remain unchanged.
+- The first release does not support concurrent Engines, account sharing, credential synchronization, cloud
+  backup/export/import or account data merge.
+- A profile update never copies state to another account.
+- Account readiness does not claim that a Gateway permits multiple simultaneous sessions.
+
+## Acceptance and tests
+
+### Schema and storage
+
+- opaque keys reject traversal, collision, symlink and hard-link substitution;
+- maximum one enabled primary account per profile is enforced in the first release;
+- encrypted credential binding mismatch fails before username/password use;
+- branding/resource/ordinary metadata revision changes do not invalidate a credential binding;
+- profile/account/workspace revisions cannot be silently coerced;
+- every account-owned path is below `profiles/<profileKey>/accounts/<accountKey>/` from P3 onward.
+
+### Isolation
+
+Use two synthetic profiles with two synthetic accounts each, even while the production UI exposes one:
+
+- A credential is never submitted in B account/profile context;
+- Cookie/localStorage/cache/service worker/site credential/pin/rule/favorite/recent/resource state is invisible
+  across accounts and profiles;
+- account A server resources/notices disappear on context change;
+- stale Engine, health, retry, MFA, certificate, credential, navigation, download, routing and telemetry
+  callbacks cannot mutate B;
+- external SOCKS/Clash/SSH always target the one active account's Campus session.
+
+### Migration and recovery
+
+- fault-inject every journal/write/fsync/rename/unlink/partition-cleanup boundary;
+- recovery yields all-old or all-new authoritative state and is restart-idempotent;
+- legacy HKUST Cookie state appears only in the migrated primary workspace;
+- credential replacement/logout/account reset cannot succeed while a reusable legacy rollback blob remains;
+- revoked pin/direct rule/site credential cannot reappear through rollback or downgrade;
+- transient I/O never collapses into an empty store that authorizes overwrite.
+
+### Lifecycle and deletion
+
+- 100 profile/account context switches leave no Engine PID, port, timer, View, challenge, sidecar or borrowed
+  credential;
+- switch/quit/sleep/offline/crash races start no new Engine from ambiguous context;
+- cleanup-unconfirmed blocks context activation;
+- account/profile deletion cannot remove a registry record before partition and secret/grant cleanup;
+- tombstoned accounts are never selectable, auto-connected or assigned a reused key.
+
+### Renderer/privacy
+
+- IPC schema rejects raw usernames, credential payloads, filesystem keys and unknown fields outside explicit
+  credential-entry calls;
+- account handles cannot be replayed after Renderer/context changes and never equal persistent account keys;
+- no default state/log/event contains username, Gateway/Browser hostname, full URL, Cookie, token or OTP;
+- favorites/recent persistence strips query/fragment and bounds all display data;
+- Browser certificate pin and site credential remain exact-origin plus active-account scoped.
+
+## Rollout order
+
+This ADR affects existing 2.0 preparation phases without adding a new user feature:
+
+1. P1 defines `CampusAccount`, `WorkspaceScope`, opaque key and view schemas beside `SchoolProfile`.
+2. P2 provider/capability composition binds runtime capability to profile plus account context.
+3. P3 writes the account-nested layout and performs the one HKUST primary-account migration directly.
+4. P4 implements one `ActiveContextCoordinator` for profile and future account transitions while keeping only
+   HKUST primary selectable.
+5. Later Browser/routing/resource work consumes `WorkspaceScope`; it does not introduce another storage move.
+
+No second real school, custom Gateway credential entry or second production account is enabled by this ADR.

--- a/docs/architecture/2.0-capability-matrix.md
+++ b/docs/architecture/2.0-capability-matrix.md
@@ -44,7 +44,8 @@
   `5d8323d37de7c279ae70b3ec646f93791d6a3581`；main CI `32630023985`及tag
   build/release `32630322732`通过，四个正式资产已发布。该交付事实提升release/package
   evidence，不提升任何缺少学校canary的Gateway capability；
-- zju-connect当前固定为`2c71a34c17ea7ecf04c5fe862c4c315344128653`，见
+- zju-connect协议审计固定为`2c71a34c17ea7ecf04c5fe862c4c315344128653`，并单独复核当前main
+  配置delta `4b2bcaa0acc34a33de672c26e3b2cb83bd583b15`，见
   [`2c71a34-observation.md`](../research/zju-connect/2c71a34-observation.md)；历史审计快照见
   [`2026-08-23-zju-current-comparison-plan.md`](../audits/2026-08-23-zju-current-comparison-plan.md)；
 - EasyConnect没有可提交或可重分发的固定包快照。本表中的`Historical Observed`仅来自
@@ -54,14 +55,16 @@
 
 | 能力 | EasyConnect | zju-connect 固定审计 | HKUST(GZ) Connect 当前 | 2.0 目标与完成证据 |
 | --- | --- | --- | --- | --- |
-| School/profile selection | VPN地址历史/多配置门户；隔离语义未验证 | CLI/TOML选择server/protocol | `I0/E1`；单一HKUST上下文 | reviewed presets + local custom profile；schema/property/package evidence |
+| School/profile selection | VPN地址历史/多配置门户；隔离语义未验证 | CLI/TOML选择server/protocol | `I0/E1`；单一HKUST上下文 | reviewed presets先行；第二reviewed school完成后才开放Advanced custom profile |
+| Account/workspace scope | per-VPN设置线索；账户隔离行为未验证 | 单进程/单配置，无Browser workspace | `I0/E1`；school/account共享flat userData | `SchoolProfile→CampusAccount→WorkspaceScope`；两profile×两account交叉可见数=0 |
 | Safe Gateway connector | 内部Agent/privileged服务；本次仅静态线索 | underlay支持显式/自动接口绑定；无同等自定义域名SSRF边界 | `I1/E2`；`.no_proxy()`但无通用resolved-address连接约束 | 全CNAME/A/AAAA验证、mixed/unsafe拒绝、实际peer绑定、hostname PKI；HTTP/特殊TLS同generation |
-| Custom Gateway onboarding | 用户可输入VPN地址；后续由Agent处理 | `-server/-protocol`直接配置 | `I0/E1` | 无凭据probe仅识别public auth surface→一次性确认→新opaque profile→先校验target/config再解密；0 password/Cookie during discovery |
+| Custom Gateway onboarding | 用户可输入VPN地址；后续由Agent处理 | `-server/-protocol`直接配置 | `I0/E1` | P11 Advanced/experimental；无凭据probe→一次性确认→新opaque profile/account→先校验target/config再解密；0 password/Cookie |
 | Cross-profile data isolation | per-VPN设置存在；Cookie/secret边界不满足本项目目标 | 单进程/单配置，无对应Browser产品面 | `I0/E1`；全局vault/partition/rules | 两synthetic profiles间password/Cookie/pin/rule/event可见数=0；100 switch residue=0 |
 | Password auth | Historical Observed | Source-observed production | `I3/E2`；Historical E4，当前exact-SHA E4待补 | 同 profile 20/20；拒绝/不确定/协议错误分类一致 |
 | Gateway MFA | Hypothesis：官方包/其他profile有线索 | SMS/TOTP/cert/aTrust source wiring | `I2/E2` generic framework；真实 provider 无 | 每种方法独立 `I3/E5`；未知方法 100% fail-closed |
 | Modern L3 IPv4 | Historical Observed | Source-observed | `I3/E2`；Historical E4，当前exact-SHA E4待补 | 100 connect/reconnect；0 leaked session/socket |
-| Resource catalogue | Historical Observed UI | Source capability | `I2/E2` offline parser；production retrieval无 | retrieval/expiry/auth semantics `E5` |
+| Resource domain/search | 多资源类型静态线索；active profile未知 | resource/routing source capability | `I2/E2` offline parser；当前仅Web shortcut UI | neutral descriptor/view/opaque handle；search/category/favorite/recent；unsupported typed fail-closed |
+| Resource catalogue | Historical Observed UI | Source capability | `I2/E2` offline parser；production retrieval无 | authenticated retrieval/revision/expiry/auth semantics `E5` |
 | WebVPN | Unknown：active profile未观察 | 未观察到backend；aTrust明确忽略WEB资源 | `I1/E1` typed slot；production unsupported | 只在 L3-disabled school profile 后实现 |
 | Campus DNS UDP | Historical Observed | Source production | `I3/E2`；Historical E4，当前HPC E4待补 | HPC 20/20；外部 DNS packet=0 |
 | Campus DNS TCP | Unknown | Source production，策略不同 | `I3/E2`，仅matching TC→same resolver | synthetic matrix + real TC canary；0 public fallback |
@@ -76,6 +79,8 @@
 | Multi-Exit semantics | Unknown | 多 backend/route | `I0/E1`；无统一Exit model | Direct/L3/WebVPN typed capability，无隐式 fallback |
 | Multi-Exit detection/selection | Unknown | explicit/auto source wiring | `I0/E1`；2.0设计Deferred，1.x只用system route | 两个受控候选后再实现；Gateway RTT/failure/stability评分，Auto hysteresis和manual fail-closed |
 | Underlay binding | Unknown：官方行为需观察 | explicit/auto source wiring | `I0/E1` | 三平台 explicit；绑定失败 unbound fallback=0 |
+| Scoped TCP/UDP forwarding | 官方资源/平台组件静态线索 | Source production | `I0/E1`；当前用户经SOCKS/SSH手动配置 | account-bound loopback temporary forwarding；严格认证/idle cleanup；再暴露给Headless |
+| CLI/headless/service | vendor Agent/daemon；不适合作为模板 | Source production，配置/secret边界不同 | `I1/E1` development CLI only | unprivileged service/Docker；secret不进argv/TOML/env；restart residue=0 |
 | Multi-line | Hypothesis | node selection source wiring | `I2/E2` offline endpoint parse；无production selection | sticky/hysteresis；默认切线重新认证 |
 | Loop prevention | Unknown | 部分 underlay/TUN | `I3/E2` local destination与Gateway `.no_proxy()`；无underlay identity | graph cycle test=100%；self recursion=0 |
 | TUN/FakeIP | Historical Observed system integration | production/experimental | `I0/E1`，ADR明确Deferred | 条件 Ingress；100 crash cycles残留=0 |
@@ -89,6 +94,7 @@
 
 ### Correctness and routing
 
+- two profiles × two accounts cross-scope credential/Cookie/pin/rule/resource/event visibility `=0`；
 - 128 条规则 decision p95 `<0.5 ms`；
 - 100,000 个 property corpus 中 JS/PAC/Rust/Exit mismatch `=0`；
 - policy transaction 期间越权请求 `=0`；
@@ -97,6 +103,7 @@
 
 ### Stability
 
+- 100 次profile/account切换无残留Engine、Browser view、partition owner、listener或timer；
 - 100 次 connect/disconnect/reconnect 无残留 Engine、listener、timer、thread；
 - 1,000 次 parser/network fault injection crash/panic `=0`；
 - interface generation 变化后旧 socket/request 继续发送 `=0`；
@@ -105,6 +112,7 @@
 
 ### Security
 
+- Renderer收到原始resource authorization、private target、LaunchHandle、Cookie/token数量 `=0`；
 - 非 loopback listener `=0`；
 - Gateway 隐式环境代理使用 `=0`；
 - campus DNS 失败时 system/public DNS packet `=0`；
@@ -115,6 +123,7 @@
 
 ### Performance
 
+- 10,000 ResourceDescriptorView本地搜索可取消且不阻塞control window；
 - SOCKS/frontend offline p95 `≤10 ms`；
 - netstack offline matrix p95 `≤10 ms`；
 - 相对固定 1.x 同机基线 throughput/latency 回退 `≤5%`；
@@ -133,6 +142,7 @@
 
 ### Maintainability and release
 
+- `main`受pull request、required CI、package verifier与exact-tree secret scan保护；
 - CommonJS/Rust boundary cycle `=0`；
 - 新跨层 import 在 CI fail；
 - 每个 production provider 有独立 fixture、rollback 和 owner；

--- a/docs/architecture/2.0-capability-matrix.md
+++ b/docs/architecture/2.0-capability-matrix.md
@@ -54,6 +54,10 @@
 
 | 能力 | EasyConnect | zju-connect 固定审计 | HKUST(GZ) Connect 当前 | 2.0 目标与完成证据 |
 | --- | --- | --- | --- | --- |
+| School/profile selection | VPN地址历史/多配置门户；隔离语义未验证 | CLI/TOML选择server/protocol | `I0/E1`；单一HKUST上下文 | reviewed presets + local custom profile；schema/property/package evidence |
+| Safe Gateway connector | 内部Agent/privileged服务；本次仅静态线索 | underlay支持显式/自动接口绑定；无同等自定义域名SSRF边界 | `I1/E2`；`.no_proxy()`但无通用resolved-address连接约束 | 全CNAME/A/AAAA验证、mixed/unsafe拒绝、实际peer绑定、hostname PKI；HTTP/特殊TLS同generation |
+| Custom Gateway onboarding | 用户可输入VPN地址；后续由Agent处理 | `-server/-protocol`直接配置 | `I0/E1` | 无凭据probe仅识别public auth surface→一次性确认→新opaque profile→先校验target/config再解密；0 password/Cookie during discovery |
+| Cross-profile data isolation | per-VPN设置存在；Cookie/secret边界不满足本项目目标 | 单进程/单配置，无对应Browser产品面 | `I0/E1`；全局vault/partition/rules | 两synthetic profiles间password/Cookie/pin/rule/event可见数=0；100 switch residue=0 |
 | Password auth | Historical Observed | Source-observed production | `I3/E2`；Historical E4，当前exact-SHA E4待补 | 同 profile 20/20；拒绝/不确定/协议错误分类一致 |
 | Gateway MFA | Hypothesis：官方包/其他profile有线索 | SMS/TOTP/cert/aTrust source wiring | `I2/E2` generic framework；真实 provider 无 | 每种方法独立 `I3/E5`；未知方法 100% fail-closed |
 | Modern L3 IPv4 | Historical Observed | Source-observed | `I3/E2`；Historical E4，当前exact-SHA E4待补 | 100 connect/reconnect；0 leaked session/socket |

--- a/docs/architecture/2.0-capability-matrix.md
+++ b/docs/architecture/2.0-capability-matrix.md
@@ -37,14 +37,15 @@
 
 本表必须与固定快照一起阅读：
 
-- HKUST(GZ) Connect implementation固定为
-  `6efca3c2b762a9b2b47f74b11b965b2c126e5c91`，并由本轮
-  [`1x-release-gate.md`](../engineering/1x-release-gate.md)追踪；文档提交不改变该实现树；
+- HKUST(GZ) Connect当前implementation固定为
+  `ed47f93f6594c7ae41ef344f08fa0aa6b5c47fc2`；已发布v1.2.3仍固定为`5d8323d`。
+  post-release convergence只提升生命周期实现/测试证据，不提升Gateway capability等级；
 - 正式v1.2.3 delivery commit和tag source为
   `5d8323d37de7c279ae70b3ec646f93791d6a3581`；main CI `32630023985`及tag
   build/release `32630322732`通过，四个正式资产已发布。该交付事实提升release/package
   evidence，不提升任何缺少学校canary的Gateway capability；
-- zju-connect固定为`4c4b41fee599646efc1463ecf080590724b24f28`，证据与限制见
+- zju-connect当前固定为`2c71a34c17ea7ecf04c5fe862c4c315344128653`，见
+  [`2c71a34-observation.md`](../research/zju-connect/2c71a34-observation.md)；历史审计快照见
   [`2026-08-23-zju-current-comparison-plan.md`](../audits/2026-08-23-zju-current-comparison-plan.md)；
 - EasyConnect没有可提交或可重分发的固定包快照。本表中的`Historical Observed`仅来自
   2026-08-23以前本校授权观察，因缺少本轮可复现的精确客户端版本，只能作为历史线索，
@@ -57,7 +58,7 @@
 | Gateway MFA | Hypothesis：官方包/其他profile有线索 | SMS/TOTP/cert/aTrust source wiring | `I2/E2` generic framework；真实 provider 无 | 每种方法独立 `I3/E5`；未知方法 100% fail-closed |
 | Modern L3 IPv4 | Historical Observed | Source-observed | `I3/E2`；Historical E4，当前exact-SHA E4待补 | 100 connect/reconnect；0 leaked session/socket |
 | Resource catalogue | Historical Observed UI | Source capability | `I2/E2` offline parser；production retrieval无 | retrieval/expiry/auth semantics `E5` |
-| WebVPN | Unknown：active profile未观察 | Source support线索 | `I1/E1` typed slot；production unsupported | 只在 L3-disabled school profile 后实现 |
+| WebVPN | Unknown：active profile未观察 | 未观察到backend；aTrust明确忽略WEB资源 | `I1/E1` typed slot；production unsupported | 只在 L3-disabled school profile 后实现 |
 | Campus DNS UDP | Historical Observed | Source production | `I3/E2`；Historical E4，当前HPC E4待补 | HPC 20/20；外部 DNS packet=0 |
 | Campus DNS TCP | Unknown | Source production，策略不同 | `I3/E2`，仅matching TC→same resolver | synthetic matrix + real TC canary；0 public fallback |
 | Public DNS fallback | Unknown | 可配置 secondary/public | `I3/E2` policy明确disabled；当前packet capture E4待补 | failure capture 外部 DNS packet=0 |
@@ -131,7 +132,7 @@
 - CommonJS/Rust boundary cycle `=0`；
 - 新跨层 import 在 CI fail；
 - 每个 production provider 有独立 fixture、rollback 和 owner；
-- 每个 release 的源码 SHA、四平台产物、native 架构和 package manifest 可复现；
+- 每个 release 的源码 SHA、三平台四产物、native 架构和 package manifest 可复现；
 - release capability 状态同时记录 implementation 与 evidence，不能只写 Done。
 
 ## 4. Promotion rule

--- a/docs/architecture/2.0-cross-project-feature-map.md
+++ b/docs/architecture/2.0-cross-project-feature-map.md
@@ -7,15 +7,16 @@ it does not prove that a specific school enables or supports the capability.
 
 - EasyConnect: installed-mutated macOS 7.6.7 static observation plus existing sanitized Linux/Windows
   baselines;
-- zju-connect: public source commit `2c71a34c17ea7ecf04c5fe862c4c315344128653`;
+- zju-connect: protocol/source audit at `2c71a34c17ea7ecf04c5fe862c4c315344128653`, plus reviewed current-main
+  configuration delta `4b2bcaa0acc34a33de672c26e3b2cb83bd583b15`;
 - HKUST(GZ) Connect: production source `ed47f93f6594c7ae41ef344f08fa0aa6b5c47fc2`.
 
 ## 1. Product composition, profile and session
 
 | Capability | EasyConnect 7.6.7 implementation | zju-connect implementation | Current HKUST(GZ) Connect | 2.0 independent implementation |
 | --- | --- | --- | --- | --- |
-| Product composition | Electron portal delegates to local ECAgent, monitor, privileged VPN service and modules | Go `main` builds config, protocol client, stack, resolver, dialer and local services | Electron Main owns Rust child and Browser; Rust owns auth/L3/netstack/frontend | Keep Rust/Electron split; add profile-aware compiled provider composition, no vendor Agent/root daemon |
-| School/Gateway selection | Persists VPN address/history and server-provided configuration | CLI/TOML selects server, protocol and deployment flags | One hard-coded HKUST Gateway/config | `SchoolProfile` registry with HKUST preset and isolated local custom profile generated from user-confirmed Gateway origin |
+| Product composition | Electron portal delegates to local ECAgent, monitor, privileged VPN service and modules | Go `main` builds config, protocol client, stack, resolver, dialer and local services | Electron Main owns Rust child and Browser; Rust owns auth/L3/netstack/frontend | Campus Workspace + Secure Access Runtime; keep Rust/Electron split and add reviewed profile/account composition without vendor Agent/root daemon |
+| School/Gateway selection | Persists VPN address/history and server-provided configuration | CLI/TOML selects server, protocol and deployment flags | One hard-coded HKUST Gateway/config | Reviewed `SchoolProfile` registry first; second reviewed school before experimental Advanced custom Gateway |
 | Protocol selection | Static portal/Agent/module flow suggests family and service selection; runtime negotiation is not proven by this sample | `easyconnect` or `atrust` flag | One password + Modern L3 family | Closed `ProtocolFamily`; public probe identifies only a candidate auth surface, while authenticated runtime confirms L3/DNS/transport; unknown remains unsupported |
 | Runtime capability truth | ECAgent/server/UI states determine available flows | Mostly config/source capability; some runtime resource selection | Engine hello has fixed capability list; provider traits exist | Additive `CapabilitySnapshot`: compiled ∩ selected provider ∩ profile evidence ∩ ingress mode |
 | Session ownership | TWFID/Cookie/agent state shared across portal and local service | Client/session structs own cookies/tokens; optional client-data persistence | `AuthenticatedGatewaySession` stays inside Rust | Bind session to profile ID, Gateway origin, protocol family, profile epoch and Engine generation |
@@ -29,7 +30,7 @@ it does not prove that a specific school enables or supports the capability.
 | CAPTCHA | Separate image/config/login path | Easy writes image and reads terminal; aTrust browser/file modes | State recognized, no real provider | Generic image challenge held in Engine; UI receives bounded image handle/metadata; no fixed endpoint/length |
 | SMS | SDK acquire/cooldown/submit modules | Easy fixed secondary path; aTrust continuation/custom SMS paths | Generic challenge framework only | One school-observed provider at a time; Engine owns resend/cooldown/request budget |
 | TOTP/token | TOTP/rebind and token/radius UI paths | Easy TOTP; aTrust TOTP/radius/challenge; optional TOTP secret config | Generic token challenge only | User-entered one-time response only; never persist seed or print OTP |
-| Certificate | Certificate list/import/auth; ECAgentProxy integrates macOS certificate APIs | Easy P12 file/password flow; TLS validation remains unsafe upstream | Capability typed unsupported; exact website pin store is unrelated | System certificate/Keychain selector + provider adapter + standard PKI/leaf binding; no raw P12 path in Renderer |
+| Certificate | Certificate list/import/auth; ECAgentProxy integrates macOS certificate APIs | Easy PKCS#12 file/password flow; TLS validation remains unsafe upstream | Capability typed unsupported; exact website pin store is unrelated | System certificate/Keychain selector + provider adapter + standard PKI/leaf binding; no raw PKCS#12 path in Renderer |
 | USB Key/HID | Static source contains dedicated key/HID discovery, config, registration and login modules; school activation is unknown | No USB Key/HID implementation was observed | Typed unsupported | Separate platform credential provider only with approved hardware/profile; no process/USB monitoring shim |
 | SSO/QR/social | Static source contains domain SSO, WeChat, DingTalk and enterprise-WeChat UI/SDK paths; school activation is unknown | aTrust Gateway authentication supports CAS/OAuth2 callbacks only; no QR/social implementation was observed | Campus web SSO works inside isolated Browser; Gateway SSO unsupported | Separate minimal authentication partition, exact callback/state binding and provider-specific canary |
 | Auth continuation | UI/agent advances current auth/next-service chain | aTrust bounded continuation loop; Easy fixed secondary mapping | `AuthTransactionOwner`, v3 respond/resend/cancel, synthetic provider | Close production composition over `Authenticated | PendingTransaction | Terminal`; opaque provider state stays in Rust |
@@ -39,14 +40,14 @@ it does not prove that a specific school enables or supports the capability.
 
 | Capability | EasyConnect 7.6.7 implementation | zju-connect implementation | Current HKUST(GZ) Connect | 2.0 independent implementation |
 | --- | --- | --- | --- | --- |
-| Resource catalogue | ECAgent/Web SDK normalizes groups, defaults and many resource classes | Easy parses resource XML into routing/DNS; aTrust accepts L3VPN resources | Bounded offline parser; built-in/custom resources in Campus Browser | Authenticated `ResourceProvider` with revision/expiry, opaque handles, profile/session binding and explicit unknown authorization |
+| Resource catalogue | ECAgent/Web SDK normalizes groups, defaults and many resource classes | Easy parses resource XML into routing/DNS; aTrust accepts L3VPN resources | Bounded offline parser; Web shortcut model in Campus Browser | Neutral ResourceDescriptor + opaque launcher first; authenticated `ResourceProvider` later adds revision/expiry/profile-account/session binding and explicit authorization |
 | Web resource/WebVPN | Static portal paths contain Web/EasyLink rewrite and browser/SSO flows; profile activation and wire behavior remain unknown | No Sangfor WebVPN backend; aTrust ignores WEB resources | Browser uses L3 proxy or Direct; WebVPN backend unsupported | Learn only from official parity on an L3-disabled profile; distinct `WebVpnExit`, never ordinary HTTP proxy fallback |
 | IP/L3 resource | Starts/query L3 service and applies server policy | Resource-aware L3 dial | Modern L3 tunnels all permitted frontend traffic | Compile reviewed server/user/profile policy into RoutingPolicyIR and pin Campus ingress to `CampusModernL3Exit` |
 | Per-app TCP resource | Static TCP service/module and app/resource-opener clues exist; runtime activation is unknown | aTrust per-app signed TCP tunnel; Easy cannot use it | Unsupported | Separate `TcpResourceExit` only after school evidence; never fake trusted-process/compliance attributes |
 | SSO resource | Static portal paths inject/rewrite SSO state and open resources; exact runtime behavior requires profile parity | CAS/OAuth2 authenticates the aTrust Gateway only; no resource-level SSO opener was observed | Browser preserves same-profile Cookie/POST/SAML | Profile-scoped Browser partition and strict origin/callback policy; no hidden arbitrary credential injection |
 | File/FTP/mail/app | Static portal source contains typed opener/native-integration paths; runtime activation is unknown | Resource parsing may route supported network endpoints | Browser/SSH/SOCKS cover ordinary network access | Model resource capability; open only through allowlisted OS/browser actions; no ActiveX/native automation by default |
 | RemoteApp | RSession/CSClient and clipboard/audio/input components | No equivalent official RemoteApp backend | Unsupported | Separate optional product/backend and threat model; never coupled to core 2.0 release |
-| Campus browser UX | Portal has multiple controlled windows, tray resources and external browser opening | Primarily CLI/local proxy; no equivalent integrated browser | Sandboxed multi-tab Campus Browser, custom sites, password vault, cert pins, Campus/Direct rules | Promote to profile-scoped “Campus Workspace”; this is a differentiating core feature, not an EasyConnect clone |
+| Campus browser UX | Portal has multiple controlled windows, tray resources and external browser opening | Primarily CLI/local proxy; no equivalent integrated browser | Sandboxed multi-tab Campus Browser, custom sites, password vault, cert pins, Campus/Direct rules | Promote to account-scoped Campus Workspace with search/favorites/recent and typed Web/SSH/TCP/Jupyter/Database launchers |
 | Website passwords | Portal may retain/inject account data through settings/SSO flows | Not a comparable product feature | Encrypted exact-origin local vault with OTP/MFA safety | Namespace by profile + origin; never autofill across schools even when the origin is shared |
 | Certificate exceptions | Static Electron source contains a certificate-error bypass path; its runtime scope is not generalized beyond the observed handler | Several upstream TLS paths skip verification | Exact-origin/fingerprint user-confirmed pin only in Campus Browser | Keep current narrow model and namespace by profile; Gateway TLS exceptions remain administrator-reviewed, not Browser pins |
 
@@ -76,24 +77,25 @@ it does not prove that a specific school enables or supports the capability.
 | Diagnostics | Broad portal/Agent logs and crash/heap paths | Rich debug, PCAP/keylog options and sensitive logs | Redacted 3-day logs, stable codes, no packet capture by default | Keep current privacy; add profile/correlation/Exit aggregate only, never hostname/full URL by default |
 | Tests/CI | Proprietary, not visible | Many Go tests exist but CI mainly builds | Rust/Desktop/Electron/package/secret/architecture/performance gates | Keep stronger gates; independently recreate behavior tests, never copy upstream fixtures |
 | Cross-platform | Legacy x86_64 mac app and privileged components | Go desktop/server/Android paths | macOS arm64/x64, Windows x64, Linux x64 packages | One neutral profile schema; each protocol/backend still needs platform package and real canary evidence |
+| Headless/service | Agent/daemon architecture is privileged and vendor-owned | CLI/system service/Docker-friendly foreground process | Development CLI and desktop-owned Engine; no formal service product | Separate unprivileged CLI/service over same profile/account/provider core; secrets via OS store/stdin/FD/Docker secret, strict loopback listeners |
 
 ## 6. Multi-school product decision
 
-2.0 is a multi-school EasyConnect-compatible platform, not an HKUST-only fork and not a claim of universal
-compatibility.
+2.0 is a resource-first **Campus Workspace + Secure Access Runtime**, not an HKUST-only fork, a Rust EasyConnect
+clone or a claim of universal Gateway compatibility.
 
-Login starts with:
+The ordinary-user journey starts with:
 
 ```text
-School / organization
-  ├── HKUST(GZ) — reviewed built-in profile
-  └── Other — user enters an HTTPS Gateway domain/port
+search/favorite/recent resource
+  → decide Direct or Campus
+  → connect/MFA only when required
+  → open in Campus Workspace or a typed launcher
 ```
 
-For `Other`, the application performs credential-free discovery first, shows the normalized Gateway and a
-candidate recognized public login surface, then asks for explicit confirmation before displaying credential
-fields. It explicitly marks L3/DNS/transport as requiring authenticated runtime confirmation and never
-automatically submits a password while guessing providers/endpoints.
+The school picker initially contains reviewed profiles only. `Other` is deferred to P11 under Advanced settings,
+after a second reviewed school proves the isolation model. It remains experimental/unverified and never becomes
+the headline value of 2.0.
 
 Custom Gateway discovery is unavailable until the profile identity, provider composition, storage migration
 and active-profile isolation foundations are complete. Its own admission gate must validate every resolved
@@ -102,7 +104,7 @@ escape the validated set, bind every actual outer Gateway HTTP/special-TLS socke
 the peer, and retain the confirmed hostname for TLS SNI and certificate verification. Probe Cookies/session
 state are destroyed. Any ambiguity fails closed before profile creation or a real custom-Gateway canary.
 
-Every school/custom Gateway receives isolated:
+Every reviewed/custom school and account workspace receives isolated:
 
 - VPN credential vault;
 - Browser partition/Cookies/localStorage;
@@ -111,22 +113,30 @@ Every school/custom Gateway receives isolated:
 - routing rules/resources/DNS policy/logs;
 - profile epoch and Engine generation.
 
+Account identity is not the school deployment identity. The durable hierarchy is `SchoolProfile →
+CampusAccount → WorkspaceScope`; the first UI still exposes one `primary` account, but P3 migrates directly into
+the account-aware namespace.
+
 Built-in profiles may ship reviewed DNS/resource/branding policy. Custom profiles are visibly unverified and
 default to standard PKI, an app-owned neutral page, Engine-native health only, no DNS fallback, no built-in
 routes/resources, no Gateway-driven updater and no system mutation.
 
 ## 7. Priority synthesis
 
-### Foundation required before a second real school
+### Foundation and first Campus Workspace Beta
 
-1. P1: SchoolProfile/GatewayOrigin/ProtocolFamily and the single-HKUST profile registry;
+1. P1: SchoolProfile/GatewayOrigin/ProtocolFamily + CampusAccount/WorkspaceScope placeholders;
 2. P2: production provider composition and capability snapshot bound to profile identity;
-3. P3: profile-scoped encrypted storage and journaled legacy HKUST migration;
-4. P4: ActiveProfileCoordinator and Browser partition isolation;
-5. P5: validated Gateway connector and one-shot confirmation transaction;
-6. P6: safe credential-free custom Gateway discovery and isolated local profile;
-7. P7: profile-scoped RoutingPolicyIR;
-8. P8/P9: Router/Exit ADR and behavior-preserving Campus adapter.
+3. P3: profile/account/workspace storage and journaled legacy HKUST migration;
+4. P4: ActiveProfile/ActiveAccount coordinator and Browser partition isolation;
+5. P5: behavior-preserving HKUST GatewayConnectorGeneration;
+6. P6: account-scoped RoutingPolicyIR;
+7. P7: Router ADR/test-only ec-router and behavior-preserving Campus Exit adapter;
+8. P8: ResourceDescriptor, search/favorites/recent and typed launchers—the first user-visible Beta;
+9. P9: first evidence-gated current-school capability;
+10. P10: second reviewed school;
+11. P11: advanced custom organization onboarding;
+12. P12/P13: Controlled Direct/Underlay/multi-line, then Headless/service/forwarding.
 
 ### First official capability migrations
 
@@ -145,4 +155,5 @@ Choose one per PR based on real evidence:
 - TUN/FakeIP/global route/DNS mutation;
 - Android/mobile;
 - remote profile marketplace;
+- arbitrary custom Gateway as a first-run/default UI;
 - any terminal-compliance bypass or trusted-process spoofing.

--- a/docs/architecture/2.0-cross-project-feature-map.md
+++ b/docs/architecture/2.0-cross-project-feature-map.md
@@ -1,0 +1,148 @@
+# HKUST(GZ) Connect 2.0 cross-project feature and implementation map
+
+This map compares implementation structure, not feature marketing. A source path proves only that code exists;
+it does not prove that a specific school enables or supports the capability.
+
+## Fixed baselines
+
+- EasyConnect: installed-mutated macOS 7.6.7 static observation plus existing sanitized Linux/Windows
+  baselines;
+- zju-connect: public source commit `2c71a34c17ea7ecf04c5fe862c4c315344128653`;
+- HKUST(GZ) Connect: production source `ed47f93f6594c7ae41ef344f08fa0aa6b5c47fc2`.
+
+## 1. Product composition, profile and session
+
+| Capability | EasyConnect 7.6.7 implementation | zju-connect implementation | Current HKUST(GZ) Connect | 2.0 independent implementation |
+| --- | --- | --- | --- | --- |
+| Product composition | Electron portal delegates to local ECAgent, monitor, privileged VPN service and modules | Go `main` builds config, protocol client, stack, resolver, dialer and local services | Electron Main owns Rust child and Browser; Rust owns auth/L3/netstack/frontend | Keep Rust/Electron split; add profile-aware compiled provider composition, no vendor Agent/root daemon |
+| School/Gateway selection | Persists VPN address/history and server-provided configuration | CLI/TOML selects server, protocol and deployment flags | One hard-coded HKUST Gateway/config | `SchoolProfile` registry with HKUST preset and isolated local custom profile generated from user-confirmed Gateway origin |
+| Protocol selection | Static portal/Agent/module flow suggests family and service selection; runtime negotiation is not proven by this sample | `easyconnect` or `atrust` flag | One password + Modern L3 family | Closed `ProtocolFamily`; public probe identifies only a candidate auth surface, while authenticated runtime confirms L3/DNS/transport; unknown remains unsupported |
+| Runtime capability truth | ECAgent/server/UI states determine available flows | Mostly config/source capability; some runtime resource selection | Engine hello has fixed capability list; provider traits exist | Additive `CapabilitySnapshot`: compiled ∩ selected provider ∩ profile evidence ∩ ingress mode |
+| Session ownership | TWFID/Cookie/agent state shared across portal and local service | Client/session structs own cookies/tokens; optional client-data persistence | `AuthenticatedGatewaySession` stays inside Rust | Bind session to profile ID, Gateway origin, protocol family, profile epoch and Engine generation |
+| Logout/session switch | Static UI/state paths exist for explicit logout, passive logout and session-change windows; activation remains profile-dependent | Keepalive and client `Close` lifecycle; no comparable passive-logout/session-switch UI was observed | Typed stop/logout with cleanup status | Typed user logout, passive kick, session replacement and cleanup-secondary events per profile |
+
+## 2. Authentication
+
+| Capability | EasyConnect 7.6.7 implementation | zju-connect implementation | Current HKUST(GZ) Connect | 2.0 independent implementation |
+| --- | --- | --- | --- | --- |
+| Password | Web auth module + ECAgent RSA/CSRF/anti-replay flow | Easy `requestTwfID` + password login; aTrust `LoginMethod` | Independent Rust password provider; typed reject/indeterminate | Preserve as regression oracle; make provider selected by `ProtocolFamily` |
+| CAPTCHA | Separate image/config/login path | Easy writes image and reads terminal; aTrust browser/file modes | State recognized, no real provider | Generic image challenge held in Engine; UI receives bounded image handle/metadata; no fixed endpoint/length |
+| SMS | SDK acquire/cooldown/submit modules | Easy fixed secondary path; aTrust continuation/custom SMS paths | Generic challenge framework only | One school-observed provider at a time; Engine owns resend/cooldown/request budget |
+| TOTP/token | TOTP/rebind and token/radius UI paths | Easy TOTP; aTrust TOTP/radius/challenge; optional TOTP secret config | Generic token challenge only | User-entered one-time response only; never persist seed or print OTP |
+| Certificate | Certificate list/import/auth; ECAgentProxy integrates macOS certificate APIs | Easy P12 file/password flow; TLS validation remains unsafe upstream | Capability typed unsupported; exact website pin store is unrelated | System certificate/Keychain selector + provider adapter + standard PKI/leaf binding; no raw P12 path in Renderer |
+| USB Key/HID | Static source contains dedicated key/HID discovery, config, registration and login modules; school activation is unknown | No USB Key/HID implementation was observed | Typed unsupported | Separate platform credential provider only with approved hardware/profile; no process/USB monitoring shim |
+| SSO/QR/social | Static source contains domain SSO, WeChat, DingTalk and enterprise-WeChat UI/SDK paths; school activation is unknown | aTrust Gateway authentication supports CAS/OAuth2 callbacks only; no QR/social implementation was observed | Campus web SSO works inside isolated Browser; Gateway SSO unsupported | Separate minimal authentication partition, exact callback/state binding and provider-specific canary |
+| Auth continuation | UI/agent advances current auth/next-service chain | aTrust bounded continuation loop; Easy fixed secondary mapping | `AuthTransactionOwner`, v3 respond/resend/cancel, synthetic provider | Close production composition over `Authenticated | PendingTransaction | Terminal`; opaque provider state stays in Rust |
+| Secret handling | Portal/settings/logs/argv cross several layers | Secrets may be in flags/TOML/client data/logs | OS secure storage, stdin/private pipe, zeroize/redaction | Per-profile vault, no argv/TOML/raw log; origin/family are immutable profile identity and a changed origin creates a new isolated profile |
+
+## 3. Resources, browser and user workflow
+
+| Capability | EasyConnect 7.6.7 implementation | zju-connect implementation | Current HKUST(GZ) Connect | 2.0 independent implementation |
+| --- | --- | --- | --- | --- |
+| Resource catalogue | ECAgent/Web SDK normalizes groups, defaults and many resource classes | Easy parses resource XML into routing/DNS; aTrust accepts L3VPN resources | Bounded offline parser; built-in/custom resources in Campus Browser | Authenticated `ResourceProvider` with revision/expiry, opaque handles, profile/session binding and explicit unknown authorization |
+| Web resource/WebVPN | Static portal paths contain Web/EasyLink rewrite and browser/SSO flows; profile activation and wire behavior remain unknown | No Sangfor WebVPN backend; aTrust ignores WEB resources | Browser uses L3 proxy or Direct; WebVPN backend unsupported | Learn only from official parity on an L3-disabled profile; distinct `WebVpnExit`, never ordinary HTTP proxy fallback |
+| IP/L3 resource | Starts/query L3 service and applies server policy | Resource-aware L3 dial | Modern L3 tunnels all permitted frontend traffic | Compile reviewed server/user/profile policy into RoutingPolicyIR and pin Campus ingress to `CampusModernL3Exit` |
+| Per-app TCP resource | Static TCP service/module and app/resource-opener clues exist; runtime activation is unknown | aTrust per-app signed TCP tunnel; Easy cannot use it | Unsupported | Separate `TcpResourceExit` only after school evidence; never fake trusted-process/compliance attributes |
+| SSO resource | Static portal paths inject/rewrite SSO state and open resources; exact runtime behavior requires profile parity | CAS/OAuth2 authenticates the aTrust Gateway only; no resource-level SSO opener was observed | Browser preserves same-profile Cookie/POST/SAML | Profile-scoped Browser partition and strict origin/callback policy; no hidden arbitrary credential injection |
+| File/FTP/mail/app | Static portal source contains typed opener/native-integration paths; runtime activation is unknown | Resource parsing may route supported network endpoints | Browser/SSH/SOCKS cover ordinary network access | Model resource capability; open only through allowlisted OS/browser actions; no ActiveX/native automation by default |
+| RemoteApp | RSession/CSClient and clipboard/audio/input components | No equivalent official RemoteApp backend | Unsupported | Separate optional product/backend and threat model; never coupled to core 2.0 release |
+| Campus browser UX | Portal has multiple controlled windows, tray resources and external browser opening | Primarily CLI/local proxy; no equivalent integrated browser | Sandboxed multi-tab Campus Browser, custom sites, password vault, cert pins, Campus/Direct rules | Promote to profile-scoped “Campus Workspace”; this is a differentiating core feature, not an EasyConnect clone |
+| Website passwords | Portal may retain/inject account data through settings/SSO flows | Not a comparable product feature | Encrypted exact-origin local vault with OTP/MFA safety | Namespace by profile + origin; never autofill across schools even when the origin is shared |
+| Certificate exceptions | Static Electron source contains a certificate-error bypass path; its runtime scope is not generalized beyond the observed handler | Several upstream TLS paths skip verification | Exact-origin/fingerprint user-confirmed pin only in Campus Browser | Keep current narrow model and namespace by profile; Gateway TLS exceptions remain administrator-reviewed, not Browser pins |
+
+## 4. Transport, DNS and routing
+
+| Capability | EasyConnect 7.6.7 implementation | zju-connect implementation | Current HKUST(GZ) Connect | 2.0 independent implementation |
+| --- | --- | --- | --- | --- |
+| Modern L3 | Privileged local modules/services | Easy special TLS address/send/receive channels | Independent verified Rust Modern L3 | Preserve; wrap as `CampusModernL3Exit` after Router ADR |
+| Legacy L3/TCP | Static DNS/L3VPN/TCP/VIRTUALLINE module and legacy-component topology; active family requires runtime evidence | Easy L3; aTrust L3/TCP families | Legacy parser/adapter lab only | Versioned backend only if a real profile requires it; do not widen existing special TLS backend |
+| aTrust | Official installed sample contains adjacent clues but activation unknown | Full auth/resource/node/L3/TCP implementation | No provider/backend | Independent family only after a school profile proves aTrust; never reuse compliance-spoofing behavior |
+| VPN DNS | Official DNS module and special resource configuration | Remote DNS, static mappings, cache/single-flight, UDP/TCP and public secondary | Gateway/profile campus DNS, cache/single-flight, UDP→same-server TCP, no public fallback | Make DNS policy profile-owned; Campus failures fail closed; Direct uses a separate resolver |
+| Domain/IP routing | Official resources/config drive L3/TCP/Web decisions | Resolver/Dialer carries resource context and may Direct | JS/PAC domain rules and destination safety | Canonical profile-scoped RoutingPolicyIR; explicit Exit, DNS and fallback policy; JS/PAC/Rust semantic parity |
+| Multi-line | Client UI/config and VIRTUALLINE/load-balance paths | Easy probes lines and recursively relogs; aTrust scores node groups | Endpoint parser only | `EndpointSet` + stickiness/hysteresis/failure history; fresh authentication by default; profile evidence required |
+| Keepalive/reconnect | Agent/service and portal service-state ownership | Easy update-session; aTrust heartbeat/reconnect; generic public-host keepalive | Engine/Desktop bounded retry, health supervisor and generation lifecycle | Profile/session-owned timers, typed cause, bounded backoff+jitter; never use public DNS name as tunnel keepalive |
+| Gateway underlay | Hidden inside privileged services | Explicit/optional auto interface binding | System route split across HTTP/token/data sockets; `.no_proxy()` enforced | One GatewayUnderlay identity/generation; Direct has an independent resolver/dialer |
+| Local SOCKS/HTTP | Static portal/Agent topology contains internal local control/proxy components | SOCKS defaults to wildcard `:1080` with `NoAuth` unless both credentials are set; HTTP defaults to wildcard `:1081` and has no authentication mechanism | Loopback-only strict auth plus explicit compatibility mode | Keep current security; pin external SOCKS/Clash/SSH to active Campus profile by default |
+| Port forwarding | Native service/resource opening | TCP/UDP forwarding and Shadowsocks options | SSH/SOCKS/PAC cover current needs | Optional authenticated loopback ingress only after real demand; not protocol parity |
+| TUN/FakeIP | Root service, legacy TUN/proxy hooks, DNS/route scripts | Experimental TUN/FakeIP/DNS hijack with platform mutations | Intentionally absent | Optional future ingress after Router/Exit/Underlay and 100-cycle residue tests; never default |
+
+## 5. Platform, operations and security
+
+| Capability | EasyConnect 7.6.7 implementation | zju-connect implementation | Current HKUST(GZ) Connect | 2.0 independent implementation |
+| --- | --- | --- | --- | --- |
+| Privileged services | LaunchAgent + root LaunchDaemon + setuid services + scripts/kexts | Root/admin required for TUN; otherwise foreground process | Unprivileged app/Engine, no global network mutation | Remain unprivileged by default; privileged helper only for a separately approved optional feature |
+| Update | Gateway/Agent checks and component/service update states | GitHub build/release workflows | GitHub release check; package verification | Independent signed manifest, staged rollout, rollback; Gateway can require compatibility but cannot execute code |
+| Notices/messages | Tray/resource messages, passive logout/rejection/expiry pages | Mostly CLI/log errors | Notification page and typed lifecycle errors | Profile-scoped `SessionNoticeProvider`, bounded redacted events and actionable UI |
+| Diagnostics | Broad portal/Agent logs and crash/heap paths | Rich debug, PCAP/keylog options and sensitive logs | Redacted 3-day logs, stable codes, no packet capture by default | Keep current privacy; add profile/correlation/Exit aggregate only, never hostname/full URL by default |
+| Tests/CI | Proprietary, not visible | Many Go tests exist but CI mainly builds | Rust/Desktop/Electron/package/secret/architecture/performance gates | Keep stronger gates; independently recreate behavior tests, never copy upstream fixtures |
+| Cross-platform | Legacy x86_64 mac app and privileged components | Go desktop/server/Android paths | macOS arm64/x64, Windows x64, Linux x64 packages | One neutral profile schema; each protocol/backend still needs platform package and real canary evidence |
+
+## 6. Multi-school product decision
+
+2.0 is a multi-school EasyConnect-compatible platform, not an HKUST-only fork and not a claim of universal
+compatibility.
+
+Login starts with:
+
+```text
+School / organization
+  ├── HKUST(GZ) — reviewed built-in profile
+  └── Other — user enters an HTTPS Gateway domain/port
+```
+
+For `Other`, the application performs credential-free discovery first, shows the normalized Gateway and a
+candidate recognized public login surface, then asks for explicit confirmation before displaying credential
+fields. It explicitly marks L3/DNS/transport as requiring authenticated runtime confirmation and never
+automatically submits a password while guessing providers/endpoints.
+
+Custom Gateway discovery is unavailable until the profile identity, provider composition, storage migration
+and active-profile isolation foundations are complete. Its own admission gate must validate every resolved
+A/AAAA and CNAME result (including IPv4-mapped IPv6) against the destination policy, reject DNS changes that
+escape the validated set, bind every actual outer Gateway HTTP/special-TLS socket to a validated address, verify
+the peer, and retain the confirmed hostname for TLS SNI and certificate verification. Probe Cookies/session
+state are destroyed. Any ambiguity fails closed before profile creation or a real custom-Gateway canary.
+
+Every school/custom Gateway receives isolated:
+
+- VPN credential vault;
+- Browser partition/Cookies/localStorage;
+- website credential vault;
+- certificate trust store;
+- routing rules/resources/DNS policy/logs;
+- profile epoch and Engine generation.
+
+Built-in profiles may ship reviewed DNS/resource/branding policy. Custom profiles are visibly unverified and
+default to standard PKI, an app-owned neutral page, Engine-native health only, no DNS fallback, no built-in
+routes/resources, no Gateway-driven updater and no system mutation.
+
+## 7. Priority synthesis
+
+### Foundation required before a second real school
+
+1. P1: SchoolProfile/GatewayOrigin/ProtocolFamily and the single-HKUST profile registry;
+2. P2: production provider composition and capability snapshot bound to profile identity;
+3. P3: profile-scoped encrypted storage and journaled legacy HKUST migration;
+4. P4: ActiveProfileCoordinator and Browser partition isolation;
+5. P5: validated Gateway connector and one-shot confirmation transaction;
+6. P6: safe credential-free custom Gateway discovery and isolated local profile;
+7. P7: profile-scoped RoutingPolicyIR;
+8. P8/P9: Router/Exit ADR and behavior-preserving Campus adapter.
+
+### First official capability migrations
+
+Choose one per PR based on real evidence:
+
+1. authenticated resource catalogue;
+2. passive notice/password-expiry/update reason;
+3. first actually enabled MFA method;
+4. typed multi-line/service state;
+5. L3-disabled WebVPN.
+
+### Explicitly deferred
+
+- aTrust without a real school profile;
+- RemoteApp;
+- TUN/FakeIP/global route/DNS mutation;
+- Android/mobile;
+- remote profile marketplace;
+- any terminal-compliance bypass or trusted-process spoofing.

--- a/docs/architecture/2.0-vision.md
+++ b/docs/architecture/2.0-vision.md
@@ -1,17 +1,17 @@
-# HKUST(GZ) Connect 2.0 Architecture Vision
+# Campus Connect 2.0 Product and Architecture Vision
 
 状态：Vision；不授权当前直接实现 2.0 production 功能。
 
 ## 1. Product definition
 
-2.0 的目标是一个面向多学校/组织、以 EasyConnect capability provider 为协议入口、以
-profile-scoped校园浏览器、可解释 Routing Engine 和受控 Exit 为网络核心、默认保持
-proxy-first 的校园访问平台。
+2.0 的目标是 **Campus Workspace + Secure Access Runtime**。普通学生首先看到资源搜索、
+收藏、最近访问、分类与通知；科研/开发用户按需展开SSH、代理、Jupyter、数据库、转发和
+Headless能力；EasyConnect/aTrust provider、Routing、Exit与Underlay属于底层运行时。
 
-它提供reviewed学校profile以及“Other → 输入HTTPS Gateway → 无凭据兼容性探测 → 确认后
-登录”的路径。HKUST(GZ)是首个reviewed profile，而不是产品边界。每个profile的VPN凭据、
-Browser partition、网站密码、certificate pin、路由、资源、DNS策略和事件生命周期必须隔离；
-Gateway origin或protocol family变化必须创建新profile，不能原地复用旧安全namespace。
+HKUST(GZ)是首个reviewed profile，而不是产品边界。普通学校选择器只显示reviewed profiles；
+实验性的`Other` Gateway在第二个reviewed school完成后才进入高级设置。每个profile/account
+workspace的VPN凭据、Browser partition、网站密码、certificate pin、收藏/最近、路由、资源、
+DNS策略和事件生命周期必须隔离；Gateway origin或protocol family变化必须创建新profile。
 
 它不是 zju-connect 的 Rust 翻版，不是默认全局 VPN/TUN，也不以复刻厂商所有行为为
 成功标准。
@@ -19,15 +19,31 @@ Gateway origin或protocol family变化必须创建新profile，不能原地复�
 三项目实现差异见
 [`2.0-cross-project-feature-map.md`](2.0-cross-project-feature-map.md)，多学校profile与自定义
 Gateway安全边界见
-[`ADR-0003`](../adr/0003-multi-school-profile-and-custom-gateway.md)。
+[`ADR-0003`](../adr/0003-multi-school-profile-and-custom-gateway.md)。产品、账户作用域和资源模型见
+[`2.0-product-definition.md`](../product/2.0-product-definition.md)、
+[`ADR-0004`](../adr/0004-profile-account-workspace-scope.md)和
+[`resource-domain-model.md`](resource-domain-model.md)。
 
 ## 2. Target topology
 
 ```text
-Product shell / School picker
+Student Home / Campus Workspace / Developer Access / Connection Center / Headless
             │
             ▼
-ProfileRegistry + ActiveProfileContext
+ProfileRegistry + ActiveProfileContext + ActiveAccountContext
+            │
+            ▼
+Resource search / catalogue / favorites / recent
+            │
+            ▼
+ResourceDescriptorView + non-authorizing resourceHandle
+            │
+            ▼
+ResourceLaunchBroker → short-lived one-use LaunchHandle
+├── Campus Workspace
+├── SSH configuration / terminal action
+├── scoped TCP/UDP forward
+└── allowlisted external action
             │
             ▼
 Ingress
@@ -90,9 +106,11 @@ authorized observation
 禁止复制 proprietary source/binary/resource，禁止将 zju-connect 源码、fixture 或二进制
 变成运行时依赖。研究记录必须标注 `Observed`、`Confirmed`、`Hypothesis`、`Unknown`。
 
-### 3.1 Safe custom Gateway onboarding
+### 3.1 Advanced custom Gateway onboarding (P11)
 
-`Other`不是任意URL加载器。它先规范化HTTPS域名/端口，再解析并验证每个有界
+`Other`不是首发入口或任意URL加载器。P5先为内置HKUST建立行为不变的安全connector；P10
+用第二个reviewed school证明多学校隔离；P11才在高级设置中开放experimental/unverified
+onboarding。届时它先规范化HTTPS域名/端口，再解析并验证每个有界
 CNAME/A/AAAA结果；只要解析集合含private、loopback、link-local、multicast、unspecified或
 其他不允许地址，整个请求fail-closed。实际socket绑定到已验证地址，原hostname只用于SNI与
 标准PKI，并校验连接后的peer address，防止解析与连接之间DNS rebinding。该安全connector
@@ -105,9 +123,9 @@ address-control/send/receive及任何认证后下发的外层endpoint；L3隧道
 runtime `CapabilitySnapshot`确认。
 
 Main持有的短期一次性confirmation绑定exact origin、candidate auth family、draft profile与过期
-时间。确认被消费并生成新的opaque custom profile后，系统先验证profile/origin/provider/config/
-credential binding，最后才解密密码。Custom profile始终标为unverified，使用中立起始页和
-Engine-native health，不继承HKUST网址、Cookie、pin、rule或health target。
+时间。确认被消费并生成新的opaque custom profile/account workspace后，系统先验证profile/
+account/origin/provider/config/credential binding，最后才解密密码。Custom profile始终标为
+unverified，使用中立起始页和Engine-native health，不继承reviewed profile数据。
 
 ## 4. Routing Engine
 
@@ -123,6 +141,7 @@ RouteIntent
   initiatorClass
   topLevelSite
   policyProfile
+  accountScope
 ```
 
 输出：
@@ -132,8 +151,10 @@ RouteDecision
   exitId
   decisionSource
   profileId / profileRevision
+  accountId / accountRevision
   policyRevision
   profileEpoch
+  accountEpoch
   routerGeneration
   selectedExitGeneration?
   safetyClass
@@ -251,18 +272,26 @@ UnderlayObservation
 8. future TUN 必须 bypass/protect Gateway 和 local control socket；
 9. update/telemetry 路径必须显式归类。
 
-## 9. Campus Browser
+## 9. Campus Workspace and resource-first home
 
 保留：一个持久 Session、按域名切换、SSO/Cookie/POST 连续性、切换前 request gate、
 失败时 fail-closed。
 
 升级：
 
+- Browser partition、网站密码、证书决策、收藏/最近和用户规则归属active account workspace；
+- 首页以搜索、分类、收藏、最近访问和通知为主，连接状态退居Connection Center；
+- `ResourceDescriptorView`只暴露展示字段和non-authorizing `resourceHandle`；显式launch后才由Main
+  准备并消费短期一次性`LaunchHandle`；
+- Web/SSH/TCP/Jupyter/Database/File等类型按required capability/Exit启动，不支持时typed fail-closed；
 - Campus 和 Direct 都使用受控 Exit；
 - resolved-address safety；
 - UI 展示 Exit、decision source 和 policy revision；
 - 错误区分 DNS、policy denied、Exit unavailable、TLS 和网站自身失败；
 - route choice 记录域名/规则元数据，不记录完整敏感 URL。
+
+普通模式不展示SOCKS、PAC、L3、Underlay、Exit或generation术语；高级模式和诊断页才展示
+路由来源、CapabilitySnapshot、Gateway/DNS/Exit状态与Headless配置。
 
 ## 10. TUN decision
 
@@ -292,6 +321,7 @@ loopback 代替真实 Gateway。
 - resolved-address destination policy；
 - validated Gateway address-to-socket binding and one-shot confirmation；
 - Engine-owned auth secret/session lifecycle；
+- profile/account/workspace scoped credentials, Browser state, pins, routes, resources and events；
 - localhost authentication and owner-only files；
 - sandboxed Browser/Renderer；
 - signed/reversible privileged component only when a separately approved feature requires it；
@@ -309,22 +339,24 @@ policy revision、underlay identity、retry count 和 stable failure code。
 
 ```text
 1.x Architecture Frozen
-  -> SchoolProfile/GatewayOrigin + single HKUST registry
+  -> SchoolProfile/GatewayOrigin + CampusAccount/WorkspaceScope placeholders
   -> behavior-preserving production provider composition seam
-  -> profile-scoped storage migration
-  -> ActiveProfileCoordinator + Browser isolation
-  -> safe Gateway dialer + one-shot confirmation
-  -> safe credential-free custom Gateway onboarding
-  -> profile-scoped offline RoutingPolicyIR + Router ADR/prototype
-  -> behavior-preserving Campus Exit adapter
-  -> evidence-gated first capability and stability
-  -> ControlledDirectExit activation
-  -> no-op then explicit Gateway UnderlayPolicy
-  -> evidence-gated additional Exit/provider
-  -> conditional TUN ingress
+  -> profile/account/workspace storage migration
+  -> ActiveProfile/ActiveAccount coordinator + Browser isolation
+  -> behavior-preserving HKUST GatewayConnectorGeneration
+  -> account-scoped RoutingPolicyIR
+  -> Router ADR/test-only ec-router + CampusModernL3Exit adapter
+  -> ResourceDescriptor + Campus Workspace Beta
+  -> first evidence-gated HKUST capability
+  -> second reviewed school profile
+  -> advanced custom Gateway onboarding
+  -> ControlledDirectExit + explicit Underlay + evidence-backed multi-line
+  -> CLI/headless/service + scoped forwarding
+  -> evidence-gated aTrust/WebVPN/TUN/mobile/RemoteApp products
 ```
 
 Provider composition、offline IR和test-only Router prototype不提升任何production capability。
 每个production activation仍必须独立满足真实证据、parity、canary和rollback门。
 
-不得把 MFA、Underlay、TUN、aTrust、多线路和目录重排放进一个版本。
+不得把 MFA、Underlay、TUN、aTrust、多线路、Headless和资源目录协议放进一个不可独立回滚的
+大版本提交。

--- a/docs/architecture/2.0-vision.md
+++ b/docs/architecture/2.0-vision.md
@@ -34,16 +34,18 @@ Route Evaluator
             ▼
 Loop Guard / Exit Resolver
 ├── ControlledDirectExit
-├── CampusModernL3Exit
-├── ConditionalWebVpnExit
-└── Future evidence-gated campus backend
-            │
-            ▼
-Endpoint / Underlay
-├── hostname + TLS identity
-├── explicit underlay policy
-├── endpoint health/stickiness
-└── generation invalidation
+│     └── DirectResolver + ControlledDirectDialer
+└── Campus Exit family
+      ├── CampusModernL3Exit
+      ├── ConditionalWebVpnExit
+      └── Future evidence-gated campus backend
+              │
+              ▼
+      Gateway Endpoint / Underlay
+      ├── hostname + TLS identity
+      ├── explicit underlay policy
+      ├── endpoint health/stickiness
+      └── generation invalidation
 ```
 
 关键区分：
@@ -51,6 +53,7 @@ Endpoint / Underlay
 - TUN 是 Ingress，不是 Exit；
 - Modern L3、WebVPN 和 Direct 是 Exit；
 - multi-line 是一个 Campus Exit 内的 endpoint selection；
+- Gateway Underlay只属于Campus Gateway control/data sockets；Direct有独立resolver/dialer；
 - 认证 provider 和 Exit/Transport backend 是不同扩展轴。
 
 ## 3. EasyConnect compatibility
@@ -263,12 +266,17 @@ policy revision、underlay identity、retry count 和 stable failure code。
 
 ```text
 1.x Architecture Frozen
-  -> evidence-gated first real MFA provider and stability
-  -> versioned RoutingPolicyIR
-  -> ControlledDirectExit
-  -> no-op then explicit UnderlayPolicy
+  -> behavior-preserving production provider composition seam
+  -> offline versioned RoutingPolicyIR + Router ADR/prototype
+  -> behavior-preserving Campus Exit adapter
+  -> evidence-gated first capability and stability
+  -> ControlledDirectExit activation
+  -> no-op then explicit Gateway UnderlayPolicy
   -> evidence-gated additional Exit/provider
   -> conditional TUN ingress
 ```
+
+Provider composition、offline IR和test-only Router prototype不提升任何production capability。
+每个production activation仍必须独立满足真实证据、parity、canary和rollback门。
 
 不得把 MFA、Underlay、TUN、aTrust、多线路和目录重排放进一个版本。

--- a/docs/architecture/2.0-vision.md
+++ b/docs/architecture/2.0-vision.md
@@ -4,15 +4,32 @@
 
 ## 1. Product definition
 
-2.0 的目标是一个以 EasyConnect capability provider 为协议入口、以可解释 Routing
-Engine 和受控 Exit 为网络核心、默认保持 proxy-first 的校园访问平台。
+2.0 的目标是一个面向多学校/组织、以 EasyConnect capability provider 为协议入口、以
+profile-scoped校园浏览器、可解释 Routing Engine 和受控 Exit 为网络核心、默认保持
+proxy-first 的校园访问平台。
+
+它提供reviewed学校profile以及“Other → 输入HTTPS Gateway → 无凭据兼容性探测 → 确认后
+登录”的路径。HKUST(GZ)是首个reviewed profile，而不是产品边界。每个profile的VPN凭据、
+Browser partition、网站密码、certificate pin、路由、资源、DNS策略和事件生命周期必须隔离；
+Gateway origin或protocol family变化必须创建新profile，不能原地复用旧安全namespace。
 
 它不是 zju-connect 的 Rust 翻版，不是默认全局 VPN/TUN，也不以复刻厂商所有行为为
 成功标准。
 
+三项目实现差异见
+[`2.0-cross-project-feature-map.md`](2.0-cross-project-feature-map.md)，多学校profile与自定义
+Gateway安全边界见
+[`ADR-0003`](../adr/0003-multi-school-profile-and-custom-gateway.md)。
+
 ## 2. Target topology
 
 ```text
+Product shell / School picker
+            │
+            ▼
+ProfileRegistry + ActiveProfileContext
+            │
+            ▼
 Ingress
 ├── Campus Browser
 ├── SOCKS5
@@ -73,6 +90,25 @@ authorized observation
 禁止复制 proprietary source/binary/resource，禁止将 zju-connect 源码、fixture 或二进制
 变成运行时依赖。研究记录必须标注 `Observed`、`Confirmed`、`Hypothesis`、`Unknown`。
 
+### 3.1 Safe custom Gateway onboarding
+
+`Other`不是任意URL加载器。它先规范化HTTPS域名/端口，再解析并验证每个有界
+CNAME/A/AAAA结果；只要解析集合含private、loopback、link-local、multicast、unspecified或
+其他不允许地址，整个请求fail-closed。实际socket绑定到已验证地址，原hostname只用于SNI与
+标准PKI，并校验连接后的peer address，防止解析与连接之间DNS rebinding。该安全connector
+覆盖custom profile的discovery/auth/config/authenticated-resource/logout/session-keepalive/token/
+address-control/send/receive及任何认证后下发的外层endpoint；L3隧道内部的校园私网目的地址
+属于另一策略域。
+
+探测使用一次性、无Cookie jar/缓存/环境代理的client，并在结束后丢弃全部Set-Cookie、TLS和
+会话状态。探测最多证明可识别的公开登录入口；L3、DNS、资源和Transport能力只能在认证后由
+runtime `CapabilitySnapshot`确认。
+
+Main持有的短期一次性confirmation绑定exact origin、candidate auth family、draft profile与过期
+时间。确认被消费并生成新的opaque custom profile后，系统先验证profile/origin/provider/config/
+credential binding，最后才解密密码。Custom profile始终标为unverified，使用中立起始页和
+Engine-native health，不继承HKUST网址、Cookie、pin、rule或health target。
+
 ## 4. Routing Engine
 
 中立输入：
@@ -95,12 +131,18 @@ RouteIntent
 RouteDecision
   exitId
   decisionSource
+  profileId / profileRevision
   policyRevision
-  engineGeneration
+  profileEpoch
+  routerGeneration
+  selectedExitGeneration?
   safetyClass
   dnsPolicy
   fallbackPolicy
 ```
+
+These runtime generations belong to evaluation context and the decision envelope, not to canonical persisted
+`RoutingPolicyIR`.
 
 默认优先级：
 
@@ -248,6 +290,7 @@ loopback 代替真实 Gateway。
 - no implicit environment proxy；
 - no global DNS/route/proxy mutation by default；
 - resolved-address destination policy；
+- validated Gateway address-to-socket binding and one-shot confirmation；
 - Engine-owned auth secret/session lifecycle；
 - localhost authentication and owner-only files；
 - sandboxed Browser/Renderer；
@@ -266,8 +309,13 @@ policy revision、underlay identity、retry count 和 stable failure code。
 
 ```text
 1.x Architecture Frozen
+  -> SchoolProfile/GatewayOrigin + single HKUST registry
   -> behavior-preserving production provider composition seam
-  -> offline versioned RoutingPolicyIR + Router ADR/prototype
+  -> profile-scoped storage migration
+  -> ActiveProfileCoordinator + Browser isolation
+  -> safe Gateway dialer + one-shot confirmation
+  -> safe credential-free custom Gateway onboarding
+  -> profile-scoped offline RoutingPolicyIR + Router ADR/prototype
   -> behavior-preserving Campus Exit adapter
   -> evidence-gated first capability and stability
   -> ControlledDirectExit activation

--- a/docs/architecture/resource-domain-model.md
+++ b/docs/architecture/resource-domain-model.md
@@ -1,0 +1,654 @@
+# Resource domain model
+
+Status: 2.0 architecture contract; no production capability is enabled by this document.
+
+This document defines the neutral resource model for the future Campus Workspace. It deliberately separates:
+
+- a resource being present in a package, local settings or an authenticated catalogue;
+- the source and trust class of that resource;
+- whether the current profile/account is authorized to use it;
+- whether this build and current session have the required capability and Exit;
+- the private material required to launch it.
+
+None of those facts implies another. In particular, a parsed server field, a known resource type or an opaque
+launch target does not prove that HKUST(GZ), another school or the current production build supports it.
+
+## 1. Current evidence boundary
+
+The current implementation has three relevant but separate foundations.
+
+### Desktop shortcuts
+
+`desktop/lib/campus-resources.js`, `campus-resource-store.js` and `campus-resource-ipc.js` implement a bounded
+local Web-shortcut model:
+
+```text
+id / name / description / url / route(campus|direct) / builtin
+```
+
+- built-in and local resources are merged into a maximum of 32 visible entries;
+- local entries are transactionally created, edited, reordered and deleted;
+- built-ins are read-only;
+- only HTTP(S) URLs are accepted through the Campus Browser URL normalizer;
+- a Direct resource targeting a local, private or special host is forced to Campus or rejected;
+- the control Renderer currently receives the resource URL;
+- `CampusBrowserManager.open()` currently resolves the route and then calls `ensureConnected()` before opening,
+  including for a resource labelled Direct.
+
+This is a useful compatibility model, not the final resource domain.
+
+### Rust catalogue parser
+
+`independent/src/resource_catalogue.rs` and `independent/spec/RESOURCE_CATALOGUE_V1.md` provide a bounded offline
+parser. It already separates a sanitized catalogue view from non-serializable `ResourceLaunchTarget` values
+resolved by opaque handles. Unknown authorization values become only `declared_unverified`; they never become
+allow or deny decisions.
+
+Production still uses `UnsupportedResourceProvider`. The offline provider proves parser and redaction behavior
+only. It does not prove authenticated retrieval, authorization semantics, catalogue refresh, expiry or launch.
+
+### CLI and advanced-access building blocks
+
+The current product provides an authenticated loopback SOCKS/HTTP frontend, generated Clash/PAC/SSH
+configuration and `ec-proxy-command` for an SSH-style byte stream. It does not currently provide a generic
+resource launcher, scoped TCP/UDP forwarding, database or Jupyter launch orchestration, file-resource opening,
+Remote Desktop or WebVPN.
+
+The model below must therefore preserve the current Web behavior while representing all other types honestly as
+unsupported or unavailable until their own implementation and evidence gates pass.
+
+## 2. Ownership and scope
+
+Every resource belongs to exactly one immutable scope:
+
+```text
+ResourceScope
+  profileKey
+  accountKey
+  workspaceKey
+```
+
+- `profileKey` identifies the reviewed or local school profile;
+- `accountKey` identifies one campus account without exposing its username;
+- `workspaceKey` owns Browser state, favorites, recent activity and user presentation overrides.
+
+Raw user input is never used as a path component. Moving a resource between profiles or accounts creates a new
+resource identity; it does not copy server authorization, launch material, Cookies, pins or history.
+
+The control Renderer receives only a bounded `ResourceDescriptorView`. The full descriptor and exact target
+remain Main/Engine-owned. A managed Browser may eventually navigate to an exact Web target, but that target is
+never returned through the ordinary resource-list IPC, telemetry or logs.
+
+## 3. Internal descriptor
+
+The following is a logical contract, not a claim that these exact Rust or JavaScript types already exist.
+
+```text
+ResourceDescriptorInternal
+  schemaVersion
+  resourceHandle
+  scope: ResourceScope
+
+  source
+    kind
+    providerKey?
+    sourceIdentityRef
+
+  trustClass
+  resourceType
+
+  display
+    name
+    description?
+    category?
+    tags[]
+    iconKey?
+
+  requirements
+    requiredCapabilities[]
+    requiredExit
+
+  authorization
+    state
+    decisionAvailable
+    decisionRevision?
+    decisionExpiresAt?
+    privateEvidenceRef?
+
+  catalogue
+    catalogueHandle
+    catalogueRevision
+    descriptorRevision
+    sessionGeneration?
+    fetchedAt?
+    expiresAt?
+
+  privateLaunchTarget
+```
+
+### Resource identity
+
+`resourceHandle` is an opaque, source-namespaced identity used by views, favorites and recent activity. It is
+not an authorization bearer and is not sufficient to launch anything.
+
+- a built-in handle derives from a reviewed packaged manifest identity;
+- a local handle is randomly generated and retained with the local record;
+- a server handle is derived inside the provider from its private source identity plus profile/provider scope.
+
+Raw vendor identifiers, URLs, hosts and user data never become the public handle. Reuse of a handle after a
+catalogue revision does not bypass revision, expiry or authorization checks.
+
+### Source
+
+`ResourceSourceKind` is one of:
+
+| Source | Meaning | Mutability |
+| --- | --- | --- |
+| `builtin_reviewed` | Shipped in a reviewed, packaged profile manifest | Read-only; changes with a reviewed app/profile revision |
+| `authenticated_server` | Retrieved by an authenticated, evidence-backed `ResourceProvider` | Read-only to the user; session/revision/expiry bound |
+| `local_user` | Entered on this computer by the user | Editable and deletable within its profile/account scope |
+
+Sources use separate identity namespaces. A server or local record cannot override a built-in merely by copying
+its ID, label or target. Equal URLs do not erase provenance; deduplication is a presentation decision and must
+retain the source/trust distinction.
+
+### Trust class
+
+`ResourceTrustClass` describes provenance, not permission or target safety:
+
+| Trust class | Meaning |
+| --- | --- |
+| `reviewed_builtin` | Manifest and target were reviewed for the packaged profile |
+| `authenticated_server` | Record arrived through an authenticated provider session; its value semantics may still be unknown |
+| `user_supplied` | Record was entered locally by the user |
+| `unverified` | Provenance or required semantics are insufficient for a stronger label |
+
+An authenticated server record is not automatically authorized. A reviewed built-in is still subject to current
+destination, certificate, capability and Exit checks. A local-user record is not permitted to weaken those
+checks.
+
+### Resource type
+
+`ResourceType` is a closed, versioned enum:
+
+```text
+web
+ssh
+tcp
+udp
+database
+jupyter
+file
+remote_desktop
+webvpn
+unsupported
+```
+
+`unsupported` quarantines a bounded record whose source type has no reviewed neutral mapping. It is visible only
+when useful to explain why it cannot be opened and is never launchable.
+
+The listed types are product-domain categories, not vendor numeric mappings. A vendor adapter may map a source
+value to one of them only after the value semantics are established by authorized evidence. Unknown values must
+not be guessed from apparent names, port numbers or URL shapes.
+
+### Private launch target
+
+`privateLaunchTarget` is a provider-owned, non-serializable, redacted-debug value. Its possible neutral shapes
+include:
+
+```text
+WebTarget            exact URL and intended route
+SshTarget            host, port and optional non-secret user hint
+TcpTarget            host and reviewed port policy
+UdpTarget            host and reviewed port policy
+DatabaseTarget       engine/display hint plus TcpTarget; never a database password
+JupyterTarget        private Web or Tcp composition; query tokens remain private
+FileTarget           provider-owned location and reviewed launcher family
+RemoteDesktopTarget  provider/backend-owned reference
+WebVpnTarget         provider-owned resource reference for WebVpnExit
+```
+
+These shapes do not define a vendor wire format. They must not implement ordinary `Serialize`, `Display` or
+value-bearing `Debug`. Session-bound target strings use zeroizing storage where practical.
+
+## 4. Renderer view
+
+The list/search API returns only:
+
+```text
+ResourceDescriptorView
+  schemaVersion
+  resourceHandle
+  sourceKind
+  trustClass
+  resourceType
+
+  name
+  description?
+  category?
+  tags[]
+  iconKey?
+
+  requiredCapabilities[]
+  requiredExit
+  authorizationState
+  launchAvailability
+  revisionToken
+  expiresAt?
+
+  favorite
+  lastOpenedAt?
+```
+
+The view never contains:
+
+- raw vendor identifiers or authorization fields;
+- a server host, private IP, URL path, query, fragment or embedded credential;
+- Cookie, token, CSRF, TwfID, session ID or transport token;
+- a command line, executable path or arbitrary icon/asset URL;
+- an internal provider/config reference.
+
+Server-provided display strings are presentation-only. They are bounded, control-character-free and escaped as
+text. `iconKey` resolves only to a packaged allowlisted asset. Labels, tags and handles are excluded from normal
+diagnostic logs.
+
+A local-resource editor may receive a separate `LocalResourceDraftView` containing the user's own editable
+fields. That editor contract cannot be used to retrieve or mutate built-in or server launch material.
+
+## 5. Capabilities and Exit
+
+`requiredCapabilities` contains stable, bounded capability identifiers. The effective set is derived from the
+compiled implementation, selected provider/backend, current profile and current ingress mode. Profile JSON or a
+resource record cannot promote a capability to Supported.
+
+Candidate neutral identifiers include:
+
+```text
+resource.catalogue
+resource.authorization
+frontend.campus_workspace
+frontend.ssh_proxy_command
+frontend.scoped_tcp_forward
+frontend.scoped_udp_forward
+frontend.file_launcher
+frontend.remote_desktop
+transport.l3
+transport.tcp_resource
+transport.web_vpn
+```
+
+Names in this document are reserved architecture vocabulary; only existing provider capability names are
+currently implemented. New identifiers require the normal provider/contract review.
+
+`requiredExit` is explicit and singular:
+
+```text
+direct
+campus_modern_l3
+tcp_resource
+webvpn
+unresolved
+```
+
+There is no implicit fallback. If `campus_modern_l3` is unavailable, a resource does not become Direct. If
+`webvpn` is unsupported, a WebVPN resource does not become an ordinary HTTP-proxy request. `unresolved` is
+non-launchable until a reviewed adapter selects an exact Exit.
+
+## 6. Authorization, revision and expiry
+
+`ResourceAuthorizationState` is one of:
+
+```text
+not_required
+not_declared
+declared_unverified
+allowed
+denied
+expired
+withdrawn
+unavailable
+```
+
+Rules:
+
+- `allowed` and `denied` may be produced only by a reviewed, profile-specific authorization adapter with
+  observed value semantics;
+- the current offline Rust parser produces only `not_declared` or `declared_unverified`, with
+  `decisionAvailable = false`;
+- apparent booleans, numbers, strings or missing fields are never interpreted heuristically;
+- a required decision that is unknown, unverified, unavailable or expired fails closed;
+- local and built-in resources may use `not_required`, but this bypasses neither destination policy nor runtime
+  capability checks;
+- disconnect, profile/account switch, provider replacement or session-generation change invalidates every
+  server authorization decision and launch handle tied to the old session.
+
+Revision and expiry are source-specific:
+
+| Source | Revision | Expiry |
+| --- | --- | --- |
+| Built-in | Packaged profile/app manifest revision | Valid until that reviewed manifest is replaced or withdrawn |
+| Local | Owner-only settings transaction revision | No implicit expiry; revalidated on every edit and launch |
+| Server | Provider catalogue + descriptor + authorization revisions | Explicit provider expiry when evidenced; otherwise session-bound and never durable authority |
+
+The view receives only an opaque `revisionToken`. Raw server revisions and authorization evidence remain private.
+An expired or superseded catalogue may preserve presentation tombstones for favorites, but cannot authorize a
+launch.
+
+## 7. Opaque LaunchHandle
+
+`resourceHandle` identifies a resource. `LaunchHandle` authorizes one prepared launch. They are different.
+
+A `LaunchHandle` is:
+
+- random and non-self-describing;
+- Main/Engine-owned and stored in a bounded in-memory table;
+- short-lived and normally single-use;
+- bound to profile, account, workspace, profile epoch, Engine generation, descriptor revision, catalogue
+  revision, authorization revision, required Exit and requested action;
+- invalidated by disconnect, route-policy change, profile/account switch, resource refresh, timeout, cancellation
+  or first consumption;
+- absent from settings, clipboard, history, crash reports, URLs and logs.
+
+The handle encodes no target. A MACed or encrypted target blob is not a substitute for the owner-side record.
+
+## 8. Launcher boundary
+
+### Components
+
+```text
+Control Renderer
+  -> launch-resource(resourceHandle, action)
+Trusted IPC boundary
+  -> ResourceCatalogueCoordinator
+  -> ResourceLaunchBroker
+       -> WorkspaceWebLauncher
+       -> SshConfigLauncher
+       -> ScopedTcpForwardLauncher
+       -> ScopedUdpForwardLauncher
+       -> FileResourceLauncher
+       -> RemoteDesktopLauncher
+       -> WebVpnLauncher
+```
+
+The Renderer never chooses an executable, host, port, raw URL or Exit at launch time. It chooses only a bounded
+action allowed by the view, such as `open`, `copy_config`, `create_temporary_endpoint` or `cancel`.
+
+### Launch transaction
+
+```text
+validate trusted IPC sender and exact schema
+  -> snapshot active profile/account/workspace and generations
+  -> resolve resourceHandle in the owning catalogue
+  -> verify source, revision, expiry and authorization
+  -> verify required capabilities and exact Exit
+  -> resolve and validate the private target under that Exit's destination policy
+  -> prepare a bounded LaunchHandle and launcher-owned lease
+  -> atomically consume the LaunchHandle
+  -> execute the type-specific launcher
+  -> record only a sanitized outcome
+```
+
+If any snapshot changes before consumption, launch fails and the caller must request a new handle. Cancellation
+owns and closes every partial listener, Browser request, child process and temporary credential.
+
+### Type-specific behavior and current support boundary
+
+| Type | Intended launcher | Current implementation fact | Activation rule |
+| --- | --- | --- | --- |
+| Web | Managed Campus Workspace under an exact route/Exit | Built-in/local Web shortcuts exist; they currently pass raw URLs and always call `ensureConnected()` | P8 migrates current behavior behind a handle and may skip Engine connection for a validated Direct rule under the documented 1.x Chromium-DIRECT boundary; ControlledDirectExit later strengthens resolved-address ownership |
+| SSH | Generate/copy bounded SSH config or open an allowlisted terminal action | Generic SOCKS `ProxyCommand` and SSH config generation exist, but no resource-scoped SSH launcher | P8 Beta requires this launcher after resource target validation and profile/account/generation binding tests |
+| TCP | Temporary owner-scoped loopback forwarding lease | No generic scoped TCP-forward resource launcher exists | P8 Beta requires the bounded baseline after `frontend.scoped_tcp_forward`, strict ownership, timeout and cleanup gates pass |
+| UDP | Temporary owner-scoped loopback forwarding lease | No generic scoped UDP-forward resource launcher exists; strict proxy mode intentionally cannot authenticate SOCKS UDP datagrams | Requires a reviewed local authorization/ownership design; never inherit TCP assumptions |
+| Database | A typed presentation over a scoped TCP lease | No database launcher exists | Never stores database credentials; requires the TCP launcher and a reviewed database family hint |
+| Jupyter | Compose a scoped TCP lease and managed Web launch | No Jupyter launcher exists | Tokens remain private; requires both TCP and Web launch capabilities |
+| File | Reviewed platform/provider file launcher | No safe generic file-resource launcher exists | Each scheme/platform needs an allowlist and threat model; never call a shell with arbitrary input |
+| Remote Desktop | Separate optional backend/product | Unsupported and explicitly deferred | Requires independent protocol, sandbox, input/clipboard and release review |
+| WebVPN | `WebVpnExit` with provider-owned rewrite/session state | Typed backend slot exists but production backend is unsupported | Requires an L3-disabled real profile, authenticated provider evidence and parity; never fall back to HTTP proxy |
+
+Creating the descriptor types does not activate any launcher in this table.
+
+### Scoped forwarding lease
+
+A future TCP/UDP launcher must return a private `ForwardLease`, not a permanent public listener:
+
+```text
+ForwardLease
+  leaseHandle
+  loopbackEndpoint
+  profile/account/Engine generation
+  destination resourceHandle + revision
+  protocol
+  idleDeadline / absoluteDeadline
+```
+
+The listener is loopback-only, uses an ephemeral or explicitly reviewed local port, has one owner and is removed
+on logout, disconnect, profile/account switch, Engine restart, expiry or cancellation. It is never a LAN sharing
+feature. The view may expose the local endpoint only after the lease is ready; it never exposes the remote target.
+
+## 9. Search, favorites and recent activity
+
+These are Workspace overlays, not fields that mutate provider descriptors.
+
+### Search
+
+- indexes only bounded view fields: name, description, category, tags, type and source label;
+- never indexes private targets, URLs, hosts, authorization material or raw provider values;
+- operates locally and does not send queries to a Gateway or analytics service;
+- normalizes Unicode and locale deterministically while rendering source text escaped;
+- uses stable tie-breaking so refresh does not reorder equal results unpredictably;
+- may boost exact/prefix matches, favorites and recent successful launches, but not trust or authorization beyond
+  their explicit filters.
+
+### Favorites
+
+```text
+FavoriteEntry
+  workspaceKey
+  resourceHandle
+  sourceKind
+  pinnedAt
+  optional user label/category override
+```
+
+Favorites contain no launch target and grant no authority. A withdrawn, denied or expired server resource remains
+only as an unavailable tombstone until the user removes the favorite or the retention period expires.
+
+### Recent activity
+
+Recent activity records only successful, user-initiated launch completion:
+
+```text
+RecentResourceEntry
+  workspaceKey
+  resourceHandle
+  resourceType
+  sourceKind
+  launchedAt
+```
+
+It is bounded by count and retention, stored owner-only and cleared with the Workspace. Failed attempts may update
+aggregate diagnostics by stable error code, but do not record a target, query, hostname or secret-bearing URL.
+
+## 10. Source-specific policy
+
+### Built-in reviewed
+
+- loaded only from a packaged, hash-checked profile manifest;
+- read-only in the ordinary editor;
+- may provide bounded branding/category/icon metadata;
+- cannot contain credentials or arbitrary executable/script paths;
+- is revalidated against current destination, capability and Exit policy on every launch;
+- changes only through a reviewed manifest/app update and rollback contract.
+
+### Authenticated server
+
+- retrieved only by a production `ResourceProvider` owned by an authenticated session;
+- scoped to profile, account, provider, session generation and catalogue revision;
+- retains raw target and authorization material only in the provider/Engine;
+- requires explicit refresh, expiry and withdrawal behavior before production activation;
+- cannot overwrite built-ins or local records;
+- may be displayed as `authenticated_server`, but that label never means allowed;
+- cannot launch while authorization semantics are unknown when a decision is required.
+
+### Local user
+
+- created only through a type-specific, exact-schema editor;
+- initially remains Web-only during migration from the current model;
+- is validated on write and again on launch;
+- cannot select an unsupported capability, inject a provider ID, invent server authorization or supply an
+  executable/argument list;
+- remains isolated to one profile/account/workspace and is removed through a durable local transaction.
+
+## 11. Error model
+
+Launch and catalogue errors use stable, secret-free codes. Suggested categories are:
+
+```text
+RESOURCE_NOT_FOUND
+RESOURCE_SCOPE_CHANGED
+RESOURCE_REVISION_CHANGED
+RESOURCE_CATALOGUE_EXPIRED
+RESOURCE_WITHDRAWN
+RESOURCE_AUTHORIZATION_UNKNOWN
+RESOURCE_DENIED
+RESOURCE_CAPABILITY_UNSUPPORTED
+RESOURCE_CAPABILITY_UNAVAILABLE
+RESOURCE_EXIT_UNAVAILABLE
+RESOURCE_TARGET_REJECTED
+RESOURCE_LAUNCH_HANDLE_INVALID
+RESOURCE_LAUNCH_HANDLE_EXPIRED
+RESOURCE_LAUNCH_CANCELLED
+RESOURCE_LAUNCH_FAILED
+```
+
+Messages tell the user what action is possible: reconnect, complete authentication, refresh, request access,
+change route, install/enable a reviewed feature, or contact the resource owner. Errors never echo the private
+target, server response, raw authorization value or command line.
+
+Site failure, DNS failure, Tunnel failure and authorization denial remain distinct. No error path silently sends
+a Campus resource Direct or substitutes L3 for WebVPN/TCP Resource.
+
+## 12. Security invariants
+
+1. Renderer-visible lists contain no private or session-bound launch target.
+2. Resource presence, trust, authorization and runtime availability are separate states.
+3. A handle from Profile/Account A is unusable in B.
+4. Server authorization cannot outlive its provider session, revision or expiry.
+5. LaunchHandle is one-use, generation-bound and non-persistent.
+6. Unknown type, capability, Exit or authorization semantics fail closed.
+7. Direct, Campus L3, TCP Resource and WebVPN never silently substitute for each other.
+8. Every application-owned resolved destination passes the selected Exit's post-resolution safety policy.
+   P8's existing Chromium `DIRECT` route is a documented temporary exception: it keeps current literal/text host
+   safety and proves zero Campus-Engine start/wait, but does not claim DNS-rebinding protection. P12 removes this
+   exception by activating ControlledDirectExit.
+9. Launchers never construct an arbitrary shell command from resource data.
+10. Temporary listeners are loopback-only, owner-scoped, bounded and synchronously cleaned up.
+11. Resource labels/targets are absent from default logs, telemetry and crash reports.
+12. Profile manifests, server catalogues and local records use distinct namespaces and cannot override each
+    other's trust labels.
+
+## 13. Migration from the current simple model
+
+Migration is behavior-preserving and journaled with the profile/account storage migration.
+
+Migration reads two authoritative source namespaces independently:
+
+1. every normalized packaged builtin record;
+2. every normalized custom record persisted in settings, up to the current custom-storage bound of 32.
+
+It must not use the merged visible list as migration input. The current view places six builtins first and caps
+the merged result at 32, so all 32 stored custom entries can include six records that are valid but not currently
+visible. Each source record maps as follows:
+
+```text
+legacy id           -> private sourceIdentityRef + new opaque resourceHandle
+builtin=true        -> source=builtin_reviewed, trust=reviewed_builtin
+builtin=false       -> source=local_user, trust=user_supplied
+name/description    -> bounded display fields
+url                 -> private WebTarget
+route=campus        -> requiredExit=campus_modern_l3
+route=direct        -> requiredExit=direct
+type                -> web
+authorization       -> not_required
+revision            -> packaged-manifest or local-settings transaction revision
+expiry              -> none for the migrated built-in/local record
+```
+
+Requirements:
+
+- preserve all valid built-in and all valid stored local Web shortcuts without changing route decisions;
+- preserve the current built-in-first, 32-visible compatibility view separately from the lossless stored model;
+- keep the current maximum of 32 local entries until a separately measured storage/UI bound replaces it;
+- make migration idempotent and all-old/all-new under write, fsync, rename and restart fault injection;
+- retain the existing local editor as a Web-only compatibility adapter;
+- keep non-Web local creation disabled until a type-specific editor and launcher are reviewed;
+- retain a one-release rollback input without treating old data as an alternate authorization source;
+- never attempt to synthesize a server catalogue from built-in or local shortcuts.
+
+During the compatibility phase, Main may resolve a migrated Web resource and call the existing Campus Browser
+path. This preserves current behavior but does not satisfy a future claim that Direct resources open without a
+Tunnel: the current manager still calls `ensureConnected()`. That improvement requires its own launcher/Exit
+activation and tests.
+
+## 14. P8 Resource Workspace acceptance
+
+“P8” is the Resource Domain and Campus Workspace Beta milestone in the Revision 4 execution plan. This document
+defines its gates but does not itself authorize production changes.
+
+P8 is complete only when all of the following are true.
+
+### Domain and migration
+
+- versioned internal/view schemas and exact enum/bounds tests exist;
+- current built-in/local Web resources migrate idempotently with order, route and editability preserved;
+- profile/account/workspace isolation tests show zero cross-scope resource, favorite, recent or LaunchHandle
+  visibility;
+- source and trust badges cannot be forged by local/server payloads;
+- unknown resource types and schema versions fail closed.
+
+### Catalogue and authorization
+
+- production still reports resource catalogue/authorization as unsupported until authenticated retrieval,
+  refresh, expiry and value semantics have evidence;
+- synthetic server catalogues test revision replacement, expiry, withdrawal and authorization-unknown behavior;
+- stale or expired catalogues authorize zero launches;
+- the control Renderer receives no exact server target or raw authorization material.
+
+### Search and workspace UX
+
+- search covers all view types and presentation fields without indexing private targets;
+- favorites and recent activity are profile/account/workspace scoped, bounded and durable;
+- unavailable, denied, expired and unsupported resources remain distinguishable and actionable;
+- keyboard navigation, bilingual labels and basic accessibility are covered by real Electron tests;
+- 10,000 synthetic views remain searchable and cancellable without blocking the control window.
+
+### Launcher
+
+- every launch goes through the broker transaction and a one-use LaunchHandle;
+- existing Web shortcut launch behavior has packaged Electron parity after migration;
+- resource refresh, profile/account switch, route revision or Engine restart invalidates an old handle;
+- partial Browser/listener/process resources are cleaned after cancellation and 100 repeated launch/close cycles;
+- non-Web types either pass their independent implementation gate or return the exact unsupported/unavailable
+  error; schema presence alone never counts as launch support;
+- SSH, TCP, UDP, database, Jupyter, file, Remote Desktop and WebVPN are not reported Supported merely because
+  their descriptor and launcher interfaces exist;
+- P8 SSH completion requires exact-target validation, account/profile/Engine-generation binding, bounded config
+  output, zero shell interpolation and packaged one-click copy/open tests;
+- P8 TCP completion requires exact-target validation, loopback-only ephemeral listener, one owner, absolute/idle
+  expiry, cancel/disconnect/switch cleanup and zero residue across 100 lease cycles;
+- Direct-without-Tunnel may be claimed only for the existing validated Browser Direct route after a packaged
+  P8 test proves it starts/waits for the Campus Engine zero times; it does not claim ControlledDirectExit-level
+  resolved-address protection before P12.
+
+### Security and packaging
+
+- exact IPC sender/key/length validation, secret scans and architecture cycle gates pass;
+- logs, error text, diagnostics and crash paths contain zero private targets, queries, authorization values,
+  LaunchHandles or credentials;
+- package verification excludes synthetic catalogues, test launchers and fixture targets;
+- macOS, Windows and Linux packages retain the current loopback-only, no-global-network-mutation behavior;
+- no vendor authorization field, WebVPN endpoint, Remote Desktop protocol or forwarding behavior is guessed.
+
+P8 may be called the first Resource Workspace Beta only after Web, resource-scoped SSH configuration and bounded
+TCP ForwardLease gates all pass. UDP, database, Jupyter, file, Remote Desktop and WebVPN remain typed
+future/unsupported capabilities or are omitted from the ordinary student view.

--- a/docs/audits/2026-08-23-multi-school-readiness.md
+++ b/docs/audits/2026-08-23-multi-school-readiness.md
@@ -1,0 +1,210 @@
+# HKUST(GZ) Connect multi-school readiness audit
+
+- Production baseline: `ed47f93f6594c7ae41ef344f08fa0aa6b5c47fc2`
+- Scope: current Rust Engine, Desktop, Campus Browser, data stores and packaging
+- Conclusion: protocol core is mostly school-neutral; Desktop identity/data model is single-profile and must be
+  corrected before a second real Gateway
+
+## 1. Readiness summary
+
+```text
+Rust Engine multi-school readiness: high
+Desktop/profile data readiness: low
+Campus Browser isolation primitives: strong, currently single-profile
+Safe second real school today: NO
+Profile identity + data isolation foundation: GO
+```
+
+The P0 invariant is:
+
+```text
+School A credential / Cookie / certificate trust / route / Engine event
+must never be usable in School B context.
+```
+
+## 2. Unique capabilities worth preserving
+
+### Independent Rust Engine
+
+- `independent/src/engine/provider.rs`: typed Auth/Resource/Transport capability boundary;
+- `independent/src/engine/session.rs`: authenticated Gateway session separated from Modern L3;
+- `auth_transaction.rs` / `auth_control.rs`: Engine-owned challenge/secret lifecycle;
+- `special_tls11.rs` / `modern.rs`: independently maintained Modern transport with PKI/leaf binding;
+- `netstack.rs` / `dns.rs` / `socks.rs`: userspace TCP/UDP/IP, campus DNS and loopback proxy frontend;
+- cancellation, generation, bounded shutdown and typed error model.
+
+Most Rust protocol code is deployment-neutral. Current school specificity is concentrated in engine config,
+reviewed DNS/profile policy, package filename and a small number of tests/labels.
+
+### Campus Workspace
+
+The current Campus Browser combines capabilities not observed together in the reviewed EasyConnect static
+sample or zju-connect source, and aligns with this project's isolation and ordinary-user goals:
+
+- sandboxed multi-tab browsing;
+- one persistent Session preserving Cookie/POST/SAML;
+- per-domain Campus/Direct policy and user-managed rules;
+- builtin/custom resources;
+- encrypted exact-origin website-password vault;
+- exact-origin certificate trust manager;
+- MFA/OTP-safe autofill/save detection;
+- request gate during Engine/policy transitions;
+- no Clash requirement for ordinary users.
+
+This should become a profile-scoped Campus Workspace, not be removed in favor of a generic proxy-only UI.
+
+### Desktop lifecycle and integration
+
+- authoritative connection intent/generation FSM;
+- stale event/retry/health isolation;
+- loopback strict proxy auth with explicit compatibility mode;
+- Clash/SSH/PAC adapters;
+- local redacted diagnostics and three-day retention;
+- macOS/Windows/Linux build and package gates.
+
+## 3. Current hard-coded deployment identity
+
+### Gateway and Engine
+
+- `desktop/main.js` fixes product/school labels and Gateway host;
+- `engineConfigPath()` and package scripts expect one `hkustgz.json`;
+- `independent/config/hkustgz.json` owns Gateway origin, endpoints, DNS and transport policy;
+- root CLI, Keychain labels and launch identifiers are HKUST-specific;
+- Engine hello/capability presentation is not derived from a selected profile/provider/frontend.
+
+### Flat user-data namespace
+
+Current global files include:
+
+```text
+settings.json
+cred.bin
+campus-credentials.json
+campus-certificate-trust.json
+routing-rules.json
+routing.pac
+campus-browser-routing.pac
+engine.log
+engine-owner.json
+```
+
+Adding an editable Gateway field without namespacing these stores could send a password to the wrong Gateway,
+reuse Cookies/site credentials, authorize a certificate pin across schools or apply stale route/resource/event
+state.
+
+### Browser and resources
+
+- one fixed persistent partition;
+- HKUST default home/domains and direct partner rules;
+- HKUST-only bundled resource catalogue;
+- one CampusBrowserManager, vault, certificate store and routing store;
+- HKUST-specific health targets and display text.
+
+### Product and school branding
+
+The current executable/app ID/updater/Keychain/userData identity and school branding are effectively one thing.
+2.0 must separate stable product identity from bounded school presentation. Changing app ID and profile storage
+in one release would make rollback and secure-storage migration unnecessarily risky.
+
+## 4. Required new domain types
+
+### SchoolProfile
+
+A Main/Engine-owned deployment description containing stable ID/revision, bounded branding, exact Gateway
+origin, closed protocol family, packaged config reference and Browser policy. It contains no credential, pin,
+Cookie or user rule. Renderer sees only a bounded `SchoolProfileView`, never internal DNS/config/provider state.
+
+### GatewayOrigin
+
+Canonical HTTPS origin with no credentials/path/query/fragment and a destination safety policy. Origin and
+protocol family are immutable profile identity; changing either creates a new opaque profile and copies no
+credential, Cookie, pin, route or Browser state.
+
+### ProtocolFamily
+
+A closed compiled provider/backend selection. Initial production value:
+
+```text
+easyconnect-password-modern-l3-v1
+```
+
+### CapabilitySnapshot
+
+An additive sanitized response containing compiled, selected-provider, profile-available, ingress-mode and
+effective capability states. Profile metadata cannot promote unsupported code.
+
+### ProfileRegistry and ActiveProfileContext
+
+A packaged reviewed registry plus local custom profiles. Active context owns profile epoch, stores, Browser
+partition, routing, health, resources, branding and selected Engine config.
+
+## 5. Safe custom-domain experience
+
+The user requirement “Other → enter domain” is supported through a credential-free probe, not automatic
+password trials:
+
+1. normalize HTTPS domain/port;
+2. validate every bounded CNAME/A/AAAA result and reject mixed/unsafe address sets;
+3. connect to a validated address while preserving the original hostname for SNI/PKI and verify the peer;
+4. use a bounded one-shot client with no redirect, environment proxy, Cookie jar or cache;
+5. classify only a candidate public login surface, not L3/DNS/transport capability;
+6. show exact origin/version/compatibility and issue a short-lived Main-owned confirmation;
+7. consume it once to create an opaque isolated local profile;
+8. validate profile/origin/provider/config/credential binding before decrypting the password.
+
+The validated connector must cover all custom-profile outer Gateway HTTP and special-TLS sockets. Private
+campus targets carried inside the authenticated L3 tunnel remain a separate destination policy domain.
+
+Unsupported/unknown Gateways receive a sanitized compatibility report. Custom profiles are marked unverified
+and default to an app-owned neutral page, Engine-native health only, no DNS fallback, routes, resources, updater
+or system mutation.
+
+## 6. Data migration and isolation
+
+Move global settings/proxy/update state into `global/` and profile data into an opaque profile-key directory.
+HKUST becomes the default profile and retains the existing Browser partition alias.
+
+The migration requires a journal and fault injection around every write, fsync, rename and unlink. It must be
+idempotent and yield all-old or all-new state, with no credential loss, username/password mismatch or revoked
+pin resurrection.
+
+Every continuation binds:
+
+```text
+connection intent + profile epoch + Engine generation
+```
+
+Profile switching has a durable journal and one activation commit point. It gates Browser traffic, cancels old
+continuations, confirms Engine cleanup, clears sidecar/server state and validates new stores/partition before
+committing `activeProfileId`. Cleanup or recovery uncertainty starts no Engine.
+
+## 7. Test requirements before a second real school
+
+- two synthetic Gateway/profile fixtures;
+- A password never reaches B Gateway;
+- A Browser Cookie/storage/site credential/pin/rule/resource is invisible in B;
+- A late Engine/health/retry/MFA/route callback cannot update B;
+- 100 profile switches leave zero PID/port/timer/view/sidecar residue;
+- custom discovery sends no credential and rejects invalid TLS/origin/protocol;
+- DNS rebinding/mixed-result/peer-mismatch and confirmation-replay tests;
+- probe Cookies/session state never enter authentication;
+- profile/config/binding validation happens before credential decryption;
+- migration fault matrix proves all-old/all-new and restart idempotence;
+- profile-aware JS/PAC/Rust routing differential corpus;
+- exact packaged profile/config/asset manifest on three platforms;
+- HKUST password/Modern L3/Campus Workspace regression remains unchanged.
+
+## 8. Recommended foundation order
+
+1. ADR/schema for SchoolProfile, GatewayOrigin, ProtocolFamily and capability truth;
+2. packaged registry with one HKUST compatibility profile;
+3. provider composition bound to profile identity;
+4. profile-scoped storage and journaled migration;
+5. ActiveProfileCoordinator and Browser partition isolation;
+6. safe Gateway dialer and one-shot confirmation transaction;
+7. school picker and credential-free custom Gateway probe;
+8. profile-scoped RoutingPolicyIR;
+9. only then add a second real school or production Router/Exit capability.
+
+The exact security decisions are recorded in
+[`ADR-0003`](../adr/0003-multi-school-profile-and-custom-gateway.md).

--- a/docs/audits/2026-08-23-multi-school-readiness.md
+++ b/docs/audits/2026-08-23-multi-school-readiness.md
@@ -51,7 +51,8 @@ sample or zju-connect source, and aligns with this project's isolation and ordin
 - request gate during Engine/policy transitions;
 - no Clash requirement for ordinary users.
 
-This should become a profile-scoped Campus Workspace, not be removed in favor of a generic proxy-only UI.
+This should become an account-workspace-scoped Campus Workspace, not be removed in favor of a generic
+proxy-only UI.
 
 ### Desktop lifecycle and integration
 
@@ -138,10 +139,18 @@ effective capability states. Profile metadata cannot promote unsupported code.
 A packaged reviewed registry plus local custom profiles. Active context owns profile epoch, stores, Browser
 partition, routing, health, resources, branding and selected Engine config.
 
-## 5. Safe custom-domain experience
+### CampusAccount and WorkspaceScope
 
-The user requirement “Other → enter domain” is supported through a credential-free probe, not automatic
-password trials:
+The deployment profile is not the user identity. Even while the first UI exposes only one `primary` account,
+P1 must define the account/workspace keys and P3 must migrate directly into
+`profiles/<profileKey>/accounts/<accountKey>/`. Browser partition, VPN/site credentials, pins, favorites/recent,
+user rules/resources and active session are workspace-owned. See
+[`ADR-0004`](../adr/0004-profile-account-workspace-scope.md).
+
+## 5. Safe custom-domain experience (advanced P11)
+
+The user requirement “Other → enter domain” is supported only after a second reviewed school proves isolation,
+through a credential-free probe rather than automatic password trials:
 
 1. normalize HTTPS domain/port;
 2. validate every bounded CNAME/A/AAAA result and reject mixed/unsafe address sets;
@@ -161,8 +170,9 @@ or system mutation.
 
 ## 6. Data migration and isolation
 
-Move global settings/proxy/update state into `global/` and profile data into an opaque profile-key directory.
-HKUST becomes the default profile and retains the existing Browser partition alias.
+Move global settings/proxy/update state into `global/` and account-owned data directly into an opaque
+profile/account/workspace directory. HKUST/primary becomes the default context and alone retains the existing
+Browser partition alias.
 
 The migration requires a journal and fault injection around every write, fsync, rename and unlink. It must be
 idempotent and yield all-old or all-new state, with no credential loss, username/password mismatch or revoked
@@ -171,40 +181,44 @@ pin resurrection.
 Every continuation binds:
 
 ```text
-connection intent + profile epoch + Engine generation
+connection intent + profile epoch + account epoch + Engine generation
 ```
 
 Profile switching has a durable journal and one activation commit point. It gates Browser traffic, cancels old
 continuations, confirms Engine cleanup, clears sidecar/server state and validates new stores/partition before
-committing `activeProfileId`. Cleanup or recovery uncertainty starts no Engine.
+committing `activeProfileId + activeAccountKey` at one durable commit point. Cleanup or recovery uncertainty
+starts no Engine and opens no account workspace.
 
-## 7. Test requirements before a second real school
+## 7. Test requirements before a second reviewed school
 
-- two synthetic Gateway/profile fixtures;
+- two profile × two account synthetic fixtures;
 - A password never reaches B Gateway;
 - A Browser Cookie/storage/site credential/pin/rule/resource is invisible in B;
 - A late Engine/health/retry/MFA/route callback cannot update B;
-- 100 profile switches leave zero PID/port/timer/view/sidecar residue;
-- custom discovery sends no credential and rejects invalid TLS/origin/protocol;
-- DNS rebinding/mixed-result/peer-mismatch and confirmation-replay tests;
-- probe Cookies/session state never enter authentication;
+- 100 profile/account switches leave zero PID/port/timer/view/sidecar residue;
 - profile/config/binding validation happens before credential decryption;
 - migration fault matrix proves all-old/all-new and restart idempotence;
 - profile-aware JS/PAC/Rust routing differential corpus;
 - exact packaged profile/config/asset manifest on three platforms;
 - HKUST password/Modern L3/Campus Workspace regression remains unchanged.
 
+Before P11 custom onboarding, add zero-credential discovery, invalid TLS/origin/protocol,
+DNS-rebinding/mixed-result/peer-mismatch, confirmation replay and probe Cookie/session non-promotion tests.
+
 ## 8. Recommended foundation order
 
-1. ADR/schema for SchoolProfile, GatewayOrigin, ProtocolFamily and capability truth;
+1. ADR/schema for SchoolProfile, GatewayOrigin, ProtocolFamily, CampusAccount, WorkspaceScope and capability truth;
 2. packaged registry with one HKUST compatibility profile;
 3. provider composition bound to profile identity;
-4. profile-scoped storage and journaled migration;
-5. ActiveProfileCoordinator and Browser partition isolation;
-6. safe Gateway dialer and one-shot confirmation transaction;
-7. school picker and credential-free custom Gateway probe;
-8. profile-scoped RoutingPolicyIR;
-9. only then add a second real school or production Router/Exit capability.
+4. profile/account/workspace storage and journaled migration;
+5. ActiveProfile/ActiveAccount coordinator and Browser partition isolation;
+6. behavior-preserving HKUST Gateway connector;
+7. account-scoped RoutingPolicyIR and Router/Campus Exit foundation;
+8. ResourceDescriptor and Campus Workspace Beta;
+9. first evidence-gated HKUST capability;
+10. second reviewed school;
+11. only then Advanced custom Gateway onboarding.
 
 The exact security decisions are recorded in
-[`ADR-0003`](../adr/0003-multi-school-profile-and-custom-gateway.md).
+[`ADR-0003`](../adr/0003-multi-school-profile-and-custom-gateway.md) and
+[`ADR-0004`](../adr/0004-profile-account-workspace-scope.md).

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -1,19 +1,24 @@
-# 2.0 Multi-school Campus Access Platform — Execution Plan
+# Campus Connect 2.0 — Campus Workspace + Secure Access Runtime Execution Plan
 
-- Status: Proposed; awaiting maintainer approval
-- Revision: 3 — cross-project feature mapping, immutable profiles and safe custom Gateway onboarding
+- Status: Approved direction; P1 begins only after this preparation PR merges and the governance gate is active
+- Revision: 4 — resource-first product, profile/account/workspace isolation and reviewed-school-first rollout
 - Scope: research and architecture preparation only
 - Production behavior change: none
 - Version/release change: none
 - Baseline: HKUST(GZ) Connect `main` at
   `ed47f93f6594c7ae41ef344f08fa0aa6b5c47fc2`
-- zju-connect reference: `2c71a34c17ea7ecf04c5fe862c4c315344128653`
+- zju-connect protocol reference: `2c71a34c17ea7ecf04c5fe862c4c315344128653`; reviewed current-main
+  configuration delta: `4b2bcaa0acc34a33de672c26e3b2cb83bd583b15`
 
 ## 1. Executive recommendation
 
-2.0的目标不再局限于HKUST(GZ)，而是一个保留校园浏览器与低网络侵入优势的多学校
-EasyConnect-compatible平台。HKUST(GZ)是首个reviewed profile，不再是协议、存储或产品能力的
-硬编码边界。最终中立产品名与app ID另由独立ADR决定，不与profile迁移绑在一起。
+2.0的产品定义是 **Campus Workspace + Secure Access Runtime**：对普通学生首先是校园资源入口，
+对科研/开发用户提供SSH、代理、数据库、Jupyter与受控转发，对学校/社区维护者提供可审核、
+可签名、可回滚的reviewed profile平台。EasyConnect/aTrust兼容属于底层能力，不是普通用户的
+主要产品概念。
+
+HKUST(GZ)是首个reviewed profile，不再是协议、存储或产品能力的硬编码边界。最终中立产品名
+与app ID另由独立ADR决定，不与profile/account迁移绑在一起。
 
 2.0不承诺任意Sangfor部署自动兼容，也不应把EasyConnect、zju-connect和现有代码混成一次
 大重写。正确路径是：
@@ -27,32 +32,40 @@ EasyConnect-compatible平台。HKUST(GZ)是首个reviewed profile，不再是协
   → 独立启用、独立回滚
 ```
 
-登录入口目标：
+普通模式目标：
 
 ```text
-选择学校 / 组织
-  ├── HKUST(GZ) — reviewed built-in profile
-  ├── future reviewed school profiles
-  └── Other — 输入HTTPS Gateway域名/端口
-          → 无凭据探测
-          → 展示兼容性与Gateway身份
-          → 用户确认
-          → 再显示账号/密码
+打开应用
+  → 搜索/收藏/最近访问校园资源
+  → 点击 Web / HPC / SSH / Jupyter / Database 资源
+  → 应用判断 Direct 或 Campus
+  → 需要时自动连接或展示 MFA
+  → 通过 Campus Workspace 或受控 launcher 打开
 ```
 
-本准备阶段做四件事：
+学校选择器默认只展示reviewed profiles。任意 `Other` Gateway不作为首发主入口；P5先完成安全
+connector，P10用第二个reviewed school证明多学校隔离，P11才在“高级设置 → 添加自定义组织”
+开放实验性、明确未验证的domain onboarding。
+
+本准备阶段做七件事：
 
 1. 建立EasyConnect clean-room解包与版本差分流程；
 2. 固定zju-connect当前源码事实，提取可借鉴思想而不形成源码或运行时依赖；
 3. 逐功能记录三项目实现方式和2.0迁移决策；
-4. 建立SchoolProfile、数据隔离、Provider、Routing、Exit、Ingress和Underlay边界及PR顺序。
+4. 建立SchoolProfile、CampusAccount、WorkspaceScope与数据隔离边界；
+5. 把Campus Workspace、Student/Advanced/Headless模式写成正式产品定义；
+6. 建立ResourceDescriptor、non-authorizing resourceHandle、one-use LaunchHandle与资源优先首页；
+7. 建立Provider、Routing、Exit、Ingress、Underlay与分阶段PR顺序。
 
 本阶段不启动厂商客户端、不登录网关、不读取凭据/会话，不提交任何厂商二进制、解包文件、
 抓包或反编译内容。
 
 三项目逐功能映射见
 [`2.0-cross-project-feature-map.md`](../architecture/2.0-cross-project-feature-map.md)，多学校安全决策见
-[`ADR-0003`](../adr/0003-multi-school-profile-and-custom-gateway.md)。
+[`ADR-0003`](../adr/0003-multi-school-profile-and-custom-gateway.md)。产品、账户作用域和资源模型见
+[`2.0-product-definition.md`](../product/2.0-product-definition.md)、
+[`ADR-0004`](../adr/0004-profile-account-workspace-scope.md)和
+[`resource-domain-model.md`](../architecture/resource-domain-model.md)。
 
 ## 2. Fixed evidence baseline
 
@@ -64,7 +77,7 @@ EasyConnect-compatible平台。HKUST(GZ)是首个reviewed profile，不再是协
 | EasyConnect Linux | public 7.6.7.3 package baseline | Sanitized static evidence | Named binary/capability marker and legacy transport clues |
 | EasyConnect Windows | L3 module 7.6.7.200 baseline | Sanitized static evidence | Adapter shape/hash/length metadata only |
 | HKUST gateway | M7.6.8R2 historical observation | Historical school evidence | Current profile was password + Modern L3 when observed |
-| zju-connect | `2c71a34` | Public AGPL-3.0 source review | Engineering ideas and candidate behavior; never HKUST support proof |
+| zju-connect | `2c71a34` protocol audit + `4b2bcaa` config delta | Public AGPL-3.0 source review | Engineering ideas and candidate behavior; never HKUST support proof |
 
 Evidence labels remain mandatory:
 
@@ -284,27 +297,50 @@ Before selecting a second real Gateway, introduce:
 ```text
 SchoolProfile
 SchoolProfileInternal / SchoolProfileView
+CampusAccount / CampusAccountView
+WorkspaceScope / WorkspaceView
 GatewayOrigin
 ProtocolFamily
 CapabilitySnapshot
 ProfileRegistry
 ActiveProfileContext / profileEpoch
+ActiveAccountContext / accountEpoch
 ```
 
-The first registry contains only `hkustgz`, so behavior remains unchanged. Existing global credentials,
-Browser partition, website passwords, certificate pins, routing rules, resources and logs migrate into the
-HKUST profile through a journaled all-old/all-new transaction.
+The first registry contains only `hkustgz`, and the first UI exposes only one `primary` account, so behavior
+remains unchanged. The durable namespace is nevertheless account-aware from the first migration:
 
-Every profile has an isolated VPN vault, Browser partition, website credential vault, certificate store,
-routing/resources/DNS policy and event generation. `GatewayOrigin` and `ProtocolFamily` are immutable profile
-identity: changing either creates a new opaque profile and never copies credentials, Cookies, pins or rules.
-Only one profile/Engine is active initially.
+```text
+global/
+profiles/<profileKey>/
+  profile-settings.json / profile-state.json
+  accounts/<accountKey>/
+    account.json
+    vpn-credential.bin / credential-transaction.json
+    workspace/
+      browser partition reference
+      site credentials and certificate decisions
+      favorites/recent/user resources/routing rules
+      active session and account-local diagnostics
+```
 
-The full deployment record remains Main/Engine-owned. Renderer receives only a bounded `SchoolProfileView` and
-sanitized capability tokens; it never receives internal DNS targets, Engine config references or provider state.
+Existing global credentials, Browser partition, website passwords, certificate pins, routing rules, resources
+and logs migrate into `hkustgz/primary` through a journaled all-old/all-new transaction.
 
-Custom Gateway profiles are local and minimal: standard PKI, no private DNS fallback, no bundled routes,
-no Gateway-driven updater, no system mutation, a neutral app-owned start page and no site-based health target
+`SchoolProfile` owns reviewed deployment identity and policy. `CampusAccount` owns the user identity and VPN
+credential binding. `WorkspaceScope` owns Browser partition, website vault, certificate decisions, favorites,
+recent activity, user routing/resources and the active session. Profile A data is unavailable to B; within one
+profile, Account A data is unavailable to Account B. `GatewayOrigin` and `ProtocolFamily` remain immutable
+profile identity. Only one profile/account/Engine is active initially.
+
+The full deployment/account records remain Main/Engine-owned. Renderer receives bounded `SchoolProfileView`,
+`CampusAccountView`, `WorkspaceView` and sanitized capability tokens; it never receives internal DNS targets,
+Engine config references, credential bindings or provider/session state. Detailed account decisions are fixed by
+[`ADR-0004`](../adr/0004-profile-account-workspace-scope.md).
+
+P11 custom Gateway profiles are Advanced/experimental, local and minimal: standard PKI, no private DNS
+fallback, no bundled routes, no Gateway-driven updater, no system mutation, a neutral app-owned start page and
+no site-based health target
 until a provider validates one. Their optional label is always marked `Custom / unverified` and cannot confer
 trust. Detailed invariants are fixed by
 [`ADR-0003`](../adr/0003-multi-school-profile-and-custom-gateway.md).
@@ -312,13 +348,19 @@ trust. Detailed invariants are fixed by
 ### 5.3 Target dependency direction
 
 ```text
-Product shell / School picker / Headless adapter
+Student Home / Campus Workspace / Developer Access / Headless adapter
         ↓
-ProfileRegistry + ActiveProfileContext
+ProfileRegistry + ActiveProfileContext + ActiveAccountContext
         ↓
 Application coordinator + sanitized Control/Event API
 
-Custom Gateway onboarding
+Resource search / favorites / recents / catalogue
+        ↓
+ResourceDescriptorView + non-authorizing resourceHandle
+        ↓
+ResourceLaunchBroker → one-use LaunchHandle → Browser / SSH / Forward / allowlisted action
+
+Advanced custom Gateway onboarding (P11 only)
         ↓
 GatewayOriginVerifier + one-shot GatewayConfirmation
         ↓
@@ -378,15 +420,15 @@ One versioned canonical policy must drive JS, internal PAC, external PAC and a R
 
 ```text
 RoutingPolicyIR
-  version / profileId / profileRevision
+  version / profileId / profileRevision / accountId?
   canonical rules / defaults / policyRevision
 
 RouteIntent
   scheme / host / literalIp / port / protocol
-  initiatorClass / topLevelSite / profile
+  initiatorClass / topLevelSite / profile / account
 
 RouteEvaluationContext
-  profileEpoch / routerGeneration / selectedExitGeneration?
+  profileEpoch / accountEpoch / routerGeneration / selectedExitGeneration?
   navigation and bounded stickiness context
 
 RouteDecision
@@ -472,13 +514,23 @@ The current Campus Browser already provides:
 - no requirement for Clash or manual proxy configuration.
 
 2.0 preserves this product surface and generalizes it to exactly one isolated persistent Session and matching
-vaults/rules/resources per profile. This is the intended Campus Workspace differentiation from an official
-portal or a proxy-first CLI; it is an architecture decision, not a measured comparative usability claim.
+vaults/rules/resources per active account workspace. This is the intended Campus Workspace differentiation from
+an official portal or a proxy-first CLI; it is an architecture decision, not a measured comparative usability
+claim.
 
 Reviewed profiles may supply a home URL, reviewed domains/partners, resources, health targets and bounded
 branding. Custom profiles begin with an app-owned neutral page, empty resource/routing policy and Engine-native
 health only; user resources can then be added locally. Profile A tabs, Cookies, vaults and pins are never visible
 to Profile B.
+
+The ordinary-user home is resource-first rather than connection-first: global search, categories, favorites,
+recent activity and actionable notices lead to one-click launch. Connection becomes an on-demand dependency of
+the selected resource. A neutral `ResourceDescriptor` represents reviewed built-in, authenticated-server and
+local-user resources across Web, SSH, TCP/UDP, database, Jupyter, file, remote-desktop and WebVPN classes.
+Renderer sees only a bounded display view and non-authorizing resource handle. Main prepares/consumes a
+short-lived one-use LaunchHandle only after an explicit launch request; authorization fields, hidden URL parameters,
+Cookies and raw server configuration remain Main/Engine-owned. The complete contract is in
+[`resource-domain-model.md`](../architecture/resource-domain-model.md).
 
 ## 6. Candidate capability inventory
 
@@ -489,12 +541,16 @@ automatic 2.0 scope.
 | Capability | Current state | Next evidence/architecture action |
 | --- | --- | --- |
 | Multi-school profiles | Missing; one hard-coded HKUST context | Profile registry, exact Gateway origin, isolated stores/partition and journaled HKUST migration |
-| Safe Gateway connection | Missing for user-entered hosts | Validate every CNAME/A/AAAA result, reject mixed/unsafe sets, pin the actual socket address while retaining hostname PKI, and use one-shot confirmation |
-| Custom Gateway onboarding | Missing | Credential-free HTTPS probe reports only recognized public auth surface; L3/DNS/transport remain unknown until authenticated runtime evidence |
+| Account/workspace scope | Missing; account identity and school deployment share one flat namespace | Introduce single `primary` account now, but migrate directly to profile/account/workspace paths and dual-epoch lifecycle |
+| Safe Gateway connection | Current sockets lack one common generation owner | First route reviewed HKUST HTTP/special-TLS sockets through a behavior-preserving connector; P11 adds public-address validation and one-shot custom confirmation |
+| Custom Gateway onboarding | Missing | Advanced/experimental only after a second reviewed school; probe reports only public auth surface while L3/DNS/transport remain unknown until authenticated runtime evidence |
 | Password + Modern L3 | Production foundation | Preserve as regression oracle |
 | Gateway MFA | Generic `I2/E2`; real provider absent | Implement only the first school-enabled method after the EC-6 evidence/activation gate |
-| Resource catalogue | Offline `I2/E2` | Observe authenticated retrieval/refresh/authorization, then revise provider contract |
-| Campus Workspace | HKUST-only multi-tab Browser with local vault/pins/rules | Make profile-scoped and preserve it as the principal 2.0 ordinary-user interface |
+| Resource catalogue | Offline `I2/E2` | First define neutral ResourceDescriptor/opaque launcher; later observe authenticated retrieval/refresh/authorization before enabling server resources |
+| Campus Workspace | HKUST-only multi-tab Browser with local vault/pins/rules | Make account-workspace-scoped and resource-first; preserve it as the principal 2.0 ordinary-user interface |
+| Resource search/launcher | Current bounded Web shortcut list only | P8 requires search/category/favorite/recent + Web, resource-scoped SSH config and bounded TCP ForwardLease; other types stay unavailable |
+| Second reviewed school | None | Prove profile/account isolation and real canary before exposing arbitrary Gateway UI |
+| CLI/headless/service | Development CLI only; no formal product contract | Separate config/secrets, loopback strict auth, no root; add scoped TCP/UDP forwarding before TUN |
 | Notices/kick/password expiry/upgrade | Classifier/event scaffold | Observe real server states and add typed session services |
 | WebVPN | Typed slot only | Require an L3-disabled school profile and official parity |
 | Multi-line | Offline endpoint parse only | Prove discovery, auth/data endpoint relation and token portability |
@@ -515,144 +571,172 @@ automatic 2.0 scope.
 - current capability matrix references;
 - no production code or version change.
 
-### 2.0-P1 — SchoolProfile/GatewayOrigin schema and single-profile registry
+### 2.0-P1 — Profile/account identity schema and single-HKUST registry
 
-- define `SchoolProfile`, `GatewayOrigin`, `ProtocolFamily`, `CapabilitySnapshot` and registry schemas;
+- define `SchoolProfile`, `GatewayOrigin`, `ProtocolFamily`, `CapabilitySnapshot`, `CampusAccount` and
+  `WorkspaceScope` schemas;
 - package one reviewed `hkustgz` profile that produces current constants/config/resources/branding;
+- define the `primary` role/default and a non-persistent legacy compatibility view; do not package or persist an
+  account/workspace key in P1;
 - validate IDs, origins, asset/config references, hashes, bounds and unknown protocol families;
-- retain one active profile and current external behavior;
+- retain one active profile/account and current external behavior;
 - no storage migration and no custom Gateway yet.
 
 ### 2.0-P2 — Production Provider Composition Seam
 
 - map current `easyconnect-password-modern-l3-v1` family to one compiled provider set;
-- derive a sanitized runtime capability snapshot bound to profile ID/revision;
+- derive a sanitized runtime capability snapshot internally bound to profile ID/revision + persistent
+  account key/revision + active-context epoch + Engine generation; Renderer receives only the short-lived
+  `accountHandle`, never the persistent account key;
 - run production and synthetic providers through the same coordinator;
 - use only a narrow compile-time enum/factory; no plugin ABI or speculative provider contract;
 - publish capabilities through an additive API while Event API v1 remains unchanged;
 - no real MFA and no connection behavior change.
 
-### 2.0-P3 — Profile-scoped storage and journaled HKUST migration
+### 2.0-P3 — Profile/account/workspace storage and journaled HKUST migration
 
 - split app-global and profile settings;
-- migrate VPN credentials, route rules, website passwords, certificate pins, resources and logs into HKUST;
+- create `profiles/<profileKey>/accounts/<accountKey>/workspace/` from the start;
+- generate/commit the installation-local opaque profile/account/workspace keys only inside the P3 journal;
+- migrate VPN credentials, route rules, website passwords, certificate pins, resources, favorites/recent state
+  and logs into `hkustgz/primary`;
 - retain the legacy HKUST Browser partition alias;
 - model the one-release legacy VPN rollback blob as exact-profile/origin/family-bound `active | retired` state;
+- bind credentials to dedicated profile/account credential revisions so branding/resource/favorite metadata does
+  not spuriously invalidate a password;
 - retire it durably before any password replacement, logout/credential clear, account removal or profile reset
   can report success; ordinary auto-connect never reads it;
 - fault-inject every journal/write/fsync/rename/unlink boundary;
 - prove all-old/all-new, idempotence and no username/password or revoked-pin mismatch.
 
-### 2.0-P4 — ActiveProfileCoordinator and Browser isolation
+### 2.0-P4 — ActiveProfile/ActiveAccount coordinator and Browser isolation
 
-- bind connection intent + profile epoch + Engine generation;
-- implement gate/cancel/stop/activate switch transaction;
+- bind connection intent + profile epoch + account epoch + Engine generation;
+- implement durable gate/cancel/stop/activate profile/account switch transactions;
 - isolate Browser partition, vaults, pins, routing, resources, notices, health and telemetry;
-- keep only HKUST selectable in production;
-- verify 100 synthetic switch cycles and stale-event rejection.
+- keep only HKUST/primary selectable in production;
+- verify cross-profile and same-profile cross-account zero visibility, 100 synthetic switch cycles and stale-event
+  rejection.
 
-### 2.0-P5 — Safe Gateway Underlay foundation and confirmation transaction
+### 2.0-P5 — Behavior-preserving GatewayConnectorGeneration
 
-P5 is delivered as three review units. Custom credential entry remains disabled until all three pass together:
+P5 first hardens only the packaged HKUST profile. It does not expose arbitrary Gateway input or a public probe.
+Deliver it as three review units:
 
-**P5a — origin verifier and public probe**
+**P5a — packaged-origin verifier and connector contract**
 
-- add a Main/Engine-owned `GatewayOriginVerifier`;
-- compile one closed `PublicProbeSpec` with exact root-bound GET/HEAD path, fixed safe headers, no redirect,
-  no Cookie store, bounded status/content-type/body/deadline and sanitized classifier;
-- permit no profile/user-defined path, method, header, parser or unbounded candidate list;
-- issue a short-lived one-shot `GatewayConfirmation` bound to nonce, exact origin, public-auth-surface candidate,
-  draft profile key and expiry;
+- Main/Rust resolve the immutable reviewed profile origin into a generation-bound Gateway connector;
+- standard PKI, `.no_proxy()`, leaf binding and the current system-default route remain behaviorally unchanged;
+- the connector API has resolved-address/peer checks and a reviewed private-Gateway exception field, but no
+  Renderer/user-controlled origin.
 
-**P5b — validated HTTP connector**
+**P5b — all Gateway HTTP paths**
 
-- add a generation-bound `ValidatedGatewayConnector` to discovery, authentication, configuration,
-  authenticated resource retrieval, logout, session keepalive/update and token HTTP paths;
+- route discovery, authentication, configuration, authenticated resources, logout, session keepalive/update and
+  token HTTPS through the same connector generation;
+- a generation change invalidates Cookie/session/token state rather than silently splitting the session.
 
-**P5c — special-TLS and generation closure**
+**P5c — all special-TLS paths**
 
-- use the same connector generation for address-control, send, receive and every authenticated server-provided
-  outer endpoint;
-- cover discovery, authentication, configuration, authenticated resource retrieval, logout, session
-  keepalive/update, token, address-control, send, receive and every authenticated server-provided outer endpoint;
-- canonicalize IDNA/port and resolve bounded CNAME/A/AAAA chains without environment proxy;
-- normalize IPv4-mapped IPv6 and reject the whole answer set if any result is loopback, private, link-local,
-  multicast, unspecified or otherwise disallowed for a custom profile;
-- connect the socket to an already validated address while retaining the original hostname for SNI and PKI,
-  then verify the connected peer address matches the pinned address;
-- use a fresh no-cookie/no-cache discovery client and discard all response Cookies/TLS/session state;
-- validate authenticated server-provided outer endpoints through the same custom-profile public-address policy;
-  campus/private destinations carried inside L3 remain a separate policy domain;
-- preserve HKUST behavior through the SystemDefault implementation, with performance/regression gates;
-- use synthetic rebinding, mixed-answer, CNAME, peer-mismatch and timeout fixtures; no custom credential entry yet.
+- route address-control, send, receive and every authenticated server-provided outer endpoint through the same
+  connector generation;
+- distinguish outer Gateway addresses from private destinations carried inside the authenticated L3 tunnel;
+- run HKUST regression, same-peer, rebinding, network-change and performance tests before accepting the seam.
 
-### 2.0-P6 — School picker and safe custom Gateway onboarding
+### 2.0-P6 — Account-scoped RoutingPolicyIR v1, offline first
 
-- login page offers HKUST(GZ) and `Other`;
-- normalize HTTPS Gateway domain/port and run the P5 credential-free bounded probe;
-- show Gateway identity, reported version and recognized public login surface before credentials; label L3, DNS
-  and transport as `will be checked after login`, never as probe-confirmed;
-- create a minimal isolated profile with a random/derived opaque key and trust class `custom-local` only after
-  atomically consuming the confirmation;
-- compile an owner-only Engine launch config from the closed provider factory and exact confirmed origin; custom
-  JSON can never supply endpoints/config paths;
-- validate active profile epoch, origin, provider, config digest and credential binding before decrypting the
-  password; a mismatch fails before any secret is read;
-- no automatic credential-bearing provider guessing, TLS bypass, DNS fallback, routes or Gateway updater;
-- use two synthetic Gateways before allowing a real custom profile canary;
-- add explicit deletion: an active profile cannot be deleted; cleanup closes its Browser/session and durably
-  removes credentials, pins, rules, logs and Chromium partition before the profile becomes absent.
-
-### 2.0-P7 — Profile-scoped RoutingPolicyIR v1, offline first
-
-- canonical schema/serialization/revision including profile ID/revision;
-- runtime profile/router/Exit generations remain in evaluation context;
-- current rule/resource compiler and profile namespace;
+- canonical schema/serialization/revision including profile/account identity;
+- runtime profile/account/router/Exit generations remain in evaluation context;
+- compile current rules and resources without changing outcomes;
 - JS/PAC/Rust differential evaluator with 100,000 deterministic/property cases;
 - semantic route equivalence and persisted-rule compatibility;
-- no production traffic switch until profile migration/switch E2E passes.
+- no production traffic switch until profile/account migration and switch E2E pass.
 
-### 2.0-P8 — Router topology ADR and test-only DirectExit prototype
+### 2.0-P7 — Router ADR, test-only ec-router and Campus Exit adapter
 
-- compare separate router and long-lived unified Engine before changing production frontends;
+- compare a separate long-lived `ec-router` with a unified Engine before changing production frontends;
 - specify policy activation transaction, private Campus upstream authorization and dual-process ownership;
-- specify Campus Workspace multi-exit versus campus-pinned SOCKS/Clash/SSH ingress policy;
-- test strict local auth, profile/revision/generation, DNS rebinding, loop prevention and 100-cycle cleanup;
-- prototype excluded from packages.
+- define `ExitId`, capabilities and typed failures, then wrap current VirtualNetstack/DNS as
+  `CampusModernL3Exit` without changing production routing;
+- keep external SOCKS/Clash/SSH campus-pinned while Campus Workspace may later evaluate multiple Exits;
+- test strict local auth, profile/account/revision/generation, loop prevention and 100-cycle cleanup;
+- prototype stays out of packages until the ADR selects a topology.
 
-### 2.0-P9 — Campus Exit contract, behavior preserving
+### 2.0-P8 — Resource domain and Campus Workspace 2.0 Beta
 
-- implement `ExitId`, capabilities and typed failures according to the approved P8 topology;
-- wrap current VirtualNetstack/DNS as `CampusModernL3Exit`;
-- if the separate router wins, keep the existing Engine frontend campus-only and adapt it as an upstream;
-- if the unified Engine wins, only then make its local frontend depend on the Exit interface;
-- keep one production Exit, no fallback and no production Direct activation.
+Deliver the first user-visible 2.0 value without adding another school or protocol:
 
-### 2.0-P10 — First evidence-gated official capability
+- introduce `ResourceDescriptorInternal`, bounded `ResourceDescriptorView` with opaque non-authorizing
+  `resourceHandle`, plus Main-owned short-lived one-use `LaunchHandle`;
+- distinguish reviewed built-in, authenticated-server and local-user source/trust classes;
+- model Web, SSH, TCP/UDP, database, Jupyter, file, remote-desktop and WebVPN, while unsupported types report
+  typed capability-unavailable rather than fake success;
+- replace the connection-first home with search, categories, favorites, recent activity and actionable notices;
+- launch validated Direct Web resources without starting Campus under the documented 1.x Chromium-DIRECT risk
+  boundary; Campus resources call `ensureConnected()` and surface MFA; P12 later adds ControlledDirectExit;
+- production-enable reviewed Web resources, one-click SSH configuration and an account-scoped loopback temporary
+  TCP-forward baseline; keep UDP/TUN/RemoteApp/WebVPN disabled;
+- keep authorization state, raw server fields, Cookies and hidden parameters outside Renderer;
+- preserve the existing Campus Browser multi-tab/Cookie/POST/SAML behavior and migration compatibility.
 
-- choose one capability with real school evidence: authenticated resources, notices/session policy, first real
-  MFA provider, L3-disabled WebVPN or confirmed multi-line;
-- require the EC-6 parity/canary/rollback gate per school profile;
-- keep all unrelated providers and Exits disabled.
+### 2.0-P9 — First evidence-gated official capability
 
-### 2.0-P11 — ControlledDirectExit activation
+- choose one current-school capability with real evidence: authenticated resource catalogue, session notices,
+  password expiry/concurrent-session state or the first actually enabled MFA method;
+- require EC-6 parity/canary/rollback for the exact HKUST profile/account;
+- keep WebVPN, aTrust, multi-line and unrelated providers disabled.
 
-- only after P8/P9 and the P10 stability gate;
-- preserve one profile-scoped Browser Session, Cookies, POST and SAML continuity;
-- no silent Direct↔Campus fallback;
-- independent feature rollback.
+### 2.0-P10 — Second reviewed school profile
 
-### 2.0-P12 — Explicit Gateway Underlay selection
+- onboard one staff/community-maintained school profile with fixed evidence, compiled provider/backend and
+  school-specific fixtures;
+- prove password/Cookie/pin/rule/resource/event isolation across profile and account boundaries;
+- complete official parity, package manifest validation, canary and independent rollback;
+- only after this phase may the product claim production multi-school support.
 
-- extend the safe P5 connector from `SystemDefault` to an explicit reviewed interface/underlay identity;
-- retain one Gateway policy/generation for discovery/auth/config/resource/logout, token and all data sockets;
-- DirectResolver/DirectDialer remains a separate ownership/generation axis;
-- behavior unchanged; no interface enumeration or auto-selection.
+### 2.0-P11 — Advanced custom organization onboarding
 
-### 2.0-P13+ — Additional evidence-triggered capabilities
+Expose `Other` only under **Advanced settings → Add custom organization**, marked experimental and unverified:
 
-Continue one capability per PR. Each school/profile has an independent fixture, canary, capability upgrade and
-rollback. Do not combine MFA, resources, WebVPN, multi-line, Underlay, aTrust, RemoteApp or TUN work.
+- compile a closed `PublicProbeSpec`; no profile/user-defined path, method, header, parser or unbounded candidate
+  list;
+- validate bounded CNAME/A/AAAA answers, mixed/unsafe sets, actual peer, hostname SNI/PKI, redirect/body/deadline,
+  no proxy/Cookie/cache and a short-lived one-shot confirmation;
+- report only a candidate public auth surface; L3/DNS/resource/transport remain unknown until authenticated;
+- consume confirmation to create a new opaque profile/account workspace, then validate target/config/binding
+  before decrypting a credential;
+- no provider guessing with a password, no inherited reviewed branding/routes/DNS/updater and no automatic
+  connection of an unverified draft;
+- require two synthetic Gateways plus one explicitly accepted real custom canary before broader availability.
+
+### 2.0-P12 — Controlled Direct, explicit Underlay and evidence-backed multi-line
+
+Keep these as separate review units even if they share a milestone:
+
+- activate `ControlledDirectExit` for Campus Workspace only after Router/Exit stability; never silently fall back
+  between Campus and Direct;
+- extend P5 from `SystemDefault` to explicit Wi-Fi/Ethernet/user-added local-proxy underlay identity;
+- measure the Campus Gateway rather than public websites; manual selection first, then optional sticky/hysteretic
+  auto mode;
+- switching Underlay destroys Session/token/sockets and reauthenticates; binding failure never silently falls
+  back and cycle detection prevents Gateway traffic from entering Campus SOCKS;
+- enable multi-line only after endpoint discovery, auth/data relation and token-portability evidence.
+
+### 2.0-P13 — CLI, headless service and scoped forwarding
+
+- provide `campus-connect-cli` / service mode over the same Rust providers and profile/account schema;
+- merge non-secret config with explicit precedence `defaults < file < environment < CLI`, where only supplied
+  values override lower sources and unknown keys fail closed;
+- separate non-secret configuration from credentials; accept secrets through OS store, stdin/FD, Docker secret or
+  owner-only control pipe, never ordinary argv/TOML or default environment variables;
+- run unprivileged, default listeners to loopback with strict authentication and preserve generation cleanup;
+- expose reviewed TCP and bounded UDP forwarding for server/lab/Jupyter/database use;
+- add launchd/systemd/Docker examples only after package and restart-residue tests; TUN remains separate.
+
+### 2.0-P14+ — Additional evidence-triggered products and protocols
+
+Continue one capability per PR/profile: aTrust, WebVPN, legacy backend, optional TUN/mobile or an independently
+threat-modeled RemoteApp product. Do not combine these or infer support from static EasyConnect modules.
 
 ## 8. Common quality and security gates
 
@@ -665,8 +749,10 @@ Every implementation PR must pass:
 - macOS/Windows/Linux package verifier when production files change;
 - password + Modern L3 regression with no behavior/performance regression;
 - unknown capability/state fail-closed;
-- profile/Gateway/protocol identity bound to every credential/session/continuation;
-- two-profile synthetic isolation for VPN passwords, Cookies, website passwords, pins, rules and events;
+- profile/account/Gateway/protocol identity bound to every credential/session/continuation;
+- two-profile × two-account synthetic isolation for VPN passwords, Cookies, website passwords, pins, favorites,
+  recent data, rules, resources and events;
+- 100 profile/account switches leave zero PID/port/timer/view/credential residue and reject every stale callback;
 - migration fault injection proves all-old/all-new and idempotence;
 - logout/password replacement/account clear cannot succeed while a reusable legacy rollback credential remains;
 - profile switch journal has one durable activation commit point; ambiguous recovery starts no Engine;
@@ -675,16 +761,22 @@ Every implementation PR must pass:
 - public probe request is selected only from compiled bounded `PublicProbeSpec`; no profile/user-defined probe;
 - Gateway confirmation is exact-origin/provider/draft/expiry bound and consumed once;
 - credential target/config/binding validation completes before secure-store decryption;
+- resource view/launch handles are bounded and opaque; Renderer never receives server authorization material,
+  Cookie/token, hidden query/form values or raw endpoint configuration;
+- expired/unauthorized/unsupported resources fail closed with actionable typed errors;
+- Direct resources do not start Campus; Campus resources cannot silently Direct on failure;
 - no default system DNS/route/global proxy mutation;
 - no URL/query, Cookie, token, OTP or credential in logs/events;
 - same-profile official parity and staff canary for proprietary capabilities;
+- CLI/headless secrets never enter argv/TOML/default environment; listener defaults remain loopback + strict auth;
 - explicit rollback and capability downgrade rules.
 
 ## 9. Approval gate and immediate next step
 
-After this preparation PR is reviewed, implementation begins with **2.0-P1 SchoolProfile/GatewayOrigin schema
-and single-profile registry** only. It is deliberately behavior-preserving: the sole `hkustgz` profile emits
-the current Gateway/config/resources/branding and does not yet move user data or expose another school.
+After this preparation PR is reviewed, implementation begins with **2.0-P1 Profile/account identity schema and
+single-HKUST registry** only. It is deliberately behavior-preserving: the sole `hkustgz` profile and synthetic
+`primary` account emit the current Gateway/config/resources/branding, but do not move user data, change the UI or
+expose another school/account.
 
 Before any broader EasyConnect dynamic analysis, the school must also:
 
@@ -695,7 +787,9 @@ Before any broader EasyConnect dynamic analysis, the school must also:
 
 No 2.0 production feature or release is authorized by this plan alone.
 
-P0–P5 and offline/behavior-preserving P7–P9 may proceed as reviewable foundation after this plan is approved.
-Custom Gateway activation in P6 and any official capability/Exit activation in P10/P11 or later also require
-the applicable 1.x freeze evidence or an explicit documented maintainer risk acceptance; preparation work
-never silently waives those gates.
+P1–P7 remain behavior-preserving foundation. P8 is the first user-visible Campus Workspace Beta. P9 requires
+real same-school evidence; P10 requires a second reviewed-school canary; advanced custom Gateway onboarding is
+explicitly deferred to P11. P12–P14 capabilities retain independent evidence, canary and rollback gates.
+
+Before the first P1 production-code PR, `main` must require pull requests plus the CI, package-verifier and
+exact-tree secret-scan checks. Green advisory CI without branch protection is not the governance gate.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -1,6 +1,7 @@
-# HKUST(GZ) Connect 2.0 Preparation Execution Plan
+# 2.0 Multi-school Campus Access Platform — Execution Plan
 
 - Status: Proposed; awaiting maintainer approval
+- Revision: 3 — cross-project feature mapping, immutable profiles and safe custom Gateway onboarding
 - Scope: research and architecture preparation only
 - Production behavior change: none
 - Version/release change: none
@@ -10,7 +11,12 @@
 
 ## 1. Executive recommendation
 
-2.0不应是一次把EasyConnect、zju-connect和现有代码混在一起的大重写。正确路径是：
+2.0的目标不再局限于HKUST(GZ)，而是一个保留校园浏览器与低网络侵入优势的多学校
+EasyConnect-compatible平台。HKUST(GZ)是首个reviewed profile，不再是协议、存储或产品能力的
+硬编码边界。最终中立产品名与app ID另由独立ADR决定，不与profile迁移绑在一起。
+
+2.0不承诺任意Sangfor部署自动兼容，也不应把EasyConnect、zju-connect和现有代码混成一次
+大重写。正确路径是：
 
 ```text
 固定可复现证据
@@ -21,14 +27,32 @@
   → 独立启用、独立回滚
 ```
 
-本准备阶段只做三件事：
+登录入口目标：
+
+```text
+选择学校 / 组织
+  ├── HKUST(GZ) — reviewed built-in profile
+  ├── future reviewed school profiles
+  └── Other — 输入HTTPS Gateway域名/端口
+          → 无凭据探测
+          → 展示兼容性与Gateway身份
+          → 用户确认
+          → 再显示账号/密码
+```
+
+本准备阶段做四件事：
 
 1. 建立EasyConnect clean-room解包与版本差分流程；
 2. 固定zju-connect当前源码事实，提取可借鉴思想而不形成源码或运行时依赖；
-3. 明确本仓2.0的Provider、Routing、Exit、Ingress和Underlay边界及PR顺序。
+3. 逐功能记录三项目实现方式和2.0迁移决策；
+4. 建立SchoolProfile、数据隔离、Provider、Routing、Exit、Ingress和Underlay边界及PR顺序。
 
 本阶段不启动厂商客户端、不登录网关、不读取凭据/会话，不提交任何厂商二进制、解包文件、
 抓包或反编译内容。
+
+三项目逐功能映射见
+[`2.0-cross-project-feature-map.md`](../architecture/2.0-cross-project-feature-map.md)，多学校安全决策见
+[`ADR-0003`](../adr/0003-multi-school-profile-and-custom-gateway.md)。
 
 ## 2. Fixed evidence baseline
 
@@ -36,7 +60,7 @@
 | --- | --- | --- | --- |
 | HKUST(GZ) Connect | `ed47f93` | Current production source and green CI | 1.x password + Modern L3 foundation and current extension seams |
 | Released client | `v1.2.3` → `5d8323d` | Published package evidence | Released behavior only; excludes post-release convergence fixes |
-| Installed EasyConnect macOS | [7.6.7 x86_64 sample](../research/easyconnect/sample-manifest.md) | Installed-mutated static clue | Bundle topology and candidate capability locations only |
+| Installed EasyConnect macOS | [7.6.7 x86_64 sample](../research/easyconnect/sample-manifest.md) | Installed-mutated authorized static extraction | [Electron/Web/native feature topology](../research/easyconnect/macos-7.6.7-static-observation.md); school activation still unknown |
 | EasyConnect Linux | public 7.6.7.3 package baseline | Sanitized static evidence | Named binary/capability marker and legacy transport clues |
 | EasyConnect Windows | L3 module 7.6.7.200 baseline | Sanitized static evidence | Adapter shape/hash/length metadata only |
 | HKUST gateway | M7.6.8R2 historical observation | Historical school evidence | Current profile was password + Modern L3 when observed |
@@ -50,6 +74,15 @@ Evidence labels remain mandatory:
 - `Unknown`: no adequate evidence.
 
 Implementation and evidence remain two separate axes (`I0..I4` and `E0..E5`).
+
+### Preliminary authorized static extraction completed
+
+The installed-mutated macOS 7.6.7 ASAR, sealed Web resources, signed manifests and readable native topology
+were inspected in an isolated temporary workspace. The result is recorded in
+[`macos-7.6.7-static-observation.md`](../research/easyconnect/macos-7.6.7-static-observation.md).
+No vendor program was started and no runtime socket, user setting, log, Keychain item, credential or session
+was read. Because this is not a pristine installer, it informs the feature/architecture map but does not close
+EC-1 or provide official version-differential/parity evidence.
 
 ## 3. EasyConnect research workstream
 
@@ -244,12 +277,54 @@ Keep without rewrite:
 - standard PKI plus narrow vendor leaf binding;
 - no global DNS/route/system proxy mutation.
 
-### 5.2 Target dependency direction
+### 5.2 Multi-school identity and isolation
+
+Before selecting a second real Gateway, introduce:
 
 ```text
-Desktop / Headless adapters
+SchoolProfile
+SchoolProfileInternal / SchoolProfileView
+GatewayOrigin
+ProtocolFamily
+CapabilitySnapshot
+ProfileRegistry
+ActiveProfileContext / profileEpoch
+```
+
+The first registry contains only `hkustgz`, so behavior remains unchanged. Existing global credentials,
+Browser partition, website passwords, certificate pins, routing rules, resources and logs migrate into the
+HKUST profile through a journaled all-old/all-new transaction.
+
+Every profile has an isolated VPN vault, Browser partition, website credential vault, certificate store,
+routing/resources/DNS policy and event generation. `GatewayOrigin` and `ProtocolFamily` are immutable profile
+identity: changing either creates a new opaque profile and never copies credentials, Cookies, pins or rules.
+Only one profile/Engine is active initially.
+
+The full deployment record remains Main/Engine-owned. Renderer receives only a bounded `SchoolProfileView` and
+sanitized capability tokens; it never receives internal DNS targets, Engine config references or provider state.
+
+Custom Gateway profiles are local and minimal: standard PKI, no private DNS fallback, no bundled routes,
+no Gateway-driven updater, no system mutation, a neutral app-owned start page and no site-based health target
+until a provider validates one. Their optional label is always marked `Custom / unverified` and cannot confer
+trust. Detailed invariants are fixed by
+[`ADR-0003`](../adr/0003-multi-school-profile-and-custom-gateway.md).
+
+### 5.3 Target dependency direction
+
+```text
+Product shell / School picker / Headless adapter
+        ↓
+ProfileRegistry + ActiveProfileContext
         ↓
 Application coordinator + sanitized Control/Event API
+
+Custom Gateway onboarding
+        ↓
+GatewayOriginVerifier + one-shot GatewayConfirmation
+        ↓
+ValidatedGatewayConnector generation
+  ├── HTTP client (discovery/auth/config/resource/logout/session-keepalive/token)
+  └── TCP connector (address-control/send/receive special TLS)
 
 AuthenticationOrchestrator
         ↓
@@ -278,9 +353,11 @@ Ingress Router / Exit Registry
 
 Authentication does not depend on Routing/Ingress; DNS and frontends do not depend on concrete auth;
 Gateway Underlay never interprets EasyConnect/MFA; Direct resolution/dialing does not inherit Gateway
-Underlay identity or session generation; Renderer never owns gateway session material.
+Underlay identity or session generation; Renderer never owns gateway session material. A custom Gateway cannot
+reach authentication until its validated-address dialer and one-shot confirmation are bound to the exact origin,
+profile draft, provider candidate and expiry.
 
-### 5.3 Production provider composition
+### 5.4 Production provider composition
 
 The traits already exist, but production `ec-engine` still directly composes password + Modern L3. Add a
 compile-time `ProductionProviderSet` (or equivalent) before any new provider. Runtime capability reporting
@@ -295,20 +372,21 @@ Capability truth has four layers: compiled capability, selected provider/backend
 availability and current ingress-mode capability. Expose it through an additive bounded capability response;
 do not change or reinterpret the existing Event API v1 hello schema.
 
-### 5.4 RoutingPolicyIR v1
+### 5.5 RoutingPolicyIR v1
 
 One versioned canonical policy must drive JS, internal PAC, external PAC and a Rust evaluator. Minimum types:
 
 ```text
 RoutingPolicyIR
-  version / canonical rules / profile / defaults / policyRevision
+  version / profileId / profileRevision
+  canonical rules / defaults / policyRevision
 
 RouteIntent
   scheme / host / literalIp / port / protocol
   initiatorClass / topLevelSite / profile
 
 RouteEvaluationContext
-  routerGeneration / selectedExitGeneration?
+  profileEpoch / routerGeneration / selectedExitGeneration?
   navigation and bounded stickiness context
 
 RouteDecision
@@ -321,7 +399,7 @@ The canonical IR stores no runtime generation, full URL/query or secrets. Unknow
 Current 1.x route outcomes and persisted-rule compatibility must remain semantically equivalent before
 activation; generated PAC source is not required to remain byte-for-byte identical.
 
-### 5.5 Exit and Ingress Router boundary
+### 5.6 Exit and Ingress Router boundary
 
 The current frontend directly owns `VirtualNetstack`, while Chromium `DIRECT` bypasses application-owned
 resolution/socket policy. A 2.0 `ControlledDirectExit` therefore needs a stable router lifecycle.
@@ -362,7 +440,7 @@ The ADR/prototype must resolve four integration contracts before any frontend re
    remain pinned to `CampusModernL3Exit` unless a future separately reviewed advanced policy explicitly says
    otherwise. Browser domain rules never silently send SSH/SOCKS Direct.
 
-### 5.6 UnderlayPolicy
+### 5.7 UnderlayPolicy
 
 First add a behavior-preserving `SystemDefaultUnderlay` that owns Gateway resolution, HTTP client creation
 and every Modern token/data socket. Only after that can explicit interface binding be implemented. Automatic
@@ -374,11 +452,33 @@ change invalidates the authenticated session, token and all data sockets. Future
 instead of falling back unbound; `.no_proxy()`, hostname PKI/leaf binding and same-peer constraints remain
 unchanged.
 
-### 5.7 Session services
+### 5.8 Session services
 
 The current `ResourceProvider` is an offline parser scaffold, not a final production ABI. A real session
 service needs authenticated request ownership, revision/expiry, session generation, opaque launch material
 and explicit authorization semantics. Define only after a real official resource retrieval observation.
+
+### 5.9 Campus Workspace as the ordinary-user product surface
+
+The current Campus Browser already provides:
+
+- multi-tab browsing and normal navigation toolbar;
+- one fixed persistent Session for Cookie/POST/SAML continuity;
+- Campus/Direct route choice and remembered domain rules;
+- builtin and user-added resource shortcuts, with bounded server-resource scaffolding;
+- encrypted exact-origin website passwords with MFA/OTP safety;
+- exact-origin certificate trust management;
+- fail-closed request gate during Engine/profile/policy transitions;
+- no requirement for Clash or manual proxy configuration.
+
+2.0 preserves this product surface and generalizes it to exactly one isolated persistent Session and matching
+vaults/rules/resources per profile. This is the intended Campus Workspace differentiation from an official
+portal or a proxy-first CLI; it is an architecture decision, not a measured comparative usability claim.
+
+Reviewed profiles may supply a home URL, reviewed domains/partners, resources, health targets and bounded
+branding. Custom profiles begin with an app-owned neutral page, empty resource/routing policy and Engine-native
+health only; user resources can then be added locally. Profile A tabs, Cookies, vaults and pins are never visible
+to Profile B.
 
 ## 6. Candidate capability inventory
 
@@ -388,9 +488,13 @@ automatic 2.0 scope.
 
 | Capability | Current state | Next evidence/architecture action |
 | --- | --- | --- |
+| Multi-school profiles | Missing; one hard-coded HKUST context | Profile registry, exact Gateway origin, isolated stores/partition and journaled HKUST migration |
+| Safe Gateway connection | Missing for user-entered hosts | Validate every CNAME/A/AAAA result, reject mixed/unsafe sets, pin the actual socket address while retaining hostname PKI, and use one-shot confirmation |
+| Custom Gateway onboarding | Missing | Credential-free HTTPS probe reports only recognized public auth surface; L3/DNS/transport remain unknown until authenticated runtime evidence |
 | Password + Modern L3 | Production foundation | Preserve as regression oracle |
 | Gateway MFA | Generic `I2/E2`; real provider absent | Implement only the first school-enabled method after the EC-6 evidence/activation gate |
 | Resource catalogue | Offline `I2/E2` | Observe authenticated retrieval/refresh/authorization, then revise provider contract |
+| Campus Workspace | HKUST-only multi-tab Browser with local vault/pins/rules | Make profile-scoped and preserve it as the principal 2.0 ordinary-user interface |
 | Notices/kick/password expiry/upgrade | Classifier/event scaffold | Observe real server states and add typed session services |
 | WebVPN | Typed slot only | Require an L3-disabled school profile and official parity |
 | Multi-line | Offline endpoint parse only | Prove discovery, auth/data endpoint relation and token portability |
@@ -411,64 +515,144 @@ automatic 2.0 scope.
 - current capability matrix references;
 - no production code or version change.
 
-### 2.0-P1 — Production Provider Composition Seam
+### 2.0-P1 — SchoolProfile/GatewayOrigin schema and single-profile registry
 
-- route current password + Modern L3 through one compiled provider set;
-- derive a sanitized runtime capability snapshot;
+- define `SchoolProfile`, `GatewayOrigin`, `ProtocolFamily`, `CapabilitySnapshot` and registry schemas;
+- package one reviewed `hkustgz` profile that produces current constants/config/resources/branding;
+- validate IDs, origins, asset/config references, hashes, bounds and unknown protocol families;
+- retain one active profile and current external behavior;
+- no storage migration and no custom Gateway yet.
+
+### 2.0-P2 — Production Provider Composition Seam
+
+- map current `easyconnect-password-modern-l3-v1` family to one compiled provider set;
+- derive a sanitized runtime capability snapshot bound to profile ID/revision;
 - run production and synthetic providers through the same coordinator;
 - use only a narrow compile-time enum/factory; no plugin ABI or speculative provider contract;
 - publish capabilities through an additive API while Event API v1 remains unchanged;
-- no real MFA and no external behavior change.
+- no real MFA and no connection behavior change.
 
-### 2.0-P2 — RoutingPolicyIR v1, offline only
+### 2.0-P3 — Profile-scoped storage and journaled HKUST migration
 
-- canonical schema/serialization/revision;
-- current rule/resource compiler;
-- JS/PAC/Rust differential evaluator;
-- 100,000 deterministic/property cases;
+- split app-global and profile settings;
+- migrate VPN credentials, route rules, website passwords, certificate pins, resources and logs into HKUST;
+- retain the legacy HKUST Browser partition alias;
+- model the one-release legacy VPN rollback blob as exact-profile/origin/family-bound `active | retired` state;
+- retire it durably before any password replacement, logout/credential clear, account removal or profile reset
+  can report success; ordinary auto-connect never reads it;
+- fault-inject every journal/write/fsync/rename/unlink boundary;
+- prove all-old/all-new, idempotence and no username/password or revoked-pin mismatch.
+
+### 2.0-P4 — ActiveProfileCoordinator and Browser isolation
+
+- bind connection intent + profile epoch + Engine generation;
+- implement gate/cancel/stop/activate switch transaction;
+- isolate Browser partition, vaults, pins, routing, resources, notices, health and telemetry;
+- keep only HKUST selectable in production;
+- verify 100 synthetic switch cycles and stale-event rejection.
+
+### 2.0-P5 — Safe Gateway Underlay foundation and confirmation transaction
+
+P5 is delivered as three review units. Custom credential entry remains disabled until all three pass together:
+
+**P5a — origin verifier and public probe**
+
+- add a Main/Engine-owned `GatewayOriginVerifier`;
+- compile one closed `PublicProbeSpec` with exact root-bound GET/HEAD path, fixed safe headers, no redirect,
+  no Cookie store, bounded status/content-type/body/deadline and sanitized classifier;
+- permit no profile/user-defined path, method, header, parser or unbounded candidate list;
+- issue a short-lived one-shot `GatewayConfirmation` bound to nonce, exact origin, public-auth-surface candidate,
+  draft profile key and expiry;
+
+**P5b — validated HTTP connector**
+
+- add a generation-bound `ValidatedGatewayConnector` to discovery, authentication, configuration,
+  authenticated resource retrieval, logout, session keepalive/update and token HTTP paths;
+
+**P5c — special-TLS and generation closure**
+
+- use the same connector generation for address-control, send, receive and every authenticated server-provided
+  outer endpoint;
+- cover discovery, authentication, configuration, authenticated resource retrieval, logout, session
+  keepalive/update, token, address-control, send, receive and every authenticated server-provided outer endpoint;
+- canonicalize IDNA/port and resolve bounded CNAME/A/AAAA chains without environment proxy;
+- normalize IPv4-mapped IPv6 and reject the whole answer set if any result is loopback, private, link-local,
+  multicast, unspecified or otherwise disallowed for a custom profile;
+- connect the socket to an already validated address while retaining the original hostname for SNI and PKI,
+  then verify the connected peer address matches the pinned address;
+- use a fresh no-cookie/no-cache discovery client and discard all response Cookies/TLS/session state;
+- validate authenticated server-provided outer endpoints through the same custom-profile public-address policy;
+  campus/private destinations carried inside L3 remain a separate policy domain;
+- preserve HKUST behavior through the SystemDefault implementation, with performance/regression gates;
+- use synthetic rebinding, mixed-answer, CNAME, peer-mismatch and timeout fixtures; no custom credential entry yet.
+
+### 2.0-P6 — School picker and safe custom Gateway onboarding
+
+- login page offers HKUST(GZ) and `Other`;
+- normalize HTTPS Gateway domain/port and run the P5 credential-free bounded probe;
+- show Gateway identity, reported version and recognized public login surface before credentials; label L3, DNS
+  and transport as `will be checked after login`, never as probe-confirmed;
+- create a minimal isolated profile with a random/derived opaque key and trust class `custom-local` only after
+  atomically consuming the confirmation;
+- compile an owner-only Engine launch config from the closed provider factory and exact confirmed origin; custom
+  JSON can never supply endpoints/config paths;
+- validate active profile epoch, origin, provider, config digest and credential binding before decrypting the
+  password; a mismatch fails before any secret is read;
+- no automatic credential-bearing provider guessing, TLS bypass, DNS fallback, routes or Gateway updater;
+- use two synthetic Gateways before allowing a real custom profile canary;
+- add explicit deletion: an active profile cannot be deleted; cleanup closes its Browser/session and durably
+  removes credentials, pins, rules, logs and Chromium partition before the profile becomes absent.
+
+### 2.0-P7 — Profile-scoped RoutingPolicyIR v1, offline first
+
+- canonical schema/serialization/revision including profile ID/revision;
+- runtime profile/router/Exit generations remain in evaluation context;
+- current rule/resource compiler and profile namespace;
+- JS/PAC/Rust differential evaluator with 100,000 deterministic/property cases;
 - semantic route equivalence and persisted-rule compatibility;
-- no production traffic switch.
+- no production traffic switch until profile migration/switch E2E passes.
 
-### 2.0-P3 — Router topology ADR and test-only DirectExit prototype
+### 2.0-P8 — Router topology ADR and test-only DirectExit prototype
 
 - compare separate router and long-lived unified Engine before changing production frontends;
 - specify policy activation transaction, private Campus upstream authorization and dual-process ownership;
-- specify Browser multi-exit versus campus-pinned SOCKS/Clash/SSH ingress policy;
-- test strict local auth, revision/generation, DNS rebinding, loop prevention and 100-cycle cleanup;
+- specify Campus Workspace multi-exit versus campus-pinned SOCKS/Clash/SSH ingress policy;
+- test strict local auth, profile/revision/generation, DNS rebinding, loop prevention and 100-cycle cleanup;
 - prototype excluded from packages.
 
-### 2.0-P4 — Campus Exit contract, behavior preserving
+### 2.0-P9 — Campus Exit contract, behavior preserving
 
-- implement `ExitId`, capabilities and typed failures according to the approved P3 topology;
+- implement `ExitId`, capabilities and typed failures according to the approved P8 topology;
 - wrap current VirtualNetstack/DNS as `CampusModernL3Exit`;
 - if the separate router wins, keep the existing Engine frontend campus-only and adapt it as an upstream;
 - if the unified Engine wins, only then make its local frontend depend on the Exit interface;
 - keep one production Exit, no fallback and no production Direct activation.
 
-### 2.0-P5 — First evidence-gated capability and stability
+### 2.0-P10 — First evidence-gated official capability
 
 - choose one capability with real school evidence: authenticated resources, notices/session policy, first real
   MFA provider, L3-disabled WebVPN or confirmed multi-line;
-- require the EC-6 parity/canary/rollback gate;
+- require the EC-6 parity/canary/rollback gate per school profile;
 - keep all unrelated providers and Exits disabled.
 
-### 2.0-P6 — ControlledDirectExit activation
+### 2.0-P11 — ControlledDirectExit activation
 
-- only after P3/P4 and the P5 stability gate;
-- preserve one Browser Session, Cookies, POST and SAML continuity;
+- only after P8/P9 and the P10 stability gate;
+- preserve one profile-scoped Browser Session, Cookies, POST and SAML continuity;
 - no silent Direct↔Campus fallback;
 - independent feature rollback.
 
-### 2.0-P7 — SystemDefaultUnderlay seam
+### 2.0-P12 — Explicit Gateway Underlay selection
 
-- one Gateway policy/generation for discovery/auth/config/resource/logout/token and three data sockets;
+- extend the safe P5 connector from `SystemDefault` to an explicit reviewed interface/underlay identity;
+- retain one Gateway policy/generation for discovery/auth/config/resource/logout, token and all data sockets;
 - DirectResolver/DirectDialer remains a separate ownership/generation axis;
 - behavior unchanged; no interface enumeration or auto-selection.
 
-### 2.0-P8+ — Additional evidence-triggered capabilities
+### 2.0-P13+ — Additional evidence-triggered capabilities
 
-Continue one capability per PR. Each has an independent fixture, canary, capability upgrade and rollback.
-Do not combine MFA, resources, WebVPN, multi-line, Underlay or TUN work.
+Continue one capability per PR. Each school/profile has an independent fixture, canary, capability upgrade and
+rollback. Do not combine MFA, resources, WebVPN, multi-line, Underlay, aTrust, RemoteApp or TUN work.
 
 ## 8. Common quality and security gates
 
@@ -481,6 +665,16 @@ Every implementation PR must pass:
 - macOS/Windows/Linux package verifier when production files change;
 - password + Modern L3 regression with no behavior/performance regression;
 - unknown capability/state fail-closed;
+- profile/Gateway/protocol identity bound to every credential/session/continuation;
+- two-profile synthetic isolation for VPN passwords, Cookies, website passwords, pins, rules and events;
+- migration fault injection proves all-old/all-new and idempotence;
+- logout/password replacement/account clear cannot succeed while a reusable legacy rollback credential remains;
+- profile switch journal has one durable activation commit point; ambiguous recovery starts no Engine;
+- custom Gateway discovery sends zero credentials, uses no cookie jar/cache, never bypasses standard PKI and
+  cannot connect outside its validated public address set;
+- public probe request is selected only from compiled bounded `PublicProbeSpec`; no profile/user-defined probe;
+- Gateway confirmation is exact-origin/provider/draft/expiry bound and consumed once;
+- credential target/config/binding validation completes before secure-store decryption;
 - no default system DNS/route/global proxy mutation;
 - no URL/query, Cookie, token, OTP or credential in logs/events;
 - same-profile official parity and staff canary for proprietary capabilities;
@@ -488,9 +682,9 @@ Every implementation PR must pass:
 
 ## 9. Approval gate and immediate next step
 
-After this preparation PR is reviewed, implementation begins with **2.0-P1 Production Provider Composition
-Seam** only. It is deliberately behavior-preserving and creates the smallest safe attachment point for later
-capabilities.
+After this preparation PR is reviewed, implementation begins with **2.0-P1 SchoolProfile/GatewayOrigin schema
+and single-profile registry** only. It is deliberately behavior-preserving: the sole `hkustgz` profile emits
+the current Gateway/config/resources/branding and does not yet move user data or expose another school.
 
 Before any broader EasyConnect dynamic analysis, the school must also:
 
@@ -501,6 +695,7 @@ Before any broader EasyConnect dynamic analysis, the school must also:
 
 No 2.0 production feature or release is authorized by this plan alone.
 
-P0–P4 may proceed as reviewable, behavior-preserving/offline preparation after this plan is approved. Any
-production capability activation in P5/P6 or later also requires the applicable 1.x freeze evidence or an
-explicit documented maintainer risk acceptance; preparation work never silently waives those gates.
+P0–P5 and offline/behavior-preserving P7–P9 may proceed as reviewable foundation after this plan is approved.
+Custom Gateway activation in P6 and any official capability/Exit activation in P10/P11 or later also require
+the applicable 1.x freeze evidence or an explicit documented maintainer risk acceptance; preparation work
+never silently waives those gates.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -1,0 +1,506 @@
+# HKUST(GZ) Connect 2.0 Preparation Execution Plan
+
+- Status: Proposed; awaiting maintainer approval
+- Scope: research and architecture preparation only
+- Production behavior change: none
+- Version/release change: none
+- Baseline: HKUST(GZ) Connect `main` at
+  `ed47f93f6594c7ae41ef344f08fa0aa6b5c47fc2`
+- zju-connect reference: `2c71a34c17ea7ecf04c5fe862c4c315344128653`
+
+## 1. Executive recommendation
+
+2.0不应是一次把EasyConnect、zju-connect和现有代码混在一起的大重写。正确路径是：
+
+```text
+固定可复现证据
+  → 形成中立行为规范
+  → 建立不改变1.x行为的架构接缝
+  → 只实现学校真实启用的能力
+  → official parity + staff canary
+  → 独立启用、独立回滚
+```
+
+本准备阶段只做三件事：
+
+1. 建立EasyConnect clean-room解包与版本差分流程；
+2. 固定zju-connect当前源码事实，提取可借鉴思想而不形成源码或运行时依赖；
+3. 明确本仓2.0的Provider、Routing、Exit、Ingress和Underlay边界及PR顺序。
+
+本阶段不启动厂商客户端、不登录网关、不读取凭据/会话，不提交任何厂商二进制、解包文件、
+抓包或反编译内容。
+
+## 2. Fixed evidence baseline
+
+| Source | Fixed identity | Evidence class | Permitted conclusion |
+| --- | --- | --- | --- |
+| HKUST(GZ) Connect | `ed47f93` | Current production source and green CI | 1.x password + Modern L3 foundation and current extension seams |
+| Released client | `v1.2.3` → `5d8323d` | Published package evidence | Released behavior only; excludes post-release convergence fixes |
+| Installed EasyConnect macOS | [7.6.7 x86_64 sample](../research/easyconnect/sample-manifest.md) | Installed-mutated static clue | Bundle topology and candidate capability locations only |
+| EasyConnect Linux | public 7.6.7.3 package baseline | Sanitized static evidence | Named binary/capability marker and legacy transport clues |
+| EasyConnect Windows | L3 module 7.6.7.200 baseline | Sanitized static evidence | Adapter shape/hash/length metadata only |
+| HKUST gateway | M7.6.8R2 historical observation | Historical school evidence | Current profile was password + Modern L3 when observed |
+| zju-connect | `2c71a34` | Public AGPL-3.0 source review | Engineering ideas and candidate behavior; never HKUST support proof |
+
+Evidence labels remain mandatory:
+
+- `Observed`: directly observed in one fixed official-client/gateway run;
+- `Confirmed`: current independent production path plus matching tests;
+- `Hypothesis`: marker, adjacent deployment or upstream source clue;
+- `Unknown`: no adequate evidence.
+
+Implementation and evidence remain two separate axes (`I0..I4` and `E0..E5`).
+
+## 3. EasyConnect research workstream
+
+### EC-0 — Governance gate
+
+Before broader dynamic analysis, complete
+[`../../independent/cleanroom/AUTHORIZATION_TEMPLATE.md`](../../independent/cleanroom/AUTHORIZATION_TEMPLATE.md)
+with:
+
+- named authorization owner, department, approver and expiry;
+- exact official packages, gateway environments and test accounts;
+- allowed static and dynamic activities;
+- prohibited data and production actions;
+- raw-capture storage, retention and destruction policy;
+- vendor contract/EULA review reference;
+- incident contact and stop conditions.
+
+The requester has stated that they are school staff and authorized interoperability analysis. The repository
+still needs the institutional record above before broader credentialed/dynamic work.
+
+### EC-1 — Acquire pristine official samples
+
+Acquire each sample from a fixed vendor or school-controlled channel. Record before analysis:
+
+```text
+sample_id
+source_url_or_internal_record
+acquired_at
+size
+sha256
+publisher_signature
+team_or_publisher_id
+timestamp/notarization where applicable
+platform / architecture / version
+custodian and retention class
+```
+
+Required starting set:
+
+1. pristine macOS installer matching or superseding installed 7.6.7;
+2. current Windows x64 installer and gateway-advertised modules;
+3. current Linux package;
+4. future school-approved version whenever the gateway/client changes.
+
+Raw packages remain in a school-controlled encrypted restricted store. They never enter Git, CI artifacts,
+release assets or developer dependency caches used for product builds.
+
+### EC-2 — Static inventory in an isolated workspace
+
+Use a disposable, read-only extraction workspace. Static work may include:
+
+- package/container integrity and file manifest;
+- architecture, signature, entitlements and dependency closure;
+- Electron ASAR file inventory and JavaScript module graph;
+- LaunchAgent/Daemon, system extension, kext and helper topology;
+- native import/export and capability-marker summaries;
+- configuration/XML/JSON schema names and bounded endpoint classes;
+- hashes, lengths, counts and reference classes emitted by existing Rust observers.
+
+Allowed repository outputs are neutral summaries only. No decompiled source, disassembly, vendor fixed bytes,
+ASAR content, extracted filesystem or proprietary resource is committed.
+
+Static capability categories:
+
+| Domain | Questions to answer |
+| --- | --- |
+| Authentication | password, CAPTCHA, secondary states, certificate/device/SSO indicators, cancellation and failure classes |
+| Session | cookies/CSRF ownership, logout, keepalive, passive kick, expiry and concurrent-session behavior |
+| Resources | catalogue/groups, web/file/app resources, authorization signals, refresh/expiry and launch semantics |
+| Transport | Modern/legacy L3 families, WebVPN indicators, TCP/UDP roles, heartbeat, reconnect and MTU |
+| Network policy | DNS sources, route/domain policy, multi-line discovery, endpoint selection and system mutation |
+| Platform | agents/daemons, permissions, update flow, certificate/device integration and cleanup |
+
+### EC-3 — Version/platform differential
+
+Compare normalized summaries, not raw binaries:
+
+```text
+old exact sample
+  ↔ new exact sample
+  ↔ macOS / Windows / Linux
+```
+
+Classify each change as packaging-only, UI/schema-only, authentication state, resource/session policy,
+transport/wire contract, system integration, or unknown/high risk.
+
+No baseline change is accepted automatically. A human review decides whether to preserve an old adapter,
+add a new versioned adapter, or mark the profile unsupported.
+
+### EC-4 — Controlled dynamic behavior
+
+This phase starts only after EC-0 and EC-1. Use an isolated OS user/VM, a school test account and a
+school-approved gateway. Compare official and independent clients against the same profile.
+
+Scenario groups:
+
+1. discovery, successful password login, explicit rejection and indeterminate failure;
+2. each actually enabled CAPTCHA/MFA method, one at a time;
+3. config/resource retrieval, authorization, refresh and expiry;
+4. Modern L3, campus DNS, TCP/UDP, idle heartbeat and reconnect;
+5. passive kick, password expiry, concurrent-session rejection and forced-upgrade reason;
+6. sleep/wake, offline/online, Wi-Fi/default-route change and clean logout;
+7. before/after system DNS, route, proxy, process, port and privileged component state.
+
+Rules:
+
+- credentials are supplied through the lab Keychain/stdin, never argv or files;
+- OTP is entered by the authorized user and never intercepted, persisted or replayed;
+- no guessed endpoint, fixed OTP shape, bypass or downgrade;
+- raw PCAP/HAR/log/process traces stay in restricted storage;
+- real-user data, attestation/private keys, rate limits or production instability trigger an immediate stop.
+
+### EC-5 — Sanitized facts and synthetic fixtures
+
+Only a restricted transformer may convert raw observations into a Git candidate. Every record contains:
+
+```text
+observation_id
+source_sample_hash
+profile_id (opaque)
+fact_label
+state/event category
+bounds and ordering
+redaction proof
+implementation relevance
+```
+
+All values are synthetic. Never commit password, OTP, Cookie, token, CSRF, TwfID, sslctx, RSA material,
+certificate private material, assigned IP, internal hostname/address, account identifier, vendor preface bytes,
+raw response or decompiler text.
+
+### EC-6 — Parity, promotion and rollback
+
+For each capability:
+
+```text
+neutral spec
+  → parser/property/fuzz tests
+  → synthetic gateway/backend
+  → independent implementation behind disabled capability
+  → same-profile official parity
+  → staff canary
+  → explicit production activation
+```
+
+Every adapter/provider has its own capability flag and revert boundary. Unknown versions and states fail
+closed; rollback never enables public DNS fallback, disables TLS validation or sends campus-only resources
+Direct.
+
+## 4. zju-connect research workstream
+
+The current fixed source snapshot is
+[`2c71a34`](https://github.com/Mythologyli/zju-connect/tree/2c71a34c17ea7ecf04c5fe862c4c315344128653).
+It is an engineering reference, not a dependency and not proof of HKUST behavior.
+The fixed local observation ledger is
+[`2c71a34-observation.md`](../research/zju-connect/2c71a34-observation.md).
+
+### 4.1 What can inform our design
+
+- centralized destination context and dial/underlay ownership;
+- DNS cache/single-flight and UDP-to-TCP transport separation;
+- bounded continuation-style authentication ideas;
+- endpoint set, stickiness and health scoring concepts;
+- explicit separation of L3, per-application TCP tunnel and local frontends;
+- fault-oriented tests for resolvers, forwarding and lifecycle.
+
+### 4.2 What must not be inherited
+
+- TLS certificate verification bypass or anti-MITM continue-on-failure;
+- public/secondary DNS fallback for campus-only names;
+- wildcard unauthenticated SOCKS/HTTP listeners;
+- ZJU-specific domain/10/8 policy;
+- secret-bearing argv/TOML/client-data/logging, TOTP seed persistence or OTP output;
+- TUN/FakeIP/DNS hijack/global route mutation as a default;
+- PCAP/TLS key-log product paths;
+- its source, fixtures, Go modules or binary as a build/runtime dependency.
+
+zju-connect is AGPL-3.0. Any future decision to reuse code rather than behavior ideas requires a separate
+license/compliance review. This plan assumes independent implementation only.
+
+## 5. Required 2.0 architecture seams
+
+### 5.1 Preserve the proven 1.x core
+
+Keep without rewrite:
+
+- Engine-owned secret and AuthTransaction lifecycle;
+- `AuthenticatedGatewaySession` separated from Transport;
+- Modern L3 Data Plane, VirtualNetstack and campus DNS;
+- loopback-only authenticated SOCKS/HTTP frontends;
+- Desktop intent/generation lifecycle and fail-closed Browser request gate;
+- standard PKI plus narrow vendor leaf binding;
+- no global DNS/route/system proxy mutation.
+
+### 5.2 Target dependency direction
+
+```text
+Desktop / Headless adapters
+        ↓
+Application coordinator + sanitized Control/Event API
+
+AuthenticationOrchestrator
+        ↓
+AuthenticatedGatewaySession | PendingAuthTransaction
+        ├── Session services
+        │    ├── ResourceProvider
+        │    ├── NoticePolicyProvider
+        │    └── Upgrade/SessionPolicyProvider
+        └── CampusModernL3Exit / evidence-gated WebVpnExit
+                 ↓
+          GatewayUnderlayPolicy / GatewayDialer
+
+Ingress
+  ├── Campus Browser (multi-exit policy)
+  ├── campus-only SOCKS / HTTP
+  ├── PAC / SSH adapters pinned to Campus by default
+  └── optional future TUN
+        ↓
+Versioned RoutingPolicyIR + RouteEvaluationContext
+        ↓
+Ingress Router / Exit Registry
+  ├── CampusModernL3Exit
+  ├── ControlledDirectExit → DirectResolver + ControlledDirectDialer
+  └── evidence-gated WebVpnExit
+```
+
+Authentication does not depend on Routing/Ingress; DNS and frontends do not depend on concrete auth;
+Gateway Underlay never interprets EasyConnect/MFA; Direct resolution/dialing does not inherit Gateway
+Underlay identity or session generation; Renderer never owns gateway session material.
+
+### 5.3 Production provider composition
+
+The traits already exist, but production `ec-engine` still directly composes password + Modern L3. Add a
+compile-time `ProductionProviderSet` (or equivalent) before any new provider. Runtime capability reporting
+must derive from the selected provider/backend/frontend rather than a fixed list.
+
+Keep this seam deliberately narrow: a compile-time enum/factory and the existing traits, not a dynamic
+registry, plugin ABI or configuration-driven arbitrary provider loader. It must not redesign
+`ResourceProvider`, guess MFA continuation fields or add a second implementation solely to justify the
+abstraction.
+
+Capability truth has four layers: compiled capability, selected provider/backend capability, current profile
+availability and current ingress-mode capability. Expose it through an additive bounded capability response;
+do not change or reinterpret the existing Event API v1 hello schema.
+
+### 5.4 RoutingPolicyIR v1
+
+One versioned canonical policy must drive JS, internal PAC, external PAC and a Rust evaluator. Minimum types:
+
+```text
+RoutingPolicyIR
+  version / canonical rules / profile / defaults / policyRevision
+
+RouteIntent
+  scheme / host / literalIp / port / protocol
+  initiatorClass / topLevelSite / profile
+
+RouteEvaluationContext
+  routerGeneration / selectedExitGeneration?
+  navigation and bounded stickiness context
+
+RouteDecision
+  exitId / source / policyRevision
+  routerGeneration / selectedExitGeneration?
+  safetyClass / dnsPolicy / fallbackPolicy
+```
+
+The canonical IR stores no runtime generation, full URL/query or secrets. Unknown version/schema fails closed.
+Current 1.x route outcomes and persisted-rule compatibility must remain semantically equivalent before
+activation; generated PAC source is not required to remain byte-for-byte identical.
+
+### 5.5 Exit and Ingress Router boundary
+
+The current frontend directly owns `VirtualNetstack`, while Chromium `DIRECT` bypasses application-owned
+resolution/socket policy. A 2.0 `ControlledDirectExit` therefore needs a stable router lifecycle.
+
+Evaluate and decide through an ADR before production code:
+
+| Option | Advantages | Risks |
+| --- | --- | --- |
+| Separate long-lived `ec-router` with Campus Engine as an upstream Exit | Direct remains available independently; stable Browser port; clear multi-Exit ownership | Extra process/control/auth lifecycle |
+| Convert `ec-engine` into a long-lived router with replaceable Campus session | One process and shared observability | High-risk change to mature auth/stop lifecycle |
+
+Recommended preparation: test-only prototype of the separate router first. No production DirectExit is enabled
+until the ADR, threat model and three-platform lifecycle tests choose an option.
+
+The ADR/prototype must resolve four integration contracts before any frontend refactor:
+
+1. **Policy activation transaction**
+
+   ```text
+   close Browser request gate
+     → stage canonical IR in router
+     → validate and atomically activate exact revision
+     → close superseded router connections
+     → confirm revision + router generation
+     → reopen Browser request gate
+   ```
+
+   A failed activation or rollback keeps the Browser blocked; it never continues on an old unconfirmed policy.
+
+2. **Router-to-Campus upstream authorization** — generation-bound credentials travel only through a private
+   pipe/owner-only sidecar, never argv, PAC, logs or ordinary settings. Engine restart/port change atomically
+   replaces the upstream; stale router state cannot use an old Engine credential.
+
+3. **Dual-process ownership** — define Desktop quit, router/Engine crash, update, orphan cleanup, stable
+   Browser port, independent router/Engine readiness and 100-cycle PID/port/timer/credential residue tests.
+
+4. **Per-ingress policy** — Campus Browser may evaluate Campus/Direct rules. Existing SOCKS, Clash and SSH
+   remain pinned to `CampusModernL3Exit` unless a future separately reviewed advanced policy explicitly says
+   otherwise. Browser domain rules never silently send SSH/SOCKS Direct.
+
+### 5.6 UnderlayPolicy
+
+First add a behavior-preserving `SystemDefaultUnderlay` that owns Gateway resolution, HTTP client creation
+and every Modern token/data socket. Only after that can explicit interface binding be implemented. Automatic
+selection, country/IP display and multi-exit scoring remain evidence-triggered.
+
+The seam must prove that discovery/auth/config/resource/logout requests, Modern token HTTPS and the
+address-control/send/receive special TLS sockets share one Gateway underlay identity and generation. A policy
+change invalidates the authenticated session, token and all data sockets. Future explicit binding fails closed
+instead of falling back unbound; `.no_proxy()`, hostname PKI/leaf binding and same-peer constraints remain
+unchanged.
+
+### 5.7 Session services
+
+The current `ResourceProvider` is an offline parser scaffold, not a final production ABI. A real session
+service needs authenticated request ownership, revision/expiry, session generation, opaque launch material
+and explicit authorization semantics. Define only after a real official resource retrieval observation.
+
+## 6. Candidate capability inventory
+
+The broader historical candidate inventory remains in
+[`FEATURE_PARITY.md`](../../independent/spec/FEATURE_PARITY.md); its entries are research candidates, not
+automatic 2.0 scope.
+
+| Capability | Current state | Next evidence/architecture action |
+| --- | --- | --- |
+| Password + Modern L3 | Production foundation | Preserve as regression oracle |
+| Gateway MFA | Generic `I2/E2`; real provider absent | Implement only the first school-enabled method after the EC-6 evidence/activation gate |
+| Resource catalogue | Offline `I2/E2` | Observe authenticated retrieval/refresh/authorization, then revise provider contract |
+| Notices/kick/password expiry/upgrade | Classifier/event scaffold | Observe real server states and add typed session services |
+| WebVPN | Typed slot only | Require an L3-disabled school profile and official parity |
+| Multi-line | Offline endpoint parse only | Prove discovery, auth/data endpoint relation and token portability |
+| RoutingPolicyIR | Missing | First neutral 2.0 core implementation |
+| Exit/Ingress Router | Missing | ADR + test-only lifecycle prototype |
+| ControlledDirectExit | Missing | Only after router decision; resolved-address/rebinding deny tests |
+| Underlay binding | Missing | No-op common dial boundary, then explicit fail-closed binding |
+| aTrust | No HKUST evidence | Research-only; no near-term production backend |
+| TUN/FakeIP | Deferred by ADR | Optional future Ingress only after a proven unmet use case |
+
+## 7. Planned PR sequence
+
+### 2.0-P0 — Preparation and evidence ledger (this PR)
+
+- this execution plan;
+- fixed EasyConnect sample manifest and clean-room workflow;
+- fixed zju-connect observation ledger;
+- current capability matrix references;
+- no production code or version change.
+
+### 2.0-P1 — Production Provider Composition Seam
+
+- route current password + Modern L3 through one compiled provider set;
+- derive a sanitized runtime capability snapshot;
+- run production and synthetic providers through the same coordinator;
+- use only a narrow compile-time enum/factory; no plugin ABI or speculative provider contract;
+- publish capabilities through an additive API while Event API v1 remains unchanged;
+- no real MFA and no external behavior change.
+
+### 2.0-P2 — RoutingPolicyIR v1, offline only
+
+- canonical schema/serialization/revision;
+- current rule/resource compiler;
+- JS/PAC/Rust differential evaluator;
+- 100,000 deterministic/property cases;
+- semantic route equivalence and persisted-rule compatibility;
+- no production traffic switch.
+
+### 2.0-P3 — Router topology ADR and test-only DirectExit prototype
+
+- compare separate router and long-lived unified Engine before changing production frontends;
+- specify policy activation transaction, private Campus upstream authorization and dual-process ownership;
+- specify Browser multi-exit versus campus-pinned SOCKS/Clash/SSH ingress policy;
+- test strict local auth, revision/generation, DNS rebinding, loop prevention and 100-cycle cleanup;
+- prototype excluded from packages.
+
+### 2.0-P4 — Campus Exit contract, behavior preserving
+
+- implement `ExitId`, capabilities and typed failures according to the approved P3 topology;
+- wrap current VirtualNetstack/DNS as `CampusModernL3Exit`;
+- if the separate router wins, keep the existing Engine frontend campus-only and adapt it as an upstream;
+- if the unified Engine wins, only then make its local frontend depend on the Exit interface;
+- keep one production Exit, no fallback and no production Direct activation.
+
+### 2.0-P5 — First evidence-gated capability and stability
+
+- choose one capability with real school evidence: authenticated resources, notices/session policy, first real
+  MFA provider, L3-disabled WebVPN or confirmed multi-line;
+- require the EC-6 parity/canary/rollback gate;
+- keep all unrelated providers and Exits disabled.
+
+### 2.0-P6 — ControlledDirectExit activation
+
+- only after P3/P4 and the P5 stability gate;
+- preserve one Browser Session, Cookies, POST and SAML continuity;
+- no silent Direct↔Campus fallback;
+- independent feature rollback.
+
+### 2.0-P7 — SystemDefaultUnderlay seam
+
+- one Gateway policy/generation for discovery/auth/config/resource/logout/token and three data sockets;
+- DirectResolver/DirectDialer remains a separate ownership/generation axis;
+- behavior unchanged; no interface enumeration or auto-selection.
+
+### 2.0-P8+ — Additional evidence-triggered capabilities
+
+Continue one capability per PR. Each has an independent fixture, canary, capability upgrade and rollback.
+Do not combine MFA, resources, WebVPN, multi-line, Underlay or TUN work.
+
+## 8. Common quality and security gates
+
+Every implementation PR must pass:
+
+- Rust fmt, Clippy `-D warnings`, full tests and module-boundary tests;
+- Desktop unit, architecture/cycle and real Electron tests;
+- exact-index and exact-tree secret scans;
+- parser/property/fuzz and failure injection for changed protocol surfaces;
+- macOS/Windows/Linux package verifier when production files change;
+- password + Modern L3 regression with no behavior/performance regression;
+- unknown capability/state fail-closed;
+- no default system DNS/route/global proxy mutation;
+- no URL/query, Cookie, token, OTP or credential in logs/events;
+- same-profile official parity and staff canary for proprietary capabilities;
+- explicit rollback and capability downgrade rules.
+
+## 9. Approval gate and immediate next step
+
+After this preparation PR is reviewed, implementation begins with **2.0-P1 Production Provider Composition
+Seam** only. It is deliberately behavior-preserving and creates the smallest safe attachment point for later
+capabilities.
+
+Before any broader EasyConnect dynamic analysis, the school must also:
+
+1. complete the authorization record;
+2. provide or approve acquisition of a pristine official installer;
+3. confirm restricted artifact storage and retention;
+4. select the first real capability to validate after the architecture foundation.
+
+No 2.0 production feature or release is authorized by this plan alone.
+
+P0–P4 may proceed as reviewable, behavior-preserving/offline preparation after this plan is approved. Any
+production capability activation in P5/P6 or later also requires the applicable 1.x freeze evidence or an
+explicit documented maintainer risk acceptance; preparation work never silently waives those gates.

--- a/docs/product/2.0-product-definition.md
+++ b/docs/product/2.0-product-definition.md
@@ -1,0 +1,446 @@
+# Campus Connect 2.0 Product Definition
+
+- Status: Product direction; does not authorize unverified protocol capability or a production release
+- Current implementation baseline: `ed47f93f6594c7ae41ef344f08fa0aa6b5c47fc2`
+- Architecture preparation: PR #7; exact head remains authoritative in GitHub and the merge commit
+- First user-visible Beta: HKUST(GZ)-only
+
+## 1. Product definition
+
+Campus Connect 2.0 is:
+
+> **Campus Workspace + Secure Access Runtime**
+>
+> A resource-first campus access workspace for students, researchers and developers, backed by an independent,
+> low-intrusion Rust access runtime.
+
+For an ordinary user, the product starts with campus resources, not VPN terminology. The expected flow is:
+
+```text
+open the application
+  -> search or choose a campus resource
+  -> resolve Direct or Campus access
+  -> connect and authenticate only when the resource needs Campus access
+  -> complete an evidence-supported challenge if required
+  -> open the resource in the appropriate workspace or tool
+```
+
+The runtime continues to expose explicit SOCKS, HTTP, PAC, Clash and SSH integration for advanced users, but
+those mechanisms are not the ordinary-user information architecture.
+
+### Product principles
+
+1. **Resource first:** users choose what they want to open; connection state is supporting context.
+2. **Low intrusion:** the default product does not take ownership of system DNS, default routes or the global
+   system proxy.
+3. **Protocol hidden by default:** terms such as SOCKS, L3, Exit, Underlay and generation belong in Advanced
+   Mode and diagnostics.
+4. **Explicit trust boundaries:** school, account, Browser state, website credentials, certificate decisions,
+   routing policy and Engine lifetime are never silently shared across security scopes.
+5. **Evidence before support:** code or a static vendor module is not proof that a school enables a capability.
+6. **Actionable failure:** every terminal failure tells the user what failed, what remains safe and what action
+   is available.
+7. **Local ownership:** credentials, favorites, recent resources, Browser state and rules remain on the user's
+   device. This definition does not introduce cloud account synchronization or export.
+
+### Non-goals
+
+2.0 is not a Rust clone of EasyConnect, a GUI wrapper around zju-connect, a promise of universal Sangfor
+compatibility or a default full-device VPN. It does not treat global network mutation, certificate bypass,
+terminal-compliance impersonation, RemoteApp or arbitrary Gateway probing as baseline product features.
+
+## 2. Product surfaces and runtime
+
+```text
+Campus Connect Product
+|
+|-- Campus Connect Desktop
+|   |-- Student Home
+|   |     resource search / categories / favorites / recent / notices
+|   |-- Campus Workspace
+|   |     multi-tab Web access / Campus-Direct routing / SSO continuity
+|   |-- Developer Access
+|   |     SOCKS / HTTP / PAC / Clash / SSH / future scoped launchers
+|   `-- Connection Center
+|         authentication / tunnel / DNS / lifecycle / actionable diagnostics
+|
+`-- Headless Mode
+      future independent CLI/service distribution for servers and automation
+
+Secure Access Runtime
+|-- profile and workspace isolation
+|-- authentication and session ownership
+|-- resource and routing policy
+|-- Campus and controlled future Exit implementations
+`-- Rust data plane and loopback frontends
+```
+
+The five product surfaces are views over one capability truth. A feature that is unavailable in the active
+profile is absent or clearly marked unsupported; a Renderer type, synthetic fixture or vendor clue cannot make
+it appear supported.
+
+## 3. Capability truth vocabulary
+
+This document uses four labels:
+
+- **Current:** present in the fixed 1.x production source and backed by repository tests or package evidence;
+- **Beta target:** required before the first HKUST-only 2.0 user Beta;
+- **Evidence-gated:** designed, but visible only after the selected school profile and production path have the
+  evidence required by the capability matrix;
+- **Deferred:** deliberately outside the first Beta and not implied by the 2.0 name.
+
+The implementation/evidence levels in the
+[`2.0 Capability Matrix`](../architecture/2.0-capability-matrix.md) remain authoritative. Proprietary
+capabilities are not user-visible as Supported until they reach the matrix's production and school-evidence
+gate.
+
+## 4. Student Home
+
+### Current
+
+The existing Connect page provides:
+
+- one HKUST(GZ) connection card and manual power switch;
+- a URL field that opens the Campus Browser;
+- one merged Web-shortcut list capped at 32 entries, including six packaged entries and locally managed custom
+  entries;
+- a Campus or Direct route on each shortcut;
+- local add, edit, delete and ordering for custom shortcuts;
+- connection details that can be expanded when needed.
+
+The current resource shape is deliberately small: `id`, `name`, `description`, `url`, `route` and `builtin`.
+There is no resource-wide search, category, favorite, recent history, typed SSH/database/Jupyter launcher,
+authenticated catalogue revision or authorization state.
+
+### Beta target
+
+Student Home becomes the default ordinary-user page and provides:
+
+- local search across reviewed built-in and user-created resources;
+- categories, favorites and recent resources stored only in the active workspace;
+- clear source labels such as School reviewed and Added on this device;
+- a compact availability state and one primary Open action;
+- Direct/Campus wording only when it helps the user recover or understand a decision;
+- school notices only when backed by a typed, evidence-supported session event;
+- an expandable connection summary rather than a connection-first home page.
+
+The first Beta resource catalogue remains bounded and local. It may introduce a versioned display model, but
+it must not claim authenticated server-resource retrieval or authorization semantics that production does not
+yet implement.
+
+### Resource-priority interaction
+
+```text
+select resource
+  -> resolve its trusted source, type and route
+  -> Direct: open without starting or waiting for the Campus Engine
+  -> Campus: ensure the current Engine generation is ready
+       -> request credentials/challenge only if required
+       -> open after the request gate and routing policy are committed
+  -> failure: keep the resource selected and show a category-specific recovery action
+```
+
+This includes a behavior change from the current control path: `CampusBrowserManager.open()` currently invokes
+its connection callback before opening both Campus and Direct requests, even though the Browser itself can
+route a tab Direct. The Beta must use the normalized resource route to avoid starting the Engine for a Direct
+resource.
+
+### P8 Beta resource domain
+
+P8 introduces `ResourceDescriptorView` with a non-authorizing opaque `resourceHandle` before any typed launcher
+is activated. An explicit launch request lets Main prepare and immediately consume a short-lived one-use
+`LaunchHandle`; it is never stored in the list view. The first
+Beta must production-enable reviewed/local Web, resource-scoped SSH configuration and the bounded temporary TCP
+ForwardLease baseline. UDP, database, Jupyter, file, Remote Desktop and WebVPN remain typed unsupported or
+evidence-gated. Renderer receives display fields and `resourceHandle` only, never raw server authorization
+data, hidden session parameters, Cookies or vendor configuration.
+
+WebVPN, per-application TCP, file integration and RemoteApp are distinct capabilities; they are not created by
+adding a new resource type to the UI.
+
+## 5. Campus Workspace
+
+### Current
+
+The current Campus Browser already provides:
+
+- a resizable multi-tab window with a normal tab strip and navigation toolbar;
+- address navigation, back/forward/reload, find-in-page, keyboard shortcuts and page zoom;
+- one fixed persistent Electron Session that preserves Cookie, POST, SAML and SSO continuity;
+- Campus/Direct selection and remembered exact-domain or subdomain rules;
+- a transactional PAC update, connection close and fail-closed request gate during routing changes;
+- a local exact-HTTPS-origin website credential vault with OTP/MFA-safe save and fill controls;
+- exact-origin certificate exception management;
+- save-location confirmation for downloads;
+- popup capture into controlled tabs, non-Web navigation denial and default permission denial;
+- bounded tabs, slow-load indication, redacted failure pages and per-tab renderer-crash recovery.
+
+Current limitations must remain visible in planning:
+
+- the Session, credential vault, certificate store and routing rules are one HKUST-wide namespace, not yet
+  profile- or account-scoped;
+- Chromium `DIRECT` is an accepted 1.x boundary, not the future `ControlledDirectExit` guarantee;
+- real cross-origin school SSO and navigation parity still require a current controlled canary;
+- a generic challenge framework exists, but no real HKUST Gateway MFA provider is claimed.
+
+### Beta target
+
+Campus Workspace preserves the existing Browser behavior while adding:
+
+- one isolated persistent workspace namespace for the built-in HKUST profile and active account;
+- transparent migration of the existing HKUST Browser partition and local stores;
+- resource-originated tabs with source, route and failure context;
+- Direct resource launch without unnecessary Campus connection;
+- a concise route explanation with an advanced link to the matching rule;
+- category-specific error actions without exposing a complete sensitive URL;
+- Student Home handoff that does not lose POST, Cookie or SAML state;
+- bilingual keyboard navigation, visible focus and usable 200% zoom/reflow.
+
+The first UI exposes one primary account only, but storage is account-ready from P3 and must not make a future
+second account share Browser state or website credentials. The exact model is fixed by
+[`ADR-0004`](../adr/0004-profile-account-workspace-scope.md).
+
+### Evidence-gated later capabilities
+
+- authenticated school resource catalogue and refresh;
+- school-observed Gateway MFA or controlled Gateway SSO;
+- a distinct `WebVpnExit` on a profile that lacks L3 access;
+- controlled Direct socket ownership instead of Chromium's bare `DIRECT`;
+- a second reviewed school profile and, later, Advanced custom-Gateway onboarding.
+
+## 6. Developer Access
+
+### Current
+
+Advanced users can currently use:
+
+- one loopback SOCKS5 endpoint;
+- authenticated HTTP CONNECT and bounded HTTP/WebSocket forwarding on the same local frontend;
+- external PAC, Clash node and SSH `ProxyCommand` configuration generated by the application;
+- a configurable local port, auto-reconnect, startup and auto-connect controls;
+- strict local proxy authentication for new installations, with an explicit compatibility choice for legacy
+  local clients;
+- routing rules for exact domains and subdomains;
+- connection, DNS and local-process diagnostics.
+
+The current SSH action copies generic proxy configuration; it is not an integrated SSH client or a typed HPC
+resource launcher. The current product does not provide general TCP/UDP port forwarding, database/Jupyter
+launchers, per-application routing or TUN.
+
+### Beta target
+
+The first Beta preserves all current advanced integrations and moves them behind an explicit Advanced Mode.
+It adds clearer ownership and explanation, not speculative protocol breadth:
+
+- copy-ready SOCKS, HTTP, PAC, Clash and SSH configuration with local-auth state shown;
+- resource-scoped one-click SSH configuration using the existing authenticated proxy/ProxyCommand boundary;
+- an account-scoped, loopback-only temporary TCP ForwardLease baseline with explicit expiry and cleanup;
+- route decision source and DNS mode without full destination logging;
+- a safe Test access action using reviewed targets only;
+- reset/reconnect actions tied to a typed failure instead of a generic retry button;
+- no weakening of loopback binding, TLS validation or Campus DNS fail-closed behavior.
+
+General UDP forwarding, database/Jupyter-specific launchers and an integrated SSH client are post-Beta features.
+The Beta SSH/TCP baseline still requires the ResourceDescriptor/opaque-launch model, listener ownership, cleanup
+and authorization tests; it is not implied by the existing SOCKS endpoint.
+
+## 7. Connection Center
+
+### Current
+
+The current control UI can display or manage connection state, assigned Campus IP, duration, Gateway latency,
+active local connections, DNS mode, applications observed using the local port, reconnect policy, logs and
+updates. The Engine and Desktop already emit structured lifecycle/error codes for many authentication,
+listener, data-plane and shutdown failures.
+
+The current product is still connection-first, shows raw logs as its notification surface, and does not map
+every failure to a user action. Generic OTP/CAPTCHA/token/approval UI is synthetic framework support; unknown
+authentication remains fail-closed and no school-specific MFA support is advertised.
+
+### Beta target
+
+Connection Center becomes a secondary status and recovery surface:
+
+- compact states: Ready, Connecting, Needs action, Degraded and Disconnected;
+- the active profile/account, Campus IP and DNS mode;
+- one current issue with a primary action and an expandable technical code;
+- session lifecycle and school notice cards only for production-supported typed events;
+- redacted three-day diagnostics with a temporary advanced diagnostic mode;
+- no hostname, complete URL, Cookie, token, OTP or credential in default diagnostics.
+
+Multi-line selection, explicit Underlay binding, automated path selection, real Gateway MFA providers and
+server-driven resource state are Evidence-gated or Deferred. Connection Center must not render static vendor
+capability clues as available controls.
+
+## 8. Headless Mode
+
+### Current
+
+The repository contains a macOS shell wrapper for the independent Engine. It can use Keychain, start an
+authenticated loopback SOCKS listener, report status, test a reviewed endpoint and install a user LaunchAgent.
+The Rust Engine also has a direct CLI contract with credentials supplied through standard input.
+
+This is maintained tooling, not yet a formal cross-platform Headless product. There is no supported neutral
+profile schema, stable machine-readable control/status API, Windows/Linux service lifecycle, Docker secret
+contract or general forwarding product surface.
+
+### Target after the first Beta
+
+Headless Mode becomes a separately documented CLI/service distribution sharing the Secure Access Runtime:
+
+- profile and non-secret configuration separated from credentials;
+- credentials from OS secure storage, stdin/FD, Docker secret or an owner-only control channel, never argv;
+- machine-readable status and stable error codes without secret-bearing logs;
+- loopback and strict authentication by default;
+- bounded reconnect and clean service shutdown;
+- launchd/systemd/Windows service and container guidance verified independently;
+- no root requirement for the proxy-first runtime;
+- no default TUN, DNS hijack or wildcard listener.
+
+Headless Mode is not required for the first HKUST-only Desktop Beta and does not inherit Desktop credentials
+without explicit user authorization.
+
+## 9. Ordinary, Advanced and Headless modes
+
+| Area | Ordinary Mode | Advanced Mode | Headless Mode |
+| --- | --- | --- | --- |
+| Primary entry | Student Home and resource search | Developer Access and Connection Center | CLI/service control |
+| Login | School, account, password and supported challenge | Profile identity and capability details | Explicit profile plus secret channel |
+| Network wording | Available / needs connection / needs action | route source, DNS mode, Exit and generation | stable state/error JSON |
+| Resources | search, favorite, recent and Open | route/launch details and local integration | opaque resource ID where supported |
+| Proxy tools | hidden | SOCKS/HTTP/PAC/Clash/SSH | configured loopback listener |
+| Custom Gateway | absent from first Beta | experimental only after reviewed admission gates | unsupported until the same gates pass |
+| TUN | absent | Deferred experimental component | absent by default |
+| Diagnostics | concise action | redacted technical detail | redacted structured events |
+
+Advanced Mode is a presentation choice, not permission to bypass TLS, destination safety, proxy authentication,
+profile isolation or capability evidence. Switching modes does not duplicate credentials or start another
+Engine.
+
+## 10. First HKUST-only 2.0 Beta
+
+### Included
+
+- one packaged and reviewed HKUST(GZ) profile;
+- internal profile/workspace namespace and journaled migration of current HKUST data;
+- Student Home with resource search, categories, favorites and recent items;
+- bounded reviewed and local Web resources with clear source and route;
+- the current multi-tab Campus Browser, route rules, password vault, certificate management and downloads;
+- Direct Web resources opening without starting or waiting for the Campus Engine;
+- Campus resources triggering password authentication and connection on demand;
+- current SOCKS/HTTP/PAC/Clash/SSH integrations in Advanced Mode;
+- resource-scoped one-click SSH configuration over the existing authenticated proxy boundary;
+- a bounded account-scoped, loopback-only temporary TCP `ForwardLease` baseline with expiry and cleanup;
+- Connection Center with actionable error categories and redacted technical details;
+- current password + Modern L3 + Campus DNS path only;
+- Chinese and English UI, keyboard navigation and basic accessibility checks;
+- package, migration, secret, architecture and regression gates for the shipped platforms.
+
+### Explicitly not included
+
+- a public `Other` Gateway entry or a second school;
+- claimed support for CAPTCHA, SMS, TOTP, certificate, SSO or another Gateway MFA method without current school
+  evidence and a production provider;
+- authenticated server resource retrieval;
+- aTrust, WebVPN, Legacy L3 or per-application TCP backends;
+- general UDP forwarding, database/Jupyter-specific launchers or an integrated SSH client;
+- Multi-line, explicit/automatic Underlay selection or public-IP/country scoring;
+- TUN/FakeIP, global DNS/route/proxy mutation or simultaneous school tunnels;
+- RemoteApp, mobile clients, a remote profile marketplace or dynamic protocol plugins;
+- a formal cross-platform Headless distribution.
+
+Architecture seams may be implemented before their UI activation. Their existence does not expand the Beta
+support statement.
+
+## 11. Actionable error contract
+
+Every terminal user-visible failure has a stable category, a short explanation, one safe primary action and an
+expandable redacted code. The product must not recommend changing routes or retrying credentials when that
+cannot address the failure.
+
+| Category | Ordinary explanation | Primary action | Must not do |
+| --- | --- | --- | --- |
+| Account or password | The school rejected the account or password | Edit credentials and retry | loop indefinitely or expose server body |
+| Additional verification | The school needs another verified step | Complete supported challenge | save OTP or guess an unsupported method |
+| Unsupported authentication | This school requires a method this version cannot safely complete | Cancel and show supported next step | downgrade or resend the password elsewhere |
+| Gateway identity/configuration | The school Gateway could not be verified or is incompatible | Retry later or update the app/profile | bypass TLS or trust a Browser certificate pin |
+| Local listener | The local access port is unavailable | Choose a free port or stop the conflicting owner | kill unrelated processes |
+| Tunnel/data plane | The secure Campus path stopped | Reconnect the current profile | silently send Campus traffic Direct |
+| Campus DNS | The Campus name could not be resolved inside the tunnel | Retry connection or contact school support | use public/system DNS fallback |
+| Routing policy | The resource may be using the wrong path | Review Campus/Direct choice and remember it | change unrelated domains automatically |
+| Website | The route is available but the site failed | Reload or open the route explanation | label one site failure as tunnel failure |
+| Local data migration | Local secure state could not be recovered safely | Retry recovery or sign in again after explicit reset | silently restore stale pins/rules or reset the port |
+| Update/compatibility | This version cannot continue safely with the current Gateway | Open verified release guidance | execute a Gateway-delivered component |
+
+Generated error content and copied diagnostics display at most a safe origin and stable code. Full SAML/OAuth
+URLs, response bodies and secrets do not enter default logs or diagnostic payloads.
+
+## 12. Product quality metrics
+
+### Ordinary-user experience
+
+- a default user can open a reviewed resource without seeing SOCKS, PAC, L3, Exit or Underlay terminology;
+- a Direct resource starts or waits for the Campus Engine `0` times;
+- a Campus resource that needs connection reaches the existing authentication flow without a separate manual
+  power-switch step;
+- local Student Home search/update p95 is `<100 ms` on the release reference machine;
+- every terminal state shown in the UI has a stable category and at least one valid action;
+- every primary flow is available in Chinese and English and is keyboard reachable;
+- the control UI and Browser remain usable at 200% zoom.
+
+### Resource integrity
+
+- every displayed resource has a bounded ID, source, type, route and trust label;
+- local and reviewed resources are visually distinguishable;
+- an unsupported resource capability opens `0` network sessions;
+- raw server authorization material exposed to Renderer equals `0`;
+- favorites/recent state never changes route authorization or server entitlement.
+
+### Isolation and security
+
+- Profile A credential, Cookie, pin, rule, resource state and event visible in Profile B equals `0`;
+- Account A credential, Cookie, pin, rule, resource state and event visible in Account B equals `0`;
+- public/system DNS fallback for Campus names equals `0`;
+- non-loopback production listeners equal `0`;
+- default log entries containing full URL, hostname detail, password, OTP, Cookie or token equal `0`;
+- 100 forced exits leave system DNS, default route and global proxy changes equal `0`;
+- unknown capability downgrade and silent Campus-to-Direct fallback equal `0`.
+
+### Reliability and performance
+
+- 100 connect/disconnect/reconnect cycles leave Engine/listener/timer residue equal `0`;
+- 100 profile/workspace activation cycles leave stale Browser request or Engine event effects equal `0`;
+- 20-tab switch p95 remains `<100 ms`;
+- tray idle CPU median remains `<1%` on the release reference machine;
+- throughput/latency regression against the fixed 1.x same-machine baseline is no more than `5%`;
+- sleep, network change and Engine restart cannot let an old generation continue sending.
+
+### Release truth
+
+- first-Beta release notes list only shipped and verified capabilities;
+- implementation and evidence levels are updated together;
+- package verification, secret scan, architecture gates and relevant three-platform builds pass for the exact
+  release commit;
+- features marked Evidence-gated or Deferred do not appear as enabled controls.
+
+## 13. Evidence map
+
+| Product statement | Repository evidence | What it proves |
+| --- | --- | --- |
+| Current connection-first control UI | [`desktop/renderer/index.html`](../../desktop/renderer/index.html), [`desktop/renderer/app.js`](../../desktop/renderer/app.js) | current pages, controls and resource-open flow |
+| Current Web shortcut model | [`campus-resources.js`](../../desktop/lib/campus-resources.js), [`campus-resource-store.js`](../../desktop/lib/campus-resource-store.js), [`campus-resources.json`](../../desktop/assets/campus-resources.json) | bounded Web-only resource fields, routes and local editing |
+| Current Browser surface | [`campus-browser.html`](../../desktop/renderer/campus-browser.html), [`campus-browser.js`](../../desktop/lib/campus-browser.js) | tabs, toolbar, route control, download, error and credential behavior |
+| Browser Session and request gate | [`browser-session-manager.js`](../../desktop/lib/browser-session-manager.js) | one persistent PAC Session, transaction and fail-closed gate |
+| Resource-triggered connection limitation | [`campus-browser-manager.js`](../../desktop/lib/campus-browser-manager.js), [`campus-open-policy.js`](../../desktop/lib/campus-open-policy.js) | manager currently connects before open; route helper can distinguish Direct |
+| Current typed errors | [`engine-output.js`](../../desktop/lib/engine-output.js), [`login-flow.js`](../../desktop/lib/login-flow.js) | existing stable categories and current UI progression |
+| Current macOS Engine wrapper | [`hkustgzconnect`](../../hkustgzconnect) | Keychain/stdin, loopback auth, launchd and status tooling; not cross-platform product proof |
+| Multi-school security boundary | [`ADR-0003`](../adr/0003-multi-school-profile-and-custom-gateway.md) | immutable profile/Gateway identity, probe and storage isolation design |
+| Profile/account/workspace boundary | [`ADR-0004`](../adr/0004-profile-account-workspace-scope.md) | account-ready storage, Browser/vault/rule ownership, switch and migration contracts |
+| Typed resource/launcher boundary | [`resource-domain-model.md`](../architecture/resource-domain-model.md) | descriptor/view/handle, authorization, launch, search/favorite/recent and P8 gates |
+| 2.0 network architecture | [`2.0 Vision`](../architecture/2.0-vision.md) | Ingress, Router, Exit and Underlay target boundaries |
+| Capability support truth | [`2.0 Capability Matrix`](../architecture/2.0-capability-matrix.md) | current implementation/evidence and promotion rules |
+| Planned architecture sequence | [`2.0 Execution Plan`](../plans/2.0-preparation-execution-plan.md) | preparation work and production activation gates |
+
+This evidence map fixes what the product can claim today. The Beta targets above remain requirements until the
+matching implementation, tests, package evidence and—where proprietary behavior is involved—school canary are
+complete.

--- a/docs/research/easyconnect/README.md
+++ b/docs/research/easyconnect/README.md
@@ -70,4 +70,6 @@ attestation/private keys or activity outside the authorized matrix.
 
 The installed macOS application is an `installed-mutated` sample because runtime-created socket entries are
 present inside the bundle. It is useful for topology clues but must not be treated as a pristine official
-file baseline. Acquire a signed, hash-fixed installer before extraction or version-differential work.
+file baseline. Its authorized static topology observation is recorded in
+[`macos-7.6.7-static-observation.md`](macos-7.6.7-static-observation.md). Acquire a signed, hash-fixed
+installer before version-differential or official-parity work.

--- a/docs/research/easyconnect/README.md
+++ b/docs/research/easyconnect/README.md
@@ -1,0 +1,73 @@
+# EasyConnect interoperability research boundary
+
+This directory contains neutral, sanitized research records only. It does not contain, and must never
+contain, official installers, application bundles, ASAR contents, native modules, captures, decompiler output
+or authentication material.
+
+## Evidence identities
+
+Every input is classified as one of:
+
+- `pristine-package`: fixed installer from an approved channel, signature and hash verified;
+- `installed-mutated`: an installed/used application; useful only for clues, never a reproducible baseline;
+- `gateway-observation`: one authorized fixed profile/run;
+- `sanitized-baseline`: hash/length/count/state summary derived under the clean-room process;
+- `public-source-reference`: third-party public source used only for engineering ideas.
+
+## Workflow
+
+```text
+authorization
+  → acquisition and signature/hash manifest
+  → restricted read-only extraction
+  → static/dynamic observation
+  → restricted raw evidence
+  → neutral fact review
+  → synthetic/redacted fixture
+  → exact secret/binary scan
+  → implementation handoff
+  → parity/canary/destruction receipt
+```
+
+The analysis team may inspect approved official artifacts. The implementation team receives only reviewed
+neutral specifications and synthetic fixtures. The validation team compares official and independent clients
+on the same authorized profile.
+
+Complete ASAR/file inventories, module graphs and symbol/reference listings remain restricted raw evidence.
+Git may retain only bounded counts, neutral categories and reviewed schema classes derived from them.
+
+## Allowed Git content
+
+- public package URL or approved opaque internal evidence record ID; never an internal path or URL;
+- acquisition date, size, SHA-256, publisher/signature and architecture;
+- bounded file/dependency/capability counts;
+- schema field names after sensitivity review;
+- neutral state diagrams, ordering and bounds;
+- synthetic fixtures containing no vendor bytes or production values;
+- evidence classification, redaction proof and destruction receipt.
+
+## Prohibited Git content
+
+- DMG/PKG/APP/ASAR/DEB/RPM/EXE/MSI/CAB/DLL/dylib or extracted files;
+- raw PCAP/HAR/log/process trace or crash dump;
+- decompiled/disassembled source and vendor fixed byte sequences;
+- password, OTP, Cookie, token, CSRF, TwfID, sslctx, RSA/private-key/certificate secrets;
+- assigned/private/internal addresses and hostnames;
+- account, phone, email, user or device identifiers;
+- raw authentication/configuration/resource responses.
+
+`.gitignore` is not a security boundary. Every candidate commit must also pass exact index/tree secret scans,
+binary/magic/size checks and an explicit provenance review.
+
+## Dynamic-analysis gate
+
+No broader dynamic work begins until
+[`../../../independent/cleanroom/AUTHORIZATION_TEMPLATE.md`](../../../independent/cleanroom/AUTHORIZATION_TEMPLATE.md)
+is completed and approved. Testing stops on real-user data, production instability, rate limits,
+attestation/private keys or activity outside the authorized matrix.
+
+## Current limitation
+
+The installed macOS application is an `installed-mutated` sample because runtime-created socket entries are
+present inside the bundle. It is useful for topology clues but must not be treated as a pristine official
+file baseline. Acquire a signed, hash-fixed installer before extraction or version-differential work.

--- a/docs/research/easyconnect/macos-7.6.7-static-observation.md
+++ b/docs/research/easyconnect/macos-7.6.7-static-observation.md
@@ -1,0 +1,278 @@
+# EasyConnect macOS 7.6.7 sanitized static observation
+
+- Sample: `EC-MAC-INSTALLED-7.6.7-20260823`
+- Evidence identity: `installed-mutated`
+- Analysis type: authorized, read-only static extraction
+- Credentials/session/runtime socket contents read: no
+- Vendor source or binary content committed: no
+- HKUST profile activation proven by this sample: none; an earlier, separate controlled observation covered the
+  historical password path, but this installed-mutated sample cannot prove the currently enabled HKUST profile
+  or any other school's configuration
+
+## 1. Two independent evidence axes
+
+Static implementation visibility and school-profile activation are different questions. A capability may be
+directly visible in readable client code while remaining completely unproven on a particular Gateway profile.
+They must not be collapsed into one confidence score.
+
+Static visibility:
+
+- `V4`: directly readable Electron/Web implementation or signed plist value;
+- `V3`: signed package manifest, dependency, entitlement or symbol topology;
+- `V2`: file/import/name marker only;
+- `V1`: indirect adjacency clue requiring corroboration;
+- `V0`: protected native internals or behavior unavailable to static inspection.
+
+Profile activation:
+
+- `A4`: current fixed school profile observed end to end with exact sample/run identity;
+- `A3`: controlled historical school observation, not proof of current state;
+- `A2`: sanitized profile/configuration response without end-to-end behavior;
+- `A1`: indirect school-specific clue that has not been reproduced in a controlled run;
+- `A0`: no profile evidence.
+
+Unless a section says otherwise, implementation statements below are `V2`–`V4` static observations and their
+HKUST activation level is `A0`. The separate historical password observation is `A3`; it is not evidence from
+this macOS sample and does not establish the current HKUST configuration.
+
+A `V3` signed-manifest/topology observation does not upgrade this `installed-mutated` sample into a pristine,
+strictly verifiable or reproducible package baseline.
+
+The sample contained approximately 1,314 ASAR files, 371 Web files and 20 bundled x86_64 dynamic
+libraries. Complete inventories and extracted content remain restricted evidence; only this neutral summary is
+retained.
+
+## 2. Product architecture
+
+```text
+Electron shell and local Web portal
+  ├── window/tray/menu/crash/settings services
+  ├── broad preload + generic IPC bridge
+  └── Web authentication/resource/settings SDK
+             ↓
+      loopback ECAgent control plane
+             ↓
+  ECAgentProxy / ECAgent / EasyMonitor / svpnservice
+             ↓
+  DNS / L3VPN / TCP / VIRTUALLINE modules
+  legacy network components, privileged scripts and optional RemoteApp stack
+```
+
+The official client's feature breadth comes largely from a privileged local control plane and platform
+components. This is not the architecture target for HKUST(GZ) Connect 2.0.
+
+## 3. Electron shell and IPC
+
+Evidence locations include ASAR Main, preload, window/controller and IPC service modules.
+Evidence: `V4` implementation visibility; `A0` school-profile activation.
+
+Observed design:
+
+- one Electron composition root starts crash, IPC, tray, VPN, window and data services;
+- local/remote pages call a generic preload API, which sends typed-name but broadly shaped IPC messages to
+  Main services and ECAgent;
+- one process owns multiple login, resource, status, settings, passive-logout, rejection and RemoteApp windows;
+- tray menus expose resources, messages, link state and application actions.
+
+Useful neutral ideas:
+
+- single-instance ownership;
+- explicit request/response correlation;
+- separate window/tray/VPN/data services;
+- service-state and passive-event UI.
+
+Rejected security behavior:
+
+- global certificate-error bypass and disabled web-security switch;
+- `sandbox=false`, `contextIsolation=false`, broad preload/remote access and plugin enablement;
+- generic IPC without exact sender/origin/schema ownership;
+- remote URL windows plus arbitrary script injection;
+- raw IPC/config/agent data logging.
+
+The current HKUST Campus Browser sandbox, context isolation, exact sender checks and permission denial remain
+the required baseline.
+
+## 4. Authentication implementation
+
+Evidence: `V4` client-module visibility; `A0` activation for the listed secondary methods. The historical
+password observation remains separate `A3` evidence.
+
+The Web SDK contains separate modules for:
+
+- password/RSA/CSRF/anti-replay and CAPTCHA;
+- SMS code acquisition, cooldown and submission;
+- token/radius/security-question style continuation;
+- TOTP and rebind;
+- certificate list/import/authentication;
+- USB key and HID discovery/registration;
+- login domain/SSO;
+- WeChat, DingTalk and enterprise-WeChat QR/OAuth flows.
+
+The initialization path also checks relogin, proxy state, update/version, anti-MITM helper, HID and security
+state before advancing through multi-step authentication and service startup.
+
+2.0 migration decision:
+
+- retain Engine-owned `AuthProvider`/`AuthTransactionOwner` and bounded challenge metadata;
+- add one provider only after the method is observed on a fixed school profile;
+- keep TwfID/Cookie/CSRF/continuation in Rust;
+- keep response/resend/cancel/deadline and zeroization;
+- never infer a provider from a static module name alone.
+
+Do not migrate endpoint/field assumptions, Renderer-owned secrets, argv token/session material or raw response
+logging.
+
+## 5. Credential and settings implementation
+
+Evidence: `V4` client implementation visibility; `A0` school-profile activation.
+
+The official shell has global and per-VPN temporary/persistent stores, login history, remember-password,
+auto-relogin and multiple VPN-address records. The static implementation uses reversible local protection and
+logs configuration keys/values in several paths.
+
+2.0 may borrow only:
+
+- global versus profile-specific settings;
+- temporary versus persistent state;
+- explicit login history/profile selection;
+- transactional migration.
+
+It must retain OS secure storage, owner-only files, no secret argv, no reversible fixed-salt password storage,
+no raw settings/credential logging and no cross-profile credential reuse.
+
+## 6. Resources, SSO and service model
+
+Evidence: `V4` client implementation visibility; `A0` HKUST profile activation for the resource classes and
+service flows listed below.
+
+The official resource SDK normalizes server configuration/resource documents into groups and multiple resource
+classes, including Web, IP, application, DNS, FTP, file share, mail, RemoteApp/terminal and SSO-related
+entries. It manages default/balanced resources, service start/query state, Web/EasyLink rewriting, external
+browser opening and SSO form/cookie flows.
+
+Useful neutral ideas:
+
+- authenticated session-owned resource retrieval;
+- opaque resource handles and grouped/default ordering;
+- typed resource capability and required Exit;
+- service readiness and per-resource failure state;
+- passive catalogue refresh and balance/revision updates.
+
+Rejected behavior:
+
+- putting session identifiers in URLs;
+- hidden-form credential/phone/certificate injection without exact origin and authorization;
+- ActiveX/remote automation assumptions;
+- interpreting opaque authorization fields without parity evidence;
+- treating Web resource rewriting as ordinary HTTP proxying.
+
+The current Campus Browser already provides multi-tab navigation, one fixed persistent Session, explicit
+Campus/Direct routes, a local credential vault and certificate trust controls. It is not yet profile-scoped.
+Making those stores and the Browser partition profile-scoped is a 2.0 target that better matches this project's
+stated isolation and ordinary-user workflow goals; this static observation does not establish a comparative
+usability result.
+
+## 7. Notices, expiry and update
+
+Evidence: `V4` UI/state-path visibility; `A0` HKUST profile activation.
+
+Static UI/state paths exist for:
+
+- passive logout/session switch;
+- rejected login and concurrent-session state;
+- password change/expiry;
+- required client update, version mismatch and reinstall;
+- service startup/download/no-power failures;
+- messages, connection information and RemoteApp notices.
+
+2.0 should expose stable secret-free events such as:
+
+```text
+session_notice
+session_replaced
+password_change_required
+upgrade_required
+resource_catalogue_changed
+service_state_changed
+```
+
+Gateway-driven updates must not download/execute privileged code directly. Application updates require an
+independently signed manifest, staged rollout and rollback.
+
+## 8. Native services and platform integration
+
+Evidence: `V3` for signed package/service topology, `V2` for module/component markers and `V0` for protected
+native behavior; `A0` HKUST profile activation unless separately observed.
+
+The bundle includes:
+
+- a user LaunchAgent for `ECAgentProxy`;
+- a root LaunchDaemon for `EasyMonitor`;
+- root-owned setuid/setgid `ECAgent`, `EasyMonitor` and `svpnservice` binaries;
+- certificate management/authentication in `ECAgentProxy`;
+- DNS, L3VPN, TCP and VIRTUALLINE module declarations;
+- legacy TUN/proxy-hook components and start/stop/reset/install scripts;
+- RemoteApp/RSession components with clipboard, audio, input and graphics dependencies.
+
+The sealed package topology also contains legacy TLS/crypto material and a private-key-formatted asset. Its
+contents were not copied or retained. This reinforces the decision not to reuse the local Agent TLS design.
+
+2.0 rejects root/setuid daemons, static local TLS keys, query-string control tokens, old driver stacks and
+default RemoteApp clipboard/audio/input exposure. Optional RemoteApp support, if ever required, is a separate
+backend and security review.
+
+## 9. DNS, route, proxy and tunnel integration
+
+Evidence: `V2`–`V4` depending on whether the item is a readable configuration/UI path or only a packaged
+component marker; `A0` HKUST profile activation.
+
+Static configuration/UI paths recognize:
+
+- preferred/alternate DNS and special resource policies;
+- L3/TCP service state;
+- system proxy detection/testing and proxy credentials;
+- multi-line selection and load balancing;
+- cache/Web optimization;
+- start/stop L3/TCP, reset-DNS and legacy TUN/proxy-hook installation components.
+
+Only the following ideas are candidates for independent implementation:
+
+- profile-owned split-DNS policy;
+- typed L3/TCP service state;
+- proxy-loop/conflict diagnostics;
+- endpoint candidates, stickiness, health and explicit rollback.
+
+Global DNS/route/system proxy mutation, kext/TUN hooks, root scripts and global first-L3 ownership remain out
+of the default architecture.
+
+## 10. Logging, crash and privacy
+
+Evidence: `V4` for readable Electron/Web logging paths and `V2`–`V3` for packaged crash/native markers; `A0`
+for school-specific use.
+
+Static paths show broad logging of startup arguments, URLs, settings/configuration and Agent responses, plus
+optional heap/crash collection. These are not acceptable diagnostics boundaries for 2.0.
+
+Retain the current project model:
+
+- typed/redacted events;
+- bounded three-day logs;
+- no full URL/query, password, OTP, Cookie, token, TwfID or raw response;
+- explicit temporary diagnostic mode;
+- crash recovery without secret-bearing heap upload.
+
+## 11. Cross-project conclusion
+
+EasyConnect contributes the broadest static feature catalogue in the reviewed evidence. It becomes a behavior
+oracle only for a capability exercised in a separately authorized, fixed and sanitized parity run; this
+installed-mutated static sample is not such an oracle. Its security and system-integration architecture is not
+a template. The highest-value evidence-triggered migrations are:
+
+1. real multi-stage authentication provider;
+2. authenticated resource catalogue and service state;
+3. passive notice/password-expiry/update reason;
+4. typed endpoint/multi-line state;
+5. independently signed update policy.
+
+WebVPN, RemoteApp, aTrust, TUN and privileged platform components remain separately gated. Static presence
+does not prove that HKUST or another school enables them.

--- a/docs/research/easyconnect/sample-manifest.md
+++ b/docs/research/easyconnect/sample-manifest.md
@@ -1,0 +1,61 @@
+# EasyConnect sanitized sample manifest
+
+This manifest records identities only. No proprietary artifact is stored in the repository.
+
+## EC-MAC-INSTALLED-7.6.7-20260823
+
+| Field | Value |
+| --- | --- |
+| Evidence identity | `installed-mutated` |
+| Local source | `/Applications/EasyConnect.app` |
+| Bundle identifier | `com.sangfor.Easyconnect` |
+| Display version/build | `7.6.7` / `6` |
+| Main architecture | x86_64 |
+| Bundle size | approximately 263 MiB |
+| Publisher | Sangfor Technologies Company Limited |
+| Apple Team ID | `YYE5WQ4M88` |
+| Signature timestamp | 2024-03-15 |
+| Main executable SHA-256 | `973d2ada4d2c298afd5ba1b3bf183b8e8a71e99cda29d7e6920a7fe1cb5a721a` |
+| `app.asar` SHA-256 | `e95b49a7f52be4ca5c5d5202057c6915a144dfd6273927da9aca1afbd204571f` |
+| Topology clue | Electron shell, native agents/monitor/service, LaunchAgent/Daemon, native libraries and legacy network components |
+| Reproducible baseline | No |
+
+The installed bundle contains runtime-created socket entries, so strict bundle verification no longer proves
+the pristine installer contents. No socket content, user setting, log, credential or session was read. Do not
+extract this sample for implementation evidence; obtain a pristine installer first.
+
+## EC-LINUX-PUBLIC-7.6.7.3
+
+| Field | Value |
+| --- | --- |
+| Evidence identity | historical `pristine-package` baseline |
+| Public package label | 7.6.7.3 |
+| Debian control version | 7.6.7.7 |
+| Architecture | x86_64 |
+| SHA-256 | `ae623c6dc0354ff87afefbb770de5013bfd943051c9a653b93db708253b2f0d3` |
+| Repository material | sanitized binary/adapter JSON only |
+
+See [`../../../independent/cleanroom/EVIDENCE_LOG.md`](../../../independent/cleanroom/EVIDENCE_LOG.md)
+and the matching files under `independent/baselines/` for provenance and limits.
+
+## EC-WINDOWS-L3-7.6.7.200
+
+| Field | Value |
+| --- | --- |
+| Evidence identity | historical sanitized gateway-module baseline |
+| Module version | 7.6.7.200 |
+| Architecture | PE32 x86 |
+| Module SHA-256 | `3a93b43b7f404fb68edcff2aa952a46ee27bcc380af9cc8068bf2ccec38ed379` |
+| Repository material | adapter hash/length/patch metadata only |
+
+The original CAB/module remains restricted and is not committed.
+
+## Gateway observation
+
+The last recorded public HKUST(GZ) gateway metadata reported `M7.6.8R2`. Client/package versions and gateway
+versions are independent identities; no compatibility claim is inferred from version-number similarity.
+
+## Required next sample
+
+A pristine, signed and hash-fixed current macOS installer is the first required acquisition. Current Windows
+and Linux packages should then be fixed so version/platform differentials compare reproducible inputs.

--- a/docs/research/easyconnect/sample-manifest.md
+++ b/docs/research/easyconnect/sample-manifest.md
@@ -7,7 +7,7 @@ This manifest records identities only. No proprietary artifact is stored in the 
 | Field | Value |
 | --- | --- |
 | Evidence identity | `installed-mutated` |
-| Local source | `/Applications/EasyConnect.app` |
+| Source class | Locally installed macOS application bundle; restricted locator held outside Git |
 | Bundle identifier | `com.sangfor.Easyconnect` |
 | Display version/build | `7.6.7` / `6` |
 | Main architecture | x86_64 |
@@ -22,7 +22,9 @@ This manifest records identities only. No proprietary artifact is stored in the 
 
 The installed bundle contains runtime-created socket entries, so strict bundle verification no longer proves
 the pristine installer contents. No socket content, user setting, log, credential or session was read. Do not
-extract this sample for implementation evidence; obtain a pristine installer first.
+use this sample for official parity or version-baseline evidence; obtain a pristine installer first. The
+authorized feature/topology summary is
+[`macos-7.6.7-static-observation.md`](macos-7.6.7-static-observation.md).
 
 ## EC-LINUX-PUBLIC-7.6.7.3
 

--- a/docs/research/zju-connect/2c71a34-observation.md
+++ b/docs/research/zju-connect/2c71a34-observation.md
@@ -28,6 +28,25 @@ upstream implementation as proof that the same capability exists on the school p
 
 ## Implementation map
 
+### 2026-08-24 current-main configuration delta
+
+The protocol/network audit remains fixed at `2c71a34c17ea7ecf04c5fe862c4c315344128653`. Current upstream `main`
+is `4b2bcaa0acc34a33de672c26e3b2cb83bd583b15`, exactly one commit ahead in this review. The reviewed delta is a
+startup/configuration refactor, not evidence of a new protocol or school capability:
+
+- configuration is merged as built-in defaults `<` TOML `<` `ZJU_CONNECT_*` environment `<` explicitly supplied
+  CLI flags;
+- explicit false CLI values can override file/environment true values;
+- collection values share one parser across sources and unknown keys are rejected;
+- remote-DNS names were generalized while legacy ZJU-named aliases remain compatible;
+- upstream documentation recommends environment variables for password, TOTP secret and certificate password.
+
+2.0 independently borrows only the typed precedence/explicit-override idea for the future Headless product.
+Desktop credentials do not move to environment variables. Headless secrets prefer OS secure storage, stdin/FD,
+Docker secret or an owner-only control pipe; ordinary argv, TOML and default environment remain prohibited secret
+sources. The EasyConnect/aTrust/DNS/routing/TUN/underlay conclusions below remain anchored to the fixed protocol
+audit because the one-commit delta does not modify those implementations.
+
 ### Composition and configuration
 
 - `configs/config.go` defines CLI/TOML fields and defaults;

--- a/docs/research/zju-connect/2c71a34-observation.md
+++ b/docs/research/zju-connect/2c71a34-observation.md
@@ -1,0 +1,59 @@
+# zju-connect source observation — 2c71a34
+
+- Repository: <https://github.com/Mythologyli/zju-connect>
+- Fixed commit: `2c71a34c17ea7ecf04c5fe862c4c315344128653`
+- License: AGPL-3.0
+- Observation type: public-source architecture review
+- HKUST(GZ) real-environment evidence: none
+- Dependency decision: no source/build/link/runtime dependency
+
+This record distinguishes source presence, default CLI behavior and HKUST evidence. It does not treat an
+upstream implementation as proof that the same capability exists on the school profile.
+
+## Capability classification
+
+| Area | Source observation | Default/activation observation | HKUST decision |
+| --- | --- | --- | --- |
+| EasyConnect auth | password, CAPTCHA, SMS, TOTP and certificate paths | password default; other paths profile/flag dependent | candidate states only; no real provider without school evidence |
+| aTrust auth | password, CAS/OAuth2, SMS and bounded continuation families | protocol must be selected; not HKUST default | research-only |
+| L3 transport | EasyConnect and aTrust implementations | EasyConnect default | current Rust Modern L3 remains independent oracle |
+| Per-app TCP tunnel | aTrust resource-driven path | optional | not WebVPN; no HKUST evidence |
+| WebVPN | no Sangfor WebVPN backend observed | N/A | cannot use upstream as a WebVPN design oracle |
+| DNS | remote DNS, cache/single-flight, UDP/TCP, secondary and FakeIP | remote DNS enabled; public secondary may be automatic | borrow transport separation only; retain campus fail-closed policy |
+| SOCKS/HTTP | local frontends | wildcard and unauthenticated by default | reject; retain loopback + strict auth |
+| Underlay | explicit and opt-in auto interface binding | auto detect disabled | borrow ownership/generation ideas after a no-op seam |
+| Multi-line | EasyConnect parsing and latency selection | enabled unless disabled | require HKUST discovery/token-portability evidence |
+| TUN/FakeIP | experimental TUN, route and DNS-hijack paths | disabled unless requested | keep deferred/optional; never 2.0 default |
+| Port forwarding | TCP/UDP forwarding | explicit configuration | only after a real user need and separate threat model |
+
+## Design ideas worth independently implementing
+
+1. A centralized dial/underlay owner for gateway sockets.
+2. DNS wire/cache/single-flight and transport separation.
+3. Opaque, bounded continuation-style authentication state.
+4. Endpoint set, stickiness, failure history and hysteresis concepts.
+5. Typed separation between L3, per-application tunnel and local ingress.
+
+## Behaviors explicitly rejected
+
+- `InsecureSkipVerify` or continue-after-anti-MITM-failure behavior;
+- public/secondary fallback for split-horizon campus names;
+- wildcard unauthenticated local proxy listeners;
+- ZJU-specific routes/domains;
+- secrets in argv, TOML, stdout, logs or ordinary persisted client data;
+- TUN/FakeIP/DNS hijack and system route mutation as defaults;
+- PCAP/TLS-key-log product paths;
+- direct source translation or copying upstream fixtures.
+
+## Test and CI evidence limits
+
+Static inventory at this commit contains 33 Go test files, 224 `Test*` functions and six benchmarks. The
+current audit environment did not have Go installed, so none were executed. Upstream CI builds multiple
+architectures but does not gate `go test`, vet, lint or vulnerability scanning; a green upstream build is not
+protocol/security regression proof.
+
+## Delta from the previous fixed review
+
+Compared with `4c4b41fee599646efc1463ecf080590724b24f28`, current `main` is one commit ahead. The delta is
+documentation/argument alignment in README/config/entrypoint files; no protocol architecture change was
+observed in that delta. Future observations must still re-fix the exact upstream commit.

--- a/docs/research/zju-connect/2c71a34-observation.md
+++ b/docs/research/zju-connect/2c71a34-observation.md
@@ -26,6 +26,155 @@ upstream implementation as proof that the same capability exists on the school p
 | TUN/FakeIP | experimental TUN, route and DNS-hijack paths | disabled unless requested | keep deferred/optional; never 2.0 default |
 | Port forwarding | TCP/UDP forwarding | explicit configuration | only after a real user need and separate threat model |
 
+## Implementation map
+
+### Composition and configuration
+
+- `configs/config.go` defines CLI/TOML fields and defaults;
+- `init.go` parses configuration and builds global options;
+- `main.go` composes the selected protocol client, underlay dialer, stack, resolver, routing dialer and local
+  services.
+
+The upstream default is EasyConnect with server/domain resources, multi-line, remote DNS, wildcard SOCKS and
+HTTP listeners, plus ZJU-specific domain/private-network policy. TUN, FakeIP, DNS hijack, TCP-only tunnel and
+underlay auto-detection are opt-in. Additional server routes are flag-controlled, but enabling TUN under the
+default ZJU profile still injects the ZJU `10/8` route even when the generic `add-route` flag is false.
+
+2.0 may borrow composition by selected profile/protocol/backend/frontend. It rejects whole-config overwrite,
+secret-bearing CLI/TOML and deployment-specific defaults.
+
+### EasyConnect authentication and session
+
+Primary locations are `client/easyconnect` request, parse, protocol and client modules.
+
+Observed flow:
+
+```text
+request TwfID / discovery
+  → password configuration and RSA/CSRF login
+  → optional CAPTCHA/secondary state
+  → token from the special HTTPS/TLS session
+  → address-control request
+  → send and receive channels
+```
+
+Separate source paths exist for SMS, TOTP and certificate flows. Multi-line configuration can select another
+endpoint and restart login. Session keepalive periodically invokes the EasyConnect session update path.
+
+Migration decision:
+
+- keep current Rust `GatewaySession`, `AuthenticatedGatewaySession`, AuthTransaction and Modern L3 backend;
+- implement each observed secondary method as an Engine-owned provider transaction;
+- never copy fixed secondary numeric mappings, endpoints, raw response errors, terminal input or TLS bypass;
+- multi-line requires endpoint/auth/token-portability evidence and a generation-bound `EndpointSet`.
+
+### EasyConnect resource and L3 data plane
+
+The upstream resource parser reads server configuration/resource documents into domain/IP/port/protocol rules,
+static DNS data and DNS server candidates. `L3Conn` owns independent send/receive channel recreation over the
+special transport.
+
+Useful ideas are typed terminal/retry causes and resource-aware routing input. Rejected behavior includes
+panic-prone parser assumptions, recursive relogin and assuming that tokens survive line changes.
+
+### aTrust authentication
+
+Primary locations are `client/atrust/auth` and the aTrust client setup path.
+
+The implementation has `Session`, `LoginMethod`, discovered auth info and method-specific password, CAS/OAuth2
+and SMS flows. A bounded continuation loop handles multiple generic challenge families, device binding and
+enhanced/access checks.
+
+Useful idea: provider-owned opaque continuation with a hard step budget. Rejected behavior: TLS verification
+bypass, continue-after-anti-MITM failure, persisted ordinary-file Cookie/device state, terminal/browser hybrids
+without a private control API, and sensitive logging.
+
+Static source presence does not prove that HKUST or any custom profile supports aTrust.
+
+### aTrust resources, L3 and per-application TCP tunnel
+
+Resource parsing accepts L3VPN access-model entries and ignores WEB resources. It builds domain/IP/port policy,
+DNS policy and node groups. L3 tunnels own per-group connections, flow authentication, heartbeat, reconnect and
+node refresh. A separate resource-selected TCP tunnel performs application/node/destination authorization.
+
+The data path also constructs fixed trusted-process/environment attributes. That behavior can amount to
+terminal-compliance impersonation and is explicitly prohibited in this project.
+
+If a future school proves aTrust support, implement it as a separate Auth/Resource/Transport family without
+changing EasyConnect Modern L3. No aTrust endpoint, field or compliance attribute enters a neutral profile.
+
+### DNS and cache
+
+`resolve.Resolver`, its cache/domain-resource index, IP pool and local DNS service implement:
+
+- normalized host/resource matching;
+- static records and positive cache;
+- single-flight remote lookups;
+- UDP with delayed/concurrent TCP fallback and temporary TCP preference;
+- secondary resolver fallback;
+- optional FakeIP mapping.
+
+The broadly useful parts are single-flight, cache ownership and UDP/TCP transport health. The upstream automatic
+public secondary resolver and later hostname Direct fallback can leak/misresolve split-horizon campus names and
+are rejected. Campus DNS remains profile-owned and fail-closed; Direct uses a separate resolver.
+
+### SOCKS, HTTP and forwarding
+
+`service` contains SOCKS, HTTP CONNECT/forward, TCP/UDP forwarding, Shadowsocks and keepalive services.
+
+- SOCKS is provided by a dependency and defaults to wildcard/no-auth;
+- HTTP supports CONNECT and ordinary forwarding but has no authentication by default;
+- UDP forwarding has explicit session, queue, memory, idle and cleanup bounds;
+- TCP forwarding and several listener paths use process-level panic/error behavior.
+
+2.0 keeps the current loopback strict-auth SOCKS/HTTP implementation. It may independently borrow bounded
+queue/session ownership tests. Port forwarding is an optional authenticated profile-bound Ingress, not
+EasyConnect protocol parity.
+
+### Routing and Direct behavior
+
+The upstream `dial.Dialer` receives domain/IP resource context, matches protocol/port and chooses VPN, aTrust
+TCP tunnel or Direct. Unknown/IPv6/unsupported paths and some DNS failures can fall through Direct; a configured
+external Direct proxy is also possible.
+
+2.0 instead produces an explicit profile-scoped RoutingPolicyIR decision. Campus DNS/resource failures never
+become Direct. Direct resolution/dialing remains separate from Gateway Underlay.
+
+### Gateway underlay
+
+`internal/underlay.Dialer` supports explicit interface binding and opt-in default-interface detection on
+macOS, Linux and Windows. It can exclude the virtual address and refresh the selected interface after failure.
+
+2.0 borrows the ownership/generation concept only. It first introduces a behavior-preserving
+`SystemDefaultGatewayUnderlay` spanning discovery/auth/config/resource/logout/token and all data sockets. Later
+explicit binding fails closed and never weakens TLS hostname/leaf binding.
+
+### TUN, FakeIP and system mutation
+
+The TUN stack integrates raw IPv4, optional route injection, UDP/53 hijack and FakeIP mapping. Platform code
+modifies macOS/Linux/Windows routes and DNS and requires elevated privileges; cleanup and IPv6 coverage vary.
+
+This is a platform Ingress, not a protocol feature. It remains deferred until a real unmet use case, separate
+ADR, signed/reversible component and 100-cycle before/after residue evidence exist.
+
+### Keepalive and reconnect
+
+EasyConnect updates its session periodically and recreates L3 channels. aTrust owns heartbeat, flow auth,
+connection groups, node refresh and reconnect. Generic keepalive may query a public hostname through remote
+DNS.
+
+2.0 borrows owner/single-flight/activity/miss concepts, but timers belong to profile epoch + connection intent
++ Engine generation and use bounded backoff/jitter. Public-host DNS keepalive, infinite fixed retry and global
+process hooks are rejected.
+
+### Mobile/Android
+
+The mobile wrapper exposes a small password-only EasyConnect login and external TUN-fd adapter. It omits most
+desktop authentication/resource/policy behavior and collapses errors.
+
+It is not a cross-platform template. Mobile requires a separate credential, structured-error, OS VPN and store
+policy project after desktop provider/profile boundaries stabilize.
+
 ## Design ideas worth independently implementing
 
 1. A centralized dial/underlay owner for gateway sockets.


### PR DESCRIPTION
## 目的

将 2.0 从“更安全的多学校 EasyConnect 客户端”修订为：

> **Campus Workspace + Secure Access Runtime**
>
> 面向学生、科研/开发用户和学校维护者的资源优先校园访问工作台。

本 PR 仍然只有产品定义、授权研究摘要、ADR、能力矩阵和执行计划；不修改 1.2.3 生产连接行为、不改版本、不构建或发布安装包。

## 三项目结合方式

### EasyConnect

- 保留认证、Session、资源目录、L3/TCP/WebVPN、多线路、通知和平台能力作为官方能力目录；
- 只基于授权、固定、脱敏证据逐项迁移；
- 不复制 Agent/root daemon、全局 DNS/路由修改、证书绕过、宽 IPC 或 proprietary 内容。

### zju-connect

- 协议/网络事实固定于 `2c71a34`；另复核 current main `4b2bcaa` 的单一配置重构增量；
- 借鉴 non-secret 配置优先级、Headless、Underlay、Forwarding、资源路由和 bounded ownership 思想；
- 不复制源码/fixture、不形成 AGPL runtime dependency，不采用 public DNS/Direct fail-open、wildcard no-auth、TLS bypass、终端合规伪装或 env/argv secret 默认路径。

### 当前 HKUST(GZ) Connect

- 保留独立 Rust Engine、Engine-owned MFA transaction、Campus DNS、严格本地代理认证、generation lifecycle 和低网络侵入；
- 把现有多标签 Campus Browser、Campus/Direct、网站密码、证书 trust、自定义网站和无需 Clash 的体验升级为产品中心 Campus Workspace。

## Revision 4 核心补充

1. 新增 `docs/product/2.0-product-definition.md`
   - Student Home、Campus Workspace、Developer Access、Connection Center、Headless；
   - Ordinary / Advanced / Headless 三种产品面；
   - 资源优先、连接按需；
   - 首个 HKUST-only Beta 的 included/excluded 与量化指标。

2. 新增 ADR-0004
   - `SchoolProfile → CampusAccount → WorkspaceScope`；
   - 首版仍只有 `primary` account，但 P3 直接迁移到 account-aware 路径；
   - profile/account 双 epoch、一个 ActiveContext 事务；
   - Browser partition、VPN/site credentials、pins、favorites/recent、rules/resources/session 全部按账户工作区隔离。

3. 新增 Resource Domain Model
   - Internal/View、source/trust/type/capability/Exit/authorization/revision/expiry；
   - list view 只含 non-authorizing `resourceHandle`；Main 在显式 launch 后准备并消费 one-use `LaunchHandle`；
   - Web、SSH、TCP、UDP、Database、Jupyter、File、Remote Desktop、WebVPN；
   - P8 Beta 必须交付 Web + resource-scoped SSH config + bounded TCP ForwardLease，其他类型保持 unavailable/unsupported。

4. 重排实施路线

```text
P1  Profile/account schema + single HKUST registry
P2  Production provider composition
P3  Profile/account/workspace migration
P4  ActiveProfile/ActiveAccount coordinator
P5  Behavior-preserving HKUST GatewayConnectorGeneration
P6  Account-scoped RoutingPolicyIR
P7  Router ADR/test ec-router + Campus Exit adapter
P8  Resource Domain + Campus Workspace Beta
P9  First evidence-gated HKUST capability
P10 Second reviewed school
P11 Advanced experimental custom organization
P12 Controlled Direct + Underlay + evidence-backed multi-line
P13 CLI/headless/service + scoped forwarding
P14+ aTrust/WebVPN/TUN/mobile/RemoteApp separately
```

5. 产品顺序修正
   - 普通入口只展示 reviewed profiles；
   - `Other` 后移到第二个 reviewed school 之后，并只出现在高级设置；
   - P5 安全 connector 可提前完成，但不开放任意 Gateway；
   - Profile 与 Account 从第一轮 schema/migration 就分离，避免未来二次迁移 Cookie/密码/pin/rules。

## 安全边界

- Gateway/profile/account/config/binding 校验完成后才解密密码；
- Profile A 与 B、同一 Profile 下 Account A 与 B 的 credential/Cookie/pin/rule/resource/event 可见数均必须为 0；
- Direct 资源在 P8 可沿用已记录的 Chromium DIRECT 临时风险边界并做到 Engine start/wait=0；P12 用 ControlledDirectExit 关闭该例外；
- Headless secrets 只允许 OS store、stdin/FD、Docker secret 或 owner-only control pipe；
- `Other` probe 只识别候选 public auth surface，不宣称 L3/DNS/resource/transport；
- 不默认修改系统 DNS、默认路由或全局代理。

## 本地验证与复核

- 三路独立产品、账户生命周期、资源/跨项目终审：GO；
- Git index/tree secret gate：PASS；
- changed Markdown local links：0 broken；
- `git diff --check`：PASS；
- 无厂商原始文件、凭据、Cookie/token、用户路径或私钥进入 Git。

新 HEAD 的 GitHub CI 必须重新全部通过后才合并；旧 HEAD 的绿色检查不作为本 Revision 的证据。

## 合并后的下一步

在首个 P1 生产代码 PR 前启用 `main` branch protection：pull request、required CI、package verifier、exact-tree secret scan、no force-push/delete。随后 P1 只实现 schema + single HKUST registry + non-persistent primary compatibility view，不迁移数据、不改变 UI 或连接行为。
