### PR TITLE
docs: simplify 2.0 around web access and tool integrations

### DIFF
--- a/desktop/test/product-scope-contract.test.js
+++ b/desktop/test/product-scope-contract.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const root = path.join(__dirname, '..', '..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, ...relativePath.split('/')), 'utf8');
+}
+
+test('2.0 keeps Web resources and external tool integration as separate product domains', () => {
+  const product = read('docs/product/2.0-product-definition.md');
+  const resources = read('docs/architecture/resource-domain-model.md');
+  const integrations = read('docs/adr/0005-external-tool-integration-center.md');
+
+  assert.match(product, /ordinary user[\s\S]*Campus Workspace/iu);
+  assert.match(product, /External Tool Integration Center/u);
+  assert.match(resources, /WebResource[\s\S]*localizedName[\s\S]*route[\s\S]*category/u);
+  assert.match(resources, /Main resolves the ID in the active Profile\/Account resource store/u);
+  assert.doesNotMatch(resources, /^ResourceDescriptorInternal$/mu);
+  assert.doesNotMatch(resources, /^A `LaunchHandle` is:/mu);
+  assert.doesNotMatch(resources, /^ResourceLaunchBroker/mu);
+
+  assert.match(integrations, /Clash Verge Rev managed extension/u);
+  assert.match(integrations, /Include ~\/\.ssh\/campus-connect\/\*\.conf/u);
+  assert.match(integrations, /remote SSH service port/u);
+  assert.match(integrations, /must not be uploaded, synchronized or shared/u);
+  assert.match(integrations, /BEGIN CAMPUS-CONNECT MANAGED <profileId>/u);
+});
+
+test('2.0 phase order keeps multi-school before integrations and ordinary-user Web work', () => {
+  const plan = read('docs/plans/2.0-preparation-execution-plan.md');
+  const p6 = plan.indexOf('### 2.0-P6 — School selector, second reviewed Profile');
+  const p7 = plan.indexOf('### 2.0-P7 — Shared Profile Network Rules and External Tool Integration Center');
+  const p8 = plan.indexOf('### 2.0-P8 — Lightweight WebResource and ordinary-user Campus Workspace upgrade');
+  assert.ok(p6 >= 0 && p7 > p6 && p8 > p7);
+  assert.doesNotMatch(plan, /P8b\s+—\s+External Tool Integration Center/u);
+  assert.match(plan, /P6b accepts only a bounded HTTPS domain\/port/u);
+});
+
+test('the first Beta has no built-in SSH HPC Jupyter database or forwarding workbench module', () => {
+  for (const relativePath of [
+    'desktop/hpc',
+    'desktop/ssh-client',
+    'desktop/jupyter',
+    'desktop/database-launcher',
+    'desktop/forwarding-workbench',
+    'independent/src/hpc',
+    'independent/src/ssh-client',
+    'independent/src/jupyter',
+    'independent/src/database-launcher',
+    'independent/src/forwarding-workbench',
+  ]) {
+    assert.equal(fs.existsSync(path.join(root, ...relativePath.split('/'))), false, relativePath);
+  }
+});

--- a/docs/adr/0003-multi-school-profile-and-custom-gateway.md
+++ b/docs/adr/0003-multi-school-profile-and-custom-gateway.md
@@ -17,7 +17,7 @@ risks: one school's password, Cookies, certificate pins or routes could be used 
 3. later, an Advanced `Other` flow where the user enters a Gateway domain/port locally.
 
 The ordinary selector initially shows reviewed profiles only. The P5 connector foundation is implemented first,
-a second reviewed school proves profile/account isolation in P10, and only P11 may expose `Other` as experimental
+a second reviewed school proves profile/account isolation in P6, and only P6b may expose `Other` as experimental
 and unverified.
 
 Entering a domain must be simple, but it must not cause the application to guess protocol endpoints and submit
@@ -142,12 +142,12 @@ PublicProbeSpec
   maximum candidate attempts
 ```
 
-P11 compiles exactly one reviewed EasyConnect public probe spec. Custom/profile data cannot provide
+P6b compiles exactly one reviewed EasyConnect public probe spec. Custom/profile data cannot provide
 its path, method, headers, parser or candidate list. Future families add a separately reviewed compiled spec and
 synthetic fixture. A probe result identifies only a candidate public authentication surface; the
 `ProtocolFamily` factory independently constructs credential-bearing endpoints after confirmation.
 
-## Advanced custom Gateway onboarding (P11)
+## Advanced custom Gateway onboarding (P6b)
 
 Proposed login surface:
 
@@ -478,7 +478,7 @@ Before adding a second reviewed school:
 - three-platform package verifier validates the exact profile manifest;
 - the new school completes official parity and staff canary.
 
-Before P11 exposes Advanced custom onboarding:
+Before P6b exposes Advanced custom onboarding:
 
 - the second reviewed school has passed the preceding gate;
 - custom Gateway probe sends no credentials and rejects invalid TLS/origin/protocol;

--- a/docs/adr/0004-profile-account-workspace-scope.md
+++ b/docs/adr/0004-profile-account-workspace-scope.md
@@ -417,10 +417,10 @@ when both accounts share a Gateway origin.
 
 Profile-reviewed builtin resources are immutable deployment input. Authenticated server resources bind account
 key + authenticated-session generation + catalogue revision/expiry. Local resources, favorites and recent
-entries belong to the workspace. Renderer sees sanitized resource views and non-authorizing opaque
-`resourceHandle` values, never raw authorization fields, Cookie-bearing URLs or hidden query parameters.
-`LaunchHandle` remains Main-owned and is prepared/consumed only after an explicit launch request; it never enters
-Renderer state.
+entries belong to the workspace. P8 uses only packaged/local lightweight `WebResource` values. The Renderer
+selects a stable bounded resource ID; Main resolves the active Profile/Account record and revalidates its URL and
+route on every open. There is no persistent or one-use launch-authorization object. Raw server authorization,
+Cookie-bearing URLs and hidden query parameters never enter Renderer state.
 
 Routing policy compilation combines profile reviewed defaults with only the active account's custom resources
 and user rules. `RoutingPolicyIR` and its decision envelope include profile/account revisions and active-context

--- a/docs/adr/0005-external-tool-integration-center.md
+++ b/docs/adr/0005-external-tool-integration-center.md
@@ -1,8 +1,8 @@
 # ADR-0005: External Tool Integration Center
 
-- Status: Accepted product/architecture direction for the first 2.0 Beta
+- Status: Accepted P7 product/architecture direction
 - Decision owner: project maintainer
-- Production activation: requires the P8 integration gates below
+- Production activation: requires the P7 integration gates below
 
 ## Context
 
@@ -16,8 +16,7 @@ local proxy authentication or silently reusing one school's tunnel after a profi
 
 ## Decision
 
-Introduce an **External Tool Integration Center** as a domain independent from the resource catalogue and
-`ResourceLaunchBroker`.
+Introduce an **External Tool Integration Center** as a domain independent from the Web resource catalogue.
 
 The first Beta supports explicit preview plus export or managed install/update/remove for:
 
@@ -31,8 +30,8 @@ The first Beta supports explicit preview plus export or managed install/update/r
 
 The Center does not:
 
-- model SSH, HPC, Jupyter, database or forwarding targets as `ResourceDescriptor` values;
-- create or consume `resourceHandle`, `LaunchHandle` or `ForwardLease` values;
+- model SSH, HPC, Jupyter, database or forwarding targets as campus resources;
+- create generic launch-authorization objects or temporary forwarding leases;
 - install VS Code extensions, open a terminal, launch an arbitrary executable or open a workspace;
 - scan local processes or search broadly for third-party configuration files;
 - scan disks or silently choose/overwrite third-party configuration, subscriptions or user-owned blocks;
@@ -56,7 +55,6 @@ IntegrationAdapterId
   user_selected_managed_block
 
 IntegrationAdapterView
-  integrationHandle          opaque, non-authorizing
   adapterId
   displayName
   supportedActions[]         preview | copy | save | install | update | remove
@@ -66,9 +64,9 @@ IntegrationAdapterView
 ```
 
 Renderer views contain no proxy username/password, generated YAML, helper credential path, persistent
-profile/account/workspace key, full third-party path or command line. A value-free trusted IPC asks Main to
-prepare an action for an opaque current `integrationHandle`; a separate explicit confirmation consumes the
-prepared diff/transaction.
+profile/account/workspace key, full third-party path or command line. The Renderer selects only a closed
+`adapterId` and action; trusted IPC asks Main to prepare the current redacted diff, and a separate explicit
+confirmation consumes the prepared transaction.
 
 Main owns the complete binding:
 
@@ -87,9 +85,24 @@ IntegrationBindingInternal
   state
 ```
 
-Persistent keys, `credentialRef` and secret output material never cross to Renderer. Non-secret integration
-records belong to the account workspace. Proxy credentials remain in the secure credential domain; an
-integration record contains only a reference and revision.
+Persistent keys, `credentialRef` and secret output material never cross to Renderer. Transient Main state may
+carry the complete binding above, but the account-scoped persistent record is deliberately small:
+
+```text
+IntegrationRecord
+  adapterId
+  profileId
+  targetFile
+  installedRevision
+  installedDigest
+  managedBlockId
+  backupReference
+```
+
+The enclosing Profile/Account workspace supplies account ownership, so no username, account key or credential is
+duplicated into the record. Proxy credentials remain in the secure credential domain. A retained record is not
+authorization; Main revalidates current profile/account/listener/auth/policy revisions before every update or
+remove action.
 
 ## Profile and account binding
 
@@ -144,7 +157,7 @@ Clipboard output is an explicit secret-bearing action performed by Main. Optiona
 when the clipboard still exactly contains the payload written by this transaction, so newer user clipboard data
 is never erased.
 
-The first Beta writes only one of these scoped targets:
+P7 writes only one of these scoped targets:
 
 1. a user-selected generic export;
 2. the dedicated Campus Connect managed extension owned by the Clash Verge Rev adapter;
@@ -155,6 +168,17 @@ No adapter performs a full-disk search, rewrites a subscription, replaces an unm
 unselected target. Every managed adapter has its own parser, conflict policy, ownership marker, diff, backup,
 readback and uninstall tests.
 
+A text adapter owns only its marked region, for example:
+
+```text
+# BEGIN CAMPUS-CONNECT MANAGED <profileId>
+...
+# END CAMPUS-CONNECT MANAGED <profileId>
+```
+
+Removal deletes only the matching region whose marker and installed digest still match the record. It does not
+restore an entire historical file and therefore cannot erase unrelated edits made after installation.
+
 ## Adapter boundaries
 
 ### Clash and Mihomo generic export
@@ -164,6 +188,14 @@ per tool. The first Beta offers copy/save export; it does not find or overwrite 
 configuration automatically. YAML contains only the loopback endpoint and the exact profile-bound proxy
 credential required by the active listener. No Browser routing rule silently changes these integrations to
 Direct.
+
+Before copy/save/install, the UI states that generated configuration contains a local campus-proxy credential
+(not the school VPN password) and must not be uploaded, synchronized or shared. Owner-only permissions/ACL are
+required where an adapter writes a file. Strict local proxy authentication is never disabled for convenience.
+
+Node names and rules come only from the active Profile's shared network rules. The generic generator never
+hardcodes HKUST domains, and `udp` remains disabled unless the selected frontend explicitly proves compatible
+authenticated UDP support.
 
 ### Clash Verge Rev managed extension
 
@@ -177,10 +209,10 @@ failure.
 ### OpenSSH and VS Code
 
 OpenSSH install uses the packaged `ec-proxy-command` and an owner-only, profile/account-bound credential sidecar.
-After an explicit preview, it adds one idempotent managed `Include` to the user-selected OpenSSH config and owns
-profile-scoped config below an app-owned directory. Update changes only the owned profile file; remove deletes the
-owned profile file and removes the Include only when no managed profile still needs it. Existing Host blocks are
-never rewritten.
+After an explicit preview, it adds one idempotent managed `Include ~/.ssh/campus-connect/*.conf` to the
+user-selected OpenSSH config and owns profile-scoped files below `~/.ssh/campus-connect/`. Update changes only the
+owned profile file; remove deletes that file and removes the Include only when no managed profile still needs it.
+Existing Host blocks are never rewritten.
 
 The OpenSSH `Port` directive always means the **remote SSH service port** (normally 22 or an explicitly
 user-selected remote port). It is never set to the local SOCKS/HTTP listener port. Campus proxying is expressed
@@ -231,9 +263,9 @@ INTEGRATION_ROLLBACK_INCOMPLETE
 Errors do not contain generated configuration, credential values, full third-party paths or arbitrary command
 lines. A failed/stale integration never changes Campus/Direct policy or starts another Engine.
 
-## P8 acceptance
+## P7 acceptance
 
-The Integration Center portion of P8 is complete only when:
+The Integration Center is complete only when:
 
 - every listed adapter has bounded schema and golden configuration tests on its supported platforms;
 - Profile A credentials are rejected after switching to Profile/Account B;
@@ -251,18 +283,27 @@ The Integration Center portion of P8 is complete only when:
 - no adapter scans disks/processes, overwrites unrelated third-party content or mutates global DNS/routes/proxy;
 - package verification includes the production adapters but excludes synthetic tool/config fixtures.
 
-P8 can ship only after both the Web Resource Workspace gates and these Integration Center gates pass. Neither
-domain implies SSH/HPC/Jupyter/database launch or scoped forwarding support.
+P7 can ship independently before the P8 ordinary-user Web upgrade, while both use the same Profile Network Rules
+and Profile/Account scope. Neither domain implies SSH/HPC/Jupyter/database launch or scoped forwarding support.
 
 ## Multi-school rollout
 
-The first user-visible Beta remains HKUST(GZ)-only. The architecture remains multi-school: P10 adds the second
-reviewed profile and must repeat the integration credential-rotation, stale-export and zero-cross-profile tests
-with two real reviewed profiles. P11 custom Gateway onboarding remains separately gated and receives no inherited
-integration record or proxy credential.
+P6 adds the school selector and second reviewed Profile before P7 activation. Integration credential rotation,
+stale-export and zero-cross-profile tests run with two real reviewed Profiles. Advanced custom-domain onboarding
+is a separately gated P6b step and receives no inherited integration record or proxy credential.
 
 ## Rollback
 
 Disabling the Integration Center removes its UI/IPC adapters and retires app-owned integration metadata without
 changing VPN credentials, Browser state or user-owned exported files. Previously exported configuration is not
 silently deleted; its profile-bound credential is revoked so it cannot authorize another active profile.
+
+## References
+
+- [Clash Verge Rev extension configuration](https://www.clashverge.dev/guide/extend.html) documents merge/script
+  extensions and their global/subscription scopes. The adapter still requires a version-pinned compatibility
+  test; this link is not authority to edit an arbitrary client file.
+- [VS Code Remote SSH](https://code.visualstudio.com/docs/remote/ssh) uses a local OpenSSH-compatible client and
+  SSH configuration, so Campus Connect reuses OpenSSH rather than defining a VS Code-specific tunnel format.
+- [OpenSSH `ssh_config`](https://man.openbsd.org/ssh_config) defines `Include`, `ProxyCommand` and `Port`; `Port`
+  is the remote server port, while Campus proxying belongs only in `ProxyCommand`.

--- a/docs/architecture/2.0-capability-matrix.md
+++ b/docs/architecture/2.0-capability-matrix.md
@@ -58,12 +58,12 @@
 | School/profile selection | VPN地址历史/多配置门户；隔离语义未验证 | CLI/TOML选择server/protocol | `I0/E1`；单一HKUST上下文 | reviewed presets先行；第二reviewed school完成后才开放Advanced custom profile |
 | Account/workspace scope | per-VPN设置线索；账户隔离行为未验证 | 单进程/单配置，无Browser workspace | `I0/E1`；school/account共享flat userData | `SchoolProfile→CampusAccount→WorkspaceScope`；两profile×两account交叉可见数=0 |
 | Safe Gateway connector | 内部Agent/privileged服务；本次仅静态线索 | underlay支持显式/自动接口绑定；无同等自定义域名SSRF边界 | `I1/E2`；`.no_proxy()`但无通用resolved-address连接约束 | 全CNAME/A/AAAA验证、mixed/unsafe拒绝、实际peer绑定、hostname PKI；HTTP/特殊TLS同generation |
-| Custom Gateway onboarding | 用户可输入VPN地址；后续由Agent处理 | `-server/-protocol`直接配置 | `I0/E1` | P11 Advanced/experimental；无凭据probe→一次性确认→新opaque profile/account→先校验target/config再解密；0 password/Cookie |
+| Custom Gateway onboarding | 用户可输入VPN地址；后续由Agent处理 | `-server/-protocol`直接配置 | `I0/E1` | P6b Advanced/experimental；无凭据probe→一次性确认→新profile/account→先校验target/config再解密；0 password/Cookie |
 | Cross-profile data isolation | per-VPN设置存在；Cookie/secret边界不满足本项目目标 | 单进程/单配置，无对应Browser产品面 | `I0/E1`；全局vault/partition/rules | 两synthetic profiles间password/Cookie/pin/rule/event可见数=0；100 switch residue=0 |
 | Password auth | Historical Observed | Source-observed production | `I3/E2`；Historical E4，当前exact-SHA E4待补 | 同 profile 20/20；拒绝/不确定/协议错误分类一致 |
 | Gateway MFA | Hypothesis：官方包/其他profile有线索 | SMS/TOTP/cert/aTrust source wiring | `I2/E2` generic framework；真实 provider 无 | 每种方法独立 `I3/E5`；未知方法 100% fail-closed |
 | Modern L3 IPv4 | Historical Observed | Source-observed | `I3/E2`；Historical E4，当前exact-SHA E4待补 | 100 connect/reconnect；0 leaked session/socket |
-| Web resource domain/search | 多资源类型静态线索；active profile未知 | resource/routing source capability | `I2/E2` offline parser；当前仅Web shortcut UI | P8只启用Web descriptor/view/opaque handle与search/category/favorite/recent；未知/非Web记录无launch action |
+| Web resource domain/search | 多资源类型静态线索；active profile未知 | resource/routing source capability | `I2/E2` offline parser；当前仅Web shortcut UI | P8只启用轻量WebResource与search/category/favorite/recent/open；点击ID后Main重查URL/route，未知/非Web记录无open action |
 | Resource catalogue | Historical Observed UI | Source capability | `I2/E2` offline parser；production retrieval无 | authenticated retrieval/revision/expiry/auth semantics `E5` |
 | WebVPN | Unknown：active profile未观察 | 未观察到backend；aTrust明确忽略WEB资源 | `I1/E1` typed slot；production unsupported | 只在 L3-disabled school profile 后实现 |
 | Campus DNS UDP | Historical Observed | Source production | `I3/E2`；Historical E4，当前HPC E4待补 | HPC 20/20；外部 DNS packet=0 |
@@ -74,13 +74,13 @@
 | UDP proxy | Historical Observed：官方系统VPN可承载 | Source production | `I3/E2` NO_AUTH compatibility；strict按设计拒绝 | 有可认证 UDP ownership 后再升级 |
 | Local proxy auth | N/A | 默认边界较宽 | `I3/E2`新装strict；legacy显式迁移 | 新装 100% strict；non-loopback listener=0 |
 | Campus Browser | Historical Observed：官方集成UI | 无同等产品面 | `I3/E3` single Session/PAC/credential safety package；真实导航/SSO E4待补 | 20-tab p95<100 ms；SSO flow 20/20 |
-| External Tool Integration Center | N/A：官方native integration不适合作为独立客户端模板 | CLI/local proxy配置，secret与profile边界不同 | `I2/E2`；现有PAC/Clash YAML/OpenSSH ProxyCommand primitives，未有managed adapter transaction | P8 generic export + Clash Verge Rev owned extension + OpenSSH Include/profile conf + user-selected managed block；diff/backup/atomic validate/rollback；old-profile auth=0、Renderer secret=0、no scan/unowned overwrite/launch |
+| External Tool Integration Center | N/A：官方native integration不适合作为独立客户端模板 | CLI/local proxy配置，secret与profile边界不同 | `I2/E2`；现有PAC/Clash YAML/OpenSSH ProxyCommand primitives，未有managed adapter transaction | P7 generic export + Clash Verge Rev owned extension + OpenSSH Include/profile conf + user-selected managed block；diff/backup/atomic validate/rollback；old-profile auth=0、Renderer secret=0、no scan/unowned overwrite/launch |
 | Domain routing | Unknown：官方资源策略未复核 | rules/TUN | `I3/E2` Campus/Direct rules production | 100k JS/PAC/Exit corpus mismatch=0 |
 | Controlled DirectExit | Unknown：官方内部行为未复核 | 不等价 | `I0/E1`；当前仅Chromium `DIRECT`风险接受 | rebinding/private resolved IP deny=100% |
 | Multi-Exit semantics | Unknown | 多 backend/route | `I0/E1`；无统一Exit model | Direct/L3/WebVPN typed capability，无隐式 fallback |
 | Multi-Exit detection/selection | Unknown | explicit/auto source wiring | `I0/E1`；2.0设计Deferred，1.x只用system route | 两个受控候选后再实现；Gateway RTT/failure/stability评分，Auto hysteresis和manual fail-closed |
 | Underlay binding | Unknown：官方行为需观察 | explicit/auto source wiring | `I0/E1` | 三平台 explicit；绑定失败 unbound fallback=0 |
-| Scoped TCP/UDP forwarding | 官方资源/平台组件静态线索 | Source production | `I0/E1`；当前用户经SOCKS/SSH手动配置 | Post-Beta P13 Headless capability only；不属于P8 Resource Workspace或External Tool Integration Center |
+| Scoped TCP/UDP forwarding | 官方资源/平台组件静态线索 | Source production | `I0/E1`；当前用户经SOCKS/SSH手动配置 | 独立Post-Beta Headless产品决策；不属于P7 Integration Center或P8 WebResource |
 | CLI/headless/service | vendor Agent/daemon；不适合作为模板 | Source production，配置/secret边界不同 | `I1/E1` development CLI only | unprivileged service/Docker；secret不进argv/TOML/env；restart residue=0 |
 | Multi-line | Hypothesis | node selection source wiring | `I2/E2` offline endpoint parse；无production selection | sticky/hysteresis；默认切线重新认证 |
 | Loop prevention | Unknown | 部分 underlay/TUN | `I3/E2` local destination与Gateway `.no_proxy()`；无underlay identity | graph cycle test=100%；self recursion=0 |
@@ -113,7 +113,7 @@
 
 ### Security
 
-- Renderer收到原始resource authorization、private target、LaunchHandle、Cookie/token数量 `=0`；
+- Renderer收到原始resource authorization、private target、Cookie/token数量 `=0`；
 - 非 loopback listener `=0`；
 - Gateway 隐式环境代理使用 `=0`；
 - campus DNS 失败时 system/public DNS packet `=0`；
@@ -124,7 +124,7 @@
 
 ### Performance
 
-- 10,000 ResourceDescriptorView本地搜索可取消且不阻塞control window；
+- 10,000 WebResource本地搜索可取消且不阻塞control window；
 - SOCKS/frontend offline p95 `≤10 ms`；
 - netstack offline matrix p95 `≤10 ms`；
 - 相对固定 1.x 同机基线 throughput/latency 回退 `≤5%`；

--- a/docs/architecture/2.0-cross-project-feature-map.md
+++ b/docs/architecture/2.0-cross-project-feature-map.md
@@ -40,9 +40,9 @@ it does not prove that a specific school enables or supports the capability.
 
 | Capability | EasyConnect 7.6.7 implementation | zju-connect implementation | Current HKUST(GZ) Connect | 2.0 independent implementation |
 | --- | --- | --- | --- | --- |
-| Resource catalogue | ECAgent/Web SDK normalizes groups, defaults and many resource classes | Easy parses resource XML into routing/DNS; aTrust accepts L3VPN resources | Bounded offline parser; Web shortcut model in Campus Browser | Web-only ResourceDescriptor/view/handle for the first Beta; authenticated `ResourceProvider` later adds revision/expiry/profile-account/session binding and explicit authorization without guessing non-Web launchers |
+| Resource catalogue | ECAgent/Web SDK normalizes groups, defaults and many resource classes | Easy parses resource XML into routing/DNS; aTrust accepts L3VPN resources | Bounded offline parser; Web shortcut model in Campus Browser | P8 uses only packaged/local lightweight WebResource; authenticated `ResourceProvider` later adds an evidence-gated Web source without guessing non-Web launchers |
 | Web resource/WebVPN | Static portal paths contain Web/EasyLink rewrite and browser/SSO flows; profile activation and wire behavior remain unknown | No Sangfor WebVPN backend; aTrust ignores WEB resources | Browser uses L3 proxy or Direct; WebVPN backend unsupported | Learn only from official parity on an L3-disabled profile; distinct `WebVpnExit`, never ordinary HTTP proxy fallback |
-| IP/L3 resource | Starts/query L3 service and applies server policy | Resource-aware L3 dial | Modern L3 tunnels all permitted frontend traffic | Compile reviewed server/user/profile policy into RoutingPolicyIR and pin Campus ingress to `CampusModernL3Exit` |
+| IP/L3 resource | Starts/query L3 service and applies server policy | Resource-aware L3 dial | Modern L3 tunnels permitted frontend traffic | Preserve the current campus tunnel; P7 Profile Network Rules decide which Web/tool traffic uses it without adding typed L3 resources |
 | Per-app TCP resource | Static TCP service/module and app/resource-opener clues exist; runtime activation is unknown | aTrust per-app signed TCP tunnel; Easy cannot use it | Unsupported | Separate `TcpResourceExit` only after school evidence; never fake trusted-process/compliance attributes |
 | SSO resource | Static portal paths inject/rewrite SSO state and open resources; exact runtime behavior requires profile parity | CAS/OAuth2 authenticates the aTrust Gateway only; no resource-level SSO opener was observed | Browser preserves same-profile Cookie/POST/SAML | Profile-scoped Browser partition and strict origin/callback policy; no hidden arbitrary credential injection |
 | File/FTP/mail/app | Static portal source contains typed opener/native-integration paths; runtime activation is unknown | Resource parsing may route supported network endpoints | Browser/OpenSSH/SOCKS cover ordinary network access | Excluded from the Web-only first Beta; any later typed opener requires an independent product/threat-model decision, never ActiveX/native automation by default |
@@ -56,17 +56,17 @@ it does not prove that a specific school enables or supports the capability.
 
 | Capability | EasyConnect 7.6.7 implementation | zju-connect implementation | Current HKUST(GZ) Connect | 2.0 independent implementation |
 | --- | --- | --- | --- | --- |
-| Modern L3 | Privileged local modules/services | Easy special TLS address/send/receive channels | Independent verified Rust Modern L3 | Preserve; wrap as `CampusModernL3Exit` after Router ADR |
+| Modern L3 | Privileged local modules/services | Easy special TLS address/send/receive channels | Independent verified Rust Modern L3 | Preserve unchanged through P7/P8; any later Exit/Router wrapper requires its own measured need and ADR |
 | Legacy L3/TCP | Static DNS/L3VPN/TCP/VIRTUALLINE module and legacy-component topology; active family requires runtime evidence | Easy L3; aTrust L3/TCP families | Legacy parser/adapter lab only | Versioned backend only if a real profile requires it; do not widen existing special TLS backend |
 | aTrust | Official installed sample contains adjacent clues but activation unknown | Full auth/resource/node/L3/TCP implementation | No provider/backend | Independent family only after a school profile proves aTrust; never reuse compliance-spoofing behavior |
 | VPN DNS | Official DNS module and special resource configuration | Remote DNS, static mappings, cache/single-flight, UDP/TCP and public secondary | Gateway/profile campus DNS, cache/single-flight, UDP→same-server TCP, no public fallback | Make DNS policy profile-owned; Campus failures fail closed; Direct uses a separate resolver |
-| Domain/IP routing | Official resources/config drive L3/TCP/Web decisions | Resolver/Dialer carries resource context and may Direct | JS/PAC domain rules and destination safety | Canonical profile-scoped RoutingPolicyIR; explicit Exit, DNS and fallback policy; JS/PAC/Rust semantic parity |
+| Domain/IP routing | Official resources/config drive L3/TCP/Web decisions | Resolver/Dialer carries resource context and may Direct | JS/PAC domain rules and destination safety | P7 Profile Network Rules drive Browser, PAC and integration adapters; a richer Rust/Exit IR is deferred |
 | Multi-line | Client UI/config and VIRTUALLINE/load-balance paths | Easy probes lines and recursively relogs; aTrust scores node groups | Endpoint parser only | `EndpointSet` + stickiness/hysteresis/failure history; fresh authentication by default; profile evidence required |
 | Keepalive/reconnect | Agent/service and portal service-state ownership | Easy update-session; aTrust heartbeat/reconnect; generic public-host keepalive | Engine/Desktop bounded retry, health supervisor and generation lifecycle | Profile/session-owned timers, typed cause, bounded backoff+jitter; never use public DNS name as tunnel keepalive |
 | Gateway underlay | Hidden inside privileged services | Explicit/optional auto interface binding | System route split across HTTP/token/data sockets; `.no_proxy()` enforced | One GatewayUnderlay identity/generation; Direct has an independent resolver/dialer |
 | Local SOCKS/HTTP | Static portal/Agent topology contains internal local control/proxy components | SOCKS defaults to wildcard `:1080` with `NoAuth` unless both credentials are set; HTTP defaults to wildcard `:1081` and has no authentication mechanism | Loopback-only strict auth plus explicit compatibility mode | Keep current security; pin external SOCKS/Clash/SSH to active Campus profile by default |
 | Port forwarding | Native service/resource opening | TCP/UDP forwarding and Shadowsocks options | SSH/SOCKS/PAC cover current needs | Optional authenticated loopback ingress only after real demand; not protocol parity |
-| TUN/FakeIP | Root service, legacy TUN/proxy hooks, DNS/route scripts | Experimental TUN/FakeIP/DNS hijack with platform mutations | Intentionally absent | Optional future ingress after Router/Exit/Underlay and 100-cycle residue tests; never default |
+| TUN/FakeIP | Root service, legacy TUN/proxy hooks, DNS/route scripts | Experimental TUN/FakeIP/DNS hijack with platform mutations | Intentionally absent | Optional independent future product only after a proven unmet use case and 100-cycle residue tests; never default |
 
 ## 5. Platform, operations and security
 
@@ -94,8 +94,8 @@ search/favorite/recent resource
   → open the Web resource in Campus Workspace
 ```
 
-The school picker initially contains reviewed profiles only. `Other` is deferred to P11 under Advanced settings,
-after a second reviewed school proves the isolation model. It remains experimental/unverified and never becomes
+The school picker initially contains reviewed profiles only. `Other` is deferred to P6b under Advanced settings,
+after P6's second reviewed school proves the isolation model. It remains experimental/unverified and never becomes
 the headline value of 2.0.
 
 Custom Gateway discovery is unavailable until the profile identity, provider composition, storage migration
@@ -131,14 +131,12 @@ routes/resources, no Gateway-driven updater and no system mutation.
 3. P3: profile/account/workspace storage and journaled legacy HKUST migration;
 4. P4: ActiveProfile/ActiveAccount coordinator and Browser partition isolation;
 5. P5: behavior-preserving HKUST GatewayConnectorGeneration;
-6. P6: account-scoped RoutingPolicyIR;
-7. P7: Router ADR/test-only ec-router and behavior-preserving Campus Exit adapter;
-8. P8: Web ResourceDescriptor/search/favorites/recent/open plus the independent External Tool Integration
-   Center—the first user-visible Beta;
+6. P6: school selector + second reviewed Profile + separately gated P6b custom-domain onboarding;
+7. P7: shared Profile Network Rules + External Tool Integration Center;
+8. P8: lightweight WebResource/search/categories/favorites/recent/open ordinary-user upgrade;
 9. P9: first evidence-gated current-school capability;
-10. P10: second reviewed school;
-11. P11: advanced custom organization onboarding;
-12. P12/P13: Controlled Direct/Underlay/multi-line, then Headless/service/forwarding.
+10. P10/P11: Controlled Direct/Underlay/multi-line, then Headless/service/forwarding;
+11. P12+: additional evidence-triggered products and protocols.
 
 ### First official capability migrations
 

--- a/docs/architecture/2.0-vision.md
+++ b/docs/architecture/2.0-vision.md
@@ -39,10 +39,10 @@ ProfileRegistry + ActiveProfileContext + ActiveAccountContext
             ▼                              ▼
 Web resource search/catalogue       External Tool Integration Center
   → favorites/recent                  → closed IntegrationAdapterRegistry
-  → ResourceDescriptorView            → profile/account-bound transaction
-  → non-authorizing resourceHandle     → preview/export/managed lifecycle
-  → one-use Web LaunchHandle           → Clash/Mihomo/Clash Verge Rev/OpenSSH/
-  → Campus Workspace Web launcher        VS Code/PAC/manual adapters
+  → lightweight WebResource            → profile/account-bound transaction
+  → stable resource ID                 → preview/export/managed lifecycle
+  → Main revalidation on every open     → Clash/Mihomo/Clash Verge Rev/OpenSSH/
+  → Campus Workspace Web open             VS Code/PAC/manual adapters
             └──────────────┬──────────────┘
                            ▼
 Ingress
@@ -105,10 +105,10 @@ authorized observation
 禁止复制 proprietary source/binary/resource，禁止将 zju-connect 源码、fixture 或二进制
 变成运行时依赖。研究记录必须标注 `Observed`、`Confirmed`、`Hypothesis`、`Unknown`。
 
-### 3.1 Advanced custom Gateway onboarding (P11)
+### 3.1 Advanced custom Gateway onboarding (P6b)
 
-`Other`不是首发入口或任意URL加载器。P5先为内置HKUST建立行为不变的安全connector；P10
-用第二个reviewed school证明多学校隔离；P11才在高级设置中开放experimental/unverified
+`Other`不是任意URL加载器。P5先为内置HKUST建立行为不变的安全connector；P6
+用第二个reviewed school与学校选择器证明多学校隔离；P6b才在高级设置中开放experimental/unverified
 onboarding。届时它先规范化HTTPS域名/端口，再解析并验证每个有界
 CNAME/A/AAAA结果；只要解析集合含private、loopback、link-local、multicast、unspecified或
 其他不允许地址，整个请求fail-closed。实际socket绑定到已验证地址，原hostname只用于SNI与
@@ -280,8 +280,10 @@ UnderlayObservation
 
 - Browser partition、网站密码、证书决策、收藏/最近和用户规则归属active account workspace；
 - 首页以搜索、分类、收藏、最近访问和通知为主，连接状态退居Connection Center；
-- `ResourceDescriptorView`只暴露展示字段和non-authorizing `resourceHandle`；显式launch后才由Main
-  为Web open准备并消费短期一次性`LaunchHandle`；
+- 首页使用轻量`WebResource`：本地化名称/说明、canonical URL、Campus/Direct route、category、
+  keywords、可选packaged icon和reviewed provenance；
+- 点击只提交stable resource ID，Main每次从active profile/account store重新查找并校验URL/route；
+  不建立`ResourceDescriptor`、`resourceHandle`、`LaunchHandle`或generic launch broker；
 - 首个Beta只启动Web资源；未知或非Web记录不映射为SSH/HPC/TCP/Jupyter/Database/File launcher，
   也不显示launch action；
 - Campus 和 Direct 都使用受控 Exit；
@@ -295,8 +297,8 @@ UnderlayObservation
 
 ### 9.1 External Tool Integration Center
 
-External Tool Integration Center与资源目录平行：它不消费`resourceHandle`/`LaunchHandle`，不从
-HPC、SSH、Jupyter或Database记录构造host、port或命令。Main只通过closed adapter对当前loopback
+External Tool Integration Center与Web资源目录平行：它不从HPC、SSH、Jupyter或Database记录构造
+host、port或命令。Main只通过closed adapter对当前loopback
 frontend生成redacted diff/preview，并执行显式export或受管install/update/remove。
 
 每个integration绑定profile/account revisions、active-context epoch、listener/Engine generation、
@@ -358,17 +360,16 @@ generated YAML、credential、sidecar/path和第三方配置内容禁止进入�
 
 ```text
 1.x Architecture Frozen
-  -> SchoolProfile/GatewayOrigin + CampusAccount/WorkspaceScope placeholders
-  -> behavior-preserving production provider composition seam
-  -> profile/account/workspace storage migration
-  -> ActiveProfile/ActiveAccount coordinator + Browser isolation
-  -> behavior-preserving HKUST GatewayConnectorGeneration
-  -> account-scoped RoutingPolicyIR
-  -> Router ADR/test-only ec-router + CampusModernL3Exit adapter
-  -> Web ResourceDescriptor + Campus Workspace + External Tool Integration Center Beta
-  -> first evidence-gated HKUST capability
-  -> second reviewed school profile
-  -> advanced custom Gateway onboarding
+  -> P1 SchoolProfile/GatewayOrigin foundation
+  -> P2 behavior-preserving provider composition + CapabilitySnapshot
+  -> P3 profile/account/workspace storage isolation
+  -> P4 ActiveProfile/ActiveAccount switch transaction + Browser isolation
+  -> P5 behavior-preserving safe Gateway connector
+  -> P6 school selector + second reviewed Profile
+  -> P6b advanced custom-domain onboarding after the same connector/isolation gates
+  -> P7 shared Profile Network Rules + External Tool Integration Center
+  -> P8 lightweight WebResource + Campus Workspace ordinary-user upgrade
+  -> P9 first evidence-gated current-school capability
   -> ControlledDirectExit + explicit Underlay + evidence-backed multi-line
   -> CLI/headless/service + scoped forwarding
   -> evidence-gated aTrust/WebVPN/TUN/mobile/RemoteApp products

--- a/docs/architecture/resource-domain-model.md
+++ b/docs/architecture/resource-domain-model.md
@@ -1,594 +1,225 @@
-# Web resource domain model
+# Web resource model
 
-Status: 2.0 architecture contract; no production capability is enabled by this document.
+Status: accepted 2.0 product/architecture direction; P8 implementation is not enabled by this document.
 
-This document defines the Web resource model for the first Campus Workspace Beta. It deliberately separates:
+## 1. Product boundary
 
-- a resource being present in a package, local settings or an authenticated catalogue;
-- the source and trust class of that resource;
-- whether the current profile/account is authorized to use it;
-- whether this build and current session have the required capability and Exit;
-- the private material required to launch it.
+The first 2.0 user-facing resource model is deliberately Web-only. Campus Connect establishes a safe campus
+network and opens ordinary Web pages in Campus Browser. Mature external tools continue to own SSH, remote
+development, databases and HPC workflows.
 
-None of those facts implies another. In particular, a parsed server field, an apparent SSH/HPC/Jupyter/database
-type or an opaque target does not prove that HKUST(GZ), another school or the current production build supports
-or should launch it.
+The first Beta does not define or implement:
 
-## 1. Current evidence boundary
+- SSH, TCP, UDP, HPC, Jupyter, database, file, Remote Desktop or WebVPN resource types;
+- `ResourceDescriptor`, `resourceHandle`, `LaunchHandle`, `ResourceLaunchBroker` or `ForwardLease`;
+- an SSH client, terminal, scheduler/HPC manager or application-specific forwarding workbench.
 
-The current implementation has three relevant but separate foundations.
+External Clash/OpenSSH/VS Code/PAC configuration belongs to the independent
+[`External Tool Integration Center`](../adr/0005-external-tool-integration-center.md), not this model.
 
-### Desktop shortcuts
+## 2. Current evidence
 
-`desktop/lib/campus-resources.js`, `campus-resource-store.js` and `campus-resource-ipc.js` implement a bounded
-local Web-shortcut model:
+The current product already has:
 
-```text
-id / name / description / url / route(campus|direct) / builtin
-```
+- six reviewed built-in Web shortcuts;
+- locally managed custom Web shortcuts;
+- Campus/Direct route choice and remembered domain rules;
+- a sandboxed, multi-tab Campus Browser;
+- a local exact-origin credential vault and certificate-pin management.
 
-- built-in and local resources are merged into a maximum of 32 visible entries;
-- local entries are transactionally created, edited, reordered and deleted;
-- built-ins are read-only;
-- only HTTP(S) URLs are accepted through the Campus Browser URL normalizer;
-- a Direct resource targeting a local, private or special host is forced to Campus or rejected;
-- the control Renderer currently receives the resource URL;
-- `CampusBrowserManager.open()` currently resolves the route and then calls `ensureConnected()` before opening,
-  including for a resource labelled Direct.
+The Rust catalogue parser is offline structural evidence only. Production does not retrieve or authorize a
+server resource catalogue. An EasyConnect/aTrust field name must not create a new resource type or launch action.
 
-This is a useful compatibility model, not the final resource domain.
+## 3. WebResource
 
-### Rust catalogue parser
-
-`independent/src/resource_catalogue.rs` and `independent/spec/RESOURCE_CATALOGUE_V1.md` provide a bounded offline
-parser. It already separates a sanitized catalogue view from non-serializable `ResourceLaunchTarget` values
-resolved by opaque handles. Unknown authorization values become only `declared_unverified`; they never become
-allow or deny decisions.
-
-Production still uses `UnsupportedResourceProvider`. The offline provider proves parser and redaction behavior
-only. It does not prove authenticated retrieval, authorization semantics, catalogue refresh, expiry or launch.
-
-### External integration building blocks are a separate domain
-
-The current product provides an authenticated loopback SOCKS/HTTP frontend, generated Clash/PAC/OpenSSH
-configuration and `ec-proxy-command` for an OpenSSH-style byte stream. These are External Tool Integration Center
-building blocks, not resource descriptors or launchers. Their profile/account binding and transactional
-export/install/update/remove contract is owned by
-[`ADR-0005`](../adr/0005-external-tool-integration-center.md).
-
-The model below preserves current Web behavior. The first Beta does not map SSH, HPC, TCP/UDP, database,
-Jupyter, file, Remote Desktop or WebVPN records into typed resource launchers.
-
-## 2. Ownership and scope
-
-Every resource belongs to exactly one immutable scope:
+P8 uses one small, versioned value model:
 
 ```text
-ResourceScope
-  profileKey
-  accountKey
-  workspaceKey
-```
-
-- `profileKey` identifies the reviewed or local school profile;
-- `accountKey` identifies one campus account without exposing its username;
-- `workspaceKey` owns Browser state, favorites, recent activity and user presentation overrides.
-
-Raw user input is never used as a path component. Moving a resource between profiles or accounts creates a new
-resource identity; it does not copy server authorization, launch material, Cookies, pins or history.
-
-The control Renderer receives only a bounded `ResourceDescriptorView`. The full descriptor and exact target
-remain Main/Engine-owned. A managed Browser may eventually navigate to an exact Web target, but that target is
-never returned through the ordinary resource-list IPC, telemetry or logs.
-
-## 3. Internal descriptor
-
-The following is a logical contract, not a claim that these exact Rust or JavaScript types already exist.
-
-```text
-ResourceDescriptorInternal
+WebResource
   schemaVersion
-  resourceHandle
-  scope: ResourceScope
-
-  source
-    kind
-    providerKey?
-    sourceIdentityRef
-
-  trustClass
-  resourceType
-
-  display
-    name
-    description?
-    category?
-    tags[]
-    iconKey?
-
-  requirements
-    requiredCapabilities[]
-    requiredExit
-
-  authorization
-    state
-    decisionAvailable
-    decisionRevision?
-    decisionExpiresAt?
-    privateEvidenceRef?
-
-  catalogue
-    catalogueHandle
-    catalogueRevision
-    descriptorRevision
-    sessionGeneration?
-    fetchedAt?
-    expiresAt?
-
-  privateWebTarget
-```
-
-### Resource identity
-
-`resourceHandle` is an opaque, source-namespaced identity used by views, favorites and recent activity. It is
-not an authorization bearer and is not sufficient to launch anything.
-
-- a built-in handle derives from a reviewed packaged manifest identity;
-- a local handle is randomly generated and retained with the local record;
-- a server handle is derived inside the provider from its private source identity plus profile/provider scope.
-
-Raw vendor identifiers, URLs, hosts and user data never become the public handle. Reuse of a handle after a
-catalogue revision does not bypass revision, expiry or authorization checks.
-
-### Source
-
-`ResourceSourceKind` is one of:
-
-| Source | Meaning | Mutability |
-| --- | --- | --- |
-| `builtin_reviewed` | Shipped in a reviewed, packaged profile manifest | Read-only; changes with a reviewed app/profile revision |
-| `authenticated_server` | Retrieved by an authenticated, evidence-backed `ResourceProvider` | Read-only to the user; session/revision/expiry bound |
-| `local_user` | Entered on this computer by the user | Editable and deletable within its profile/account scope |
-
-Sources use separate identity namespaces. A server or local record cannot override a built-in merely by copying
-its ID, label or target. Equal URLs do not erase provenance; deduplication is a presentation decision and must
-retain the source/trust distinction.
-
-### Trust class
-
-`ResourceTrustClass` describes provenance, not permission or target safety:
-
-| Trust class | Meaning |
-| --- | --- |
-| `reviewed_builtin` | Manifest and target were reviewed for the packaged profile |
-| `authenticated_server` | Record arrived through an authenticated provider session; its value semantics may still be unknown |
-| `user_supplied` | Record was entered locally by the user |
-| `unverified` | Provenance or required semantics are insufficient for a stronger label |
-
-An authenticated server record is not automatically authorized. A reviewed built-in is still subject to current
-destination, certificate, capability and Exit checks. A local-user record is not permitted to weaken those
-checks.
-
-### Resource type
-
-The first-Beta `ResourceType` is a closed, versioned enum:
-
-```text
-web
-unsupported
-```
-
-`unsupported` quarantines a bounded record whose source type has no reviewed Web mapping. It is visible only when
-useful to explain why it cannot be opened and is never launchable. SSH, HPC, TCP/UDP, database, Jupyter, file,
-Remote Desktop and WebVPN are not reserved first-Beta enum variants; adding one requires a later evidence-backed
-schema/version and an independent product decision. Unknown values must not be guessed from names, ports or URL
-shapes.
-
-### Private Web target
-
-`privateWebTarget` is a provider-owned, non-serializable, redacted-debug value:
-
-```text
-WebTarget  exact HTTPS/HTTP URL and intended route
-```
-
-This shape does not define a vendor wire format. It must not implement ordinary `Serialize`, `Display` or
-value-bearing `Debug`. Session-bound target strings use zeroizing storage where practical. External tool adapters
-never receive this target.
-
-## 4. Renderer view
-
-The list/search API returns only:
-
-```text
-ResourceDescriptorView
-  schemaVersion
-  resourceHandle
-  sourceKind
-  trustClass
-  resourceType
-
-  name
-  description?
-  category?
-  tags[]
+  id
+  localizedName
+  localizedDescription
+  url
+  route                 campus | direct
+  category
+  keywords[]
   iconKey?
-
-  requiredCapabilities[]
-  requiredExit
-  authorizationState
-  launchAvailability
-  revisionToken
-  expiresAt?
-
-  favorite
-  lastOpenedAt?
+  reviewed
 ```
 
-The view never contains:
-
-- raw vendor identifiers or authorization fields;
-- a server host, private IP, URL path, query, fragment or embedded credential;
-- Cookie, token, CSRF, TwfID, session ID or transport token;
-- a command line, executable path or arbitrary icon/asset URL;
-- an internal provider/config reference.
-
-Server-provided display strings are presentation-only. They are bounded, control-character-free and escaped as
-text. `iconKey` resolves only to a packaged allowlisted asset. Labels, tags and handles are excluded from normal
-diagnostic logs.
-
-A local-resource editor may receive a separate `LocalResourceDraftView` containing the user's own editable
-fields. That editor contract cannot be used to retrieve or mutate built-in or server launch material.
-
-## 5. Capabilities and Exit
-
-`requiredCapabilities` contains stable, bounded capability identifiers. The effective set is derived from the
-compiled implementation, selected provider/backend, current profile and current ingress mode. Profile JSON or a
-resource record cannot promote a capability to Supported.
-
-First-Beta identifiers include:
+`LocalizedText` is an exact bounded object:
 
 ```text
-resource.catalogue
-resource.authorization
-frontend.campus_workspace
-transport.l3
+LocalizedText
+  zh
+  en
 ```
 
-Only existing provider capability names are currently implemented. SSH, forwarding, file, Remote Desktop and
-WebVPN identifiers are not P8 resource capabilities; future additions require a separately versioned contract.
+No arbitrary locale keys, HTML or remote translation payloads are accepted. Until reviewed English labels are
+available, migration may use the current local label as the fallback for both locales; the UI must not invent a
+translation.
 
-`requiredExit` is explicit and singular:
+### Field rules
 
-```text
-direct
-campus_modern_l3
-unresolved
-```
+- `id` is stable and unique inside one Profile. Local IDs cannot replace a reviewed built-in ID.
+- `localizedName` and `localizedDescription` are bounded, control-character-free text rendered by text APIs.
+- `url` is a canonical HTTP(S) URL without embedded credentials. Reviewed built-ins require HTTPS.
+- `route` is explicit. Campus failure never silently becomes Direct.
+- `category` is a closed presentation value such as `common`, `academic`, `campus-service` or `custom`.
+- `keywords` are bounded local search terms. They never affect trust, authorization or routing.
+- `iconKey` resolves only to a packaged allowlisted asset; remote icon URLs are not accepted.
+- `reviewed` describes packaged review provenance. It is not server authorization and does not bypass URL,
+  destination, certificate or route checks.
 
-There is no implicit fallback. If `campus_modern_l3` is unavailable, a resource does not become Direct.
-`unresolved` is non-launchable until a reviewed Web adapter selects an exact Exit.
+The value contains no Cookie, token, CSRF, TwfID, VPN credential, proxy credential, hidden form body, command,
+executable path or provider authorization material.
 
-## 6. Authorization, revision and expiry
+## 4. Source and storage
 
-`ResourceAuthorizationState` is one of:
+The first Beta has only two production sources:
 
-```text
-not_required
-not_declared
-declared_unverified
-allowed
-denied
-expired
-withdrawn
-unavailable
-```
-
-Rules:
-
-- `allowed` and `denied` may be produced only by a reviewed, profile-specific authorization adapter with
-  observed value semantics;
-- the current offline Rust parser produces only `not_declared` or `declared_unverified`, with
-  `decisionAvailable = false`;
-- apparent booleans, numbers, strings or missing fields are never interpreted heuristically;
-- a required decision that is unknown, unverified, unavailable or expired fails closed;
-- local and built-in resources may use `not_required`, but this bypasses neither destination policy nor runtime
-  capability checks;
-- disconnect, profile/account switch, provider replacement or session-generation change invalidates every
-  server authorization decision and launch handle tied to the old session.
-
-Revision and expiry are source-specific:
-
-| Source | Revision | Expiry |
+| Source | `reviewed` | Ownership |
 | --- | --- | --- |
-| Built-in | Packaged profile/app manifest revision | Valid until that reviewed manifest is replaced or withdrawn |
-| Local | Owner-only settings transaction revision | No implicit expiry; revalidated on every edit and launch |
-| Server | Provider catalogue + descriptor + authorization revisions | Explicit provider expiry when evidenced; otherwise session-bound and never durable authority |
+| packaged Profile resource file | `true` | read-only, SHA-256 bound to the reviewed Profile manifest |
+| local custom website | `false` | editable on this computer inside the active Profile/Account workspace |
 
-The view receives only an opaque `revisionToken`. Raw server revisions and authorization evidence remain private.
-An expired or superseded catalogue may preserve presentation tombstones for favorites, but cannot authorize a
-launch.
+The packaged source is the single file referenced by `browser.builtinResourcesRef`. Profile JSON does not embed
+a duplicate resource array.
 
-## 7. Opaque LaunchHandle
+Built-in and custom documents remain independently bounded to 32 entries. The 1.x compatibility shelf is a
+built-in-first projection of at most 32 visible entries. Projection conflict/overflow receipts never rewrite the
+stored custom source. P8 may introduce category/search views over the lossless sources, but changing these limits
+requires an explicit UI/storage decision rather than an incidental merge change.
 
-`resourceHandle` identifies a resource. `LaunchHandle` authorizes one prepared launch. They are different.
+Future authenticated server Web resources require an evidence-backed `ResourceProvider`, explicit authorization
+semantics, revision/expiry and a separate promotion gate. They may be normalized into `WebResource` only after
+that gate; they do not expand the first-Beta type system.
 
-A `LaunchHandle` is:
+## 5. Open flow without launch handles
 
-- random and non-self-describing;
-- Main/Engine-owned and stored in a bounded in-memory table;
-- short-lived and normally single-use;
-- bound to profile, account, workspace, profile epoch, Engine generation, descriptor revision, catalogue
-  revision, authorization revision, required Exit and requested action;
-- invalidated by disconnect, route-policy change, profile/account switch, resource refresh, timeout, cancellation
-  or first consumption;
-- absent from settings, clipboard, history, crash reports, URLs and logs.
-
-The handle encodes no target. A MACed or encrypted target blob is not a substitute for the owner-side record.
-
-## 8. Web launcher boundary
-
-### Components
+The control Renderer selects a stable resource ID. It does not mint or receive an authorization handle.
 
 ```text
-Control Renderer
-  -> launch-resource(resourceHandle, action)
-Trusted IPC boundary
-  -> ResourceCatalogueCoordinator
-  -> ResourceLaunchBroker
-       -> WorkspaceWebLauncher
+user selects WebResource
+  -> trusted IPC validates the sender and bounded resource ID
+  -> Main resolves the ID in the active Profile/Account resource store
+  -> Main revalidates current resource revision, canonical URL and route
+  -> Direct: open without starting or waiting for Campus Engine
+  -> Campus: ensure the current Engine generation and Browser request gate are ready
+  -> open one Campus Browser tab
+  -> record a sanitized success/failure outcome
 ```
 
-The Renderer never chooses an executable, host, port, raw URL or Exit at launch time. It chooses only the bounded
-Web actions `open` or `cancel` allowed by the view.
+Every click performs a fresh owner-side lookup. The Renderer cannot supply a replacement URL, route, command,
+host or port for an existing resource. Profile/Account switches invalidate the active store and queued opens by
+context epoch; a stale request fails and the user clicks again. No persistent or one-use `LaunchHandle` table is
+needed for this Web-only flow.
 
-### Launch transaction
+For the existing local-resource editor, the user may submit their own bounded URL/name/description/route draft.
+That mutation path cannot edit a packaged built-in and remains separate from the open action.
+
+## 6. Routing behavior
+
+All Web opens use the shared route policy:
 
 ```text
-validate trusted IPC sender and exact schema
-  -> snapshot active profile/account/workspace and generations
-  -> resolve resourceHandle in the owning catalogue
-  -> verify source, revision, expiry and authorization
-  -> verify required capabilities and exact Exit
-  -> resolve and validate the private target under that Exit's destination policy
-  -> prepare a bounded Web LaunchHandle
-  -> atomically consume the LaunchHandle
-  -> execute the Workspace Web launcher
-  -> record only a sanitized outcome
+exact user domain rule
+  > user parent-domain rule
+  > local WebResource route
+  > reviewed Profile domain rule
+  > authenticated server suggestion (future, evidence-gated)
+  > Campus default
 ```
 
-If any snapshot changes before consumption, launch fails and the caller must request a new handle. Cancellation
-owns and closes every partial Browser request and temporary Web authorization material.
+Direct is forbidden for loopback, unspecified, link-local, multicast and private/local targets under the existing
+safety policy. The first Beta retains the documented Chromium Direct boundary; a future controlled Direct Exit
+may strengthen resolved-address ownership without changing `WebResource`.
 
-### Web behavior and current support boundary
+Microsoft 365, Canvas and other reviewed partner domains can remain Direct while redirects back to a campus
+domain return to Campus through the same Browser Session and route policy.
 
-| Type | Intended launcher | Current implementation fact | P8 activation rule |
-| --- | --- | --- | --- |
-| Web | Managed Campus Workspace under an exact route/Exit | Built-in/local Web shortcuts exist; they currently pass raw URLs and always call `ensureConnected()` | Migrate current behavior behind a handle and skip Engine connection for a validated Direct rule under the documented 1.x Chromium-DIRECT boundary; ControlledDirectExit later strengthens resolved-address ownership |
-| Unsupported/unknown | None | Offline parsers may observe bounded unknown records | Show only a safe explanation when useful; open action and network sessions remain absent |
+## 7. Ordinary-user features
 
-External Tool Integration Center preview/export/managed lifecycle is not a launcher row in this table. Scoped TCP/UDP
-forwarding remains a post-Beta Headless capability in P13, not a P8 `ForwardLease`.
+P8 adds lightweight presentation over `WebResource`:
 
-## 9. Search, favorites and recent activity
+- categories;
+- local search over name, description and keywords;
+- favorites;
+- recent successful opens;
+- user-defined websites;
+- clear Campus/Direct labels;
+- one-click open.
 
-These are Workspace overlays, not fields that mutate provider descriptors.
+Recommended reviewed categories are:
 
-### Search
+- **Common:** one-stop services, Outlook, Canvas and library;
+- **Academic:** SIS/course registration, class schedule/quota, exams, grades and room booking;
+- **Campus services:** school home, orientation, identity/account and IT-service entry points.
 
-- indexes only bounded view fields: name, description, category, tags, type and source label;
-- never indexes private targets, URLs, hosts, authorization material or raw provider values;
-- operates locally and does not send queries to a Gateway or analytics service;
-- normalizes Unicode and locale deterministically while rendering source text escaped;
-- uses stable tie-breaking so refresh does not reorder equal results unpredictably;
-- may boost exact/prefix matches, favorites and recent successful launches, but not trust or authorization beyond
-  their explicit filters.
+Every concrete URL must be confirmed from an official school page before entering a reviewed Profile. A product
+name alone is not sufficient evidence for a URL.
 
-### Favorites
+Favorites and recent entries store only Profile/Account scope, resource ID and bounded timestamps. They do not
+copy URLs or create routing authority. Search stays local and sends no query to the school or project maintainer.
 
-```text
-FavoriteEntry
-  workspaceKey
-  resourceHandle
-  sourceKind
-  pinnedAt
-  optional user label/category override
-```
+## 8. Multi-school isolation
 
-Favorites contain no launch target and grant no authority. A withdrawn, denied or expired server resource remains
-only as an unavailable tombstone until the user removes the favorite or the retention period expires.
+Each Profile/Account workspace owns its own:
 
-### Recent activity
+- custom websites;
+- favorites and recent entries;
+- Campus Browser partition;
+- website passwords and certificate pins;
+- domain route rules.
 
-Recent activity records only successful, user-initiated launch completion:
+Profile A records are never visible or openable in Profile B. A Profile switch closes or invalidates old queued
+opens before the new Profile becomes active. The initial multi-school release still runs only one active Engine.
 
-```text
-RecentResourceEntry
-  workspaceKey
-  resourceHandle
-  resourceType
-  sourceKind
-  launchedAt
-```
+## 9. Migration
 
-It is bounded by count and retention, stored owner-only and cleared with the Workspace. Failed attempts may update
-aggregate diagnostics by stable error code, but do not record a target, query, hostname or secret-bearing URL.
+P8 migration reads both current sources directly:
 
-## 10. Source-specific policy
+1. the manifest-bound built-in resource file;
+2. every normalized custom resource retained in settings.
 
-### Built-in reviewed
+It must not use the 32-visible compatibility projection as migration input. Existing IDs remain stable where
+valid. Migration adds localized/category/search metadata without changing URLs, routes, Browser partitions,
+cookies or website credentials.
 
-- loaded only from a packaged, hash-checked profile manifest;
-- read-only in the ordinary editor;
-- may provide bounded branding/category/icon metadata;
-- cannot contain credentials or arbitrary executable/script paths;
-- is revalidated against current destination, capability and Exit policy on every launch;
-- changes only through a reviewed manifest/app update and rollback contract.
+If a legacy custom URL duplicates a built-in, the built-in remains visible and the custom record remains
+available for explicit user deletion. Invalid or overflow normalization must produce a bounded local receipt;
+future saves must not silently erase unreported user records.
 
-### Authenticated server
+## 10. Acceptance gates
 
-- retrieved only by a production `ResourceProvider` owned by an authenticated session;
-- scoped to profile, account, provider, session generation and catalogue revision;
-- retains raw target and authorization material only in the provider/Engine;
-- requires explicit refresh, expiry and withdrawal behavior before production activation;
-- cannot overwrite built-ins or local records;
-- may be displayed as `authenticated_server`, but that label never means allowed;
-- cannot launch while authorization semantics are unknown when a decision is required.
+P8 is complete only when:
 
-### Local user
+- no SSH/HPC/TCP/Jupyter/database/File/Remote Desktop/WebVPN launcher or `LaunchHandle` exists in production;
+- all packaged resources pass the single shared schema at package and runtime validation;
+- Direct Web resources open without starting Campus; Campus resources never silently fall back Direct;
+- category/search/favorite/recent/custom/open behavior is Profile/Account isolated;
+- a stale Profile/Account request opens zero pages;
+- invalid, duplicate and canonical-length-overflow resources fail or produce an explicit compatibility receipt;
+- Renderer/IPC/logs contain zero VPN/proxy credentials, Cookies, tokens or hidden authorization material;
+- current Browser routing, password-vault, certificate and multi-tab E2E suites remain green;
+- macOS, Windows and Linux package verifiers contain the reviewed resource source and reject the legacy duplicate
+  resource asset.
 
-- created only through the Web exact-schema editor;
-- remains Web-only during and after the first-Beta migration;
-- is validated on write and again on launch;
-- cannot select an unsupported capability, inject a provider ID, invent server authorization, supply an
-  executable/argument list or create a non-Web resource type;
-- remains isolated to one profile/account/workspace and is removed through a durable local transaction.
+## 11. Deferred capabilities
 
-## 11. Error model
+The following remain separate evidence-gated decisions after the first Beta:
 
-Launch and catalogue errors use stable, secret-free codes. Suggested categories are:
+- authenticated EasyConnect resource catalogue and notices;
+- WebVPN, aTrust and per-application TCP backends;
+- generic port forwarding, TUN and Headless service mode;
+- RemoteApp or mobile clients.
 
-```text
-RESOURCE_NOT_FOUND
-RESOURCE_SCOPE_CHANGED
-RESOURCE_REVISION_CHANGED
-RESOURCE_CATALOGUE_EXPIRED
-RESOURCE_WITHDRAWN
-RESOURCE_AUTHORIZATION_UNKNOWN
-RESOURCE_DENIED
-RESOURCE_CAPABILITY_UNSUPPORTED
-RESOURCE_CAPABILITY_UNAVAILABLE
-RESOURCE_EXIT_UNAVAILABLE
-RESOURCE_TARGET_REJECTED
-RESOURCE_LAUNCH_HANDLE_INVALID
-RESOURCE_LAUNCH_HANDLE_EXPIRED
-RESOURCE_LAUNCH_CANCELLED
-RESOURCE_LAUNCH_FAILED
-```
+None of them is activated by adding a field or enum value to `WebResource`.
 
-Messages tell the user what action is possible: reconnect, complete authentication, refresh, request access,
-change route, install/enable a reviewed feature, or contact the resource owner. Errors never echo the private
-target, server response, raw authorization value or command line.
+## References
 
-Site failure, DNS failure, Tunnel failure and authorization denial remain distinct. No error path silently sends
-a Campus Web resource Direct or treats an unsupported/unknown record as launchable.
-
-## 12. Security invariants
-
-1. Renderer-visible lists contain no private or session-bound launch target.
-2. Resource presence, trust, authorization and runtime availability are separate states.
-3. A handle from Profile/Account A is unusable in B.
-4. Server authorization cannot outlive its provider session, revision or expiry.
-5. LaunchHandle is one-use, generation-bound and non-persistent.
-6. Unknown type, capability, Exit or authorization semantics fail closed.
-7. Direct and Campus L3 never silently substitute for each other.
-8. Every application-owned resolved destination passes the selected Exit's post-resolution safety policy.
-   P8's existing Chromium `DIRECT` route is a documented temporary exception: it keeps current literal/text host
-   safety and proves zero Campus-Engine start/wait, but does not claim DNS-rebinding protection. P12 removes this
-   exception by activating ControlledDirectExit.
-9. The Web launcher never constructs a shell command or external-tool configuration from resource data.
-10. Resource labels/targets are absent from default logs, telemetry and crash reports.
-11. Profile manifests, server catalogues and local records use distinct namespaces and cannot override each
-    other's trust labels.
-
-## 13. Migration from the current simple model
-
-Migration is behavior-preserving and journaled with the profile/account storage migration.
-
-Migration reads two authoritative source namespaces independently:
-
-1. every normalized packaged builtin record;
-2. every normalized custom record persisted in settings, up to the current custom-storage bound of 32.
-
-It must not use the merged visible list as migration input. The current view places six builtins first and caps
-the merged result at 32, so all 32 stored custom entries can include six records that are valid but not currently
-visible. Each source record maps as follows:
-
-```text
-legacy id           -> private sourceIdentityRef + new opaque resourceHandle
-builtin=true        -> source=builtin_reviewed, trust=reviewed_builtin
-builtin=false       -> source=local_user, trust=user_supplied
-name/description    -> bounded display fields
-url                 -> private WebTarget
-route=campus        -> requiredExit=campus_modern_l3
-route=direct        -> requiredExit=direct
-type                -> web
-authorization       -> not_required
-revision            -> packaged-manifest or local-settings transaction revision
-expiry              -> none for the migrated built-in/local record
-```
-
-Requirements:
-
-- preserve all valid built-in and all valid stored local Web shortcuts without changing route decisions;
-- preserve the current built-in-first, 32-visible compatibility view separately from the lossless stored model;
-- keep the current maximum of 32 local entries until a separately measured storage/UI bound replaces it;
-- make migration idempotent and all-old/all-new under write, fsync, rename and restart fault injection;
-- retain the existing local editor as a Web-only compatibility adapter;
-- reject non-Web local creation in the first-Beta schema; future support requires a new versioned contract;
-- retain a one-release rollback input without treating old data as an alternate authorization source;
-- never attempt to synthesize a server catalogue from built-in or local shortcuts.
-
-During the compatibility phase, Main may resolve a migrated Web resource and call the existing Campus Browser
-path. This preserves current behavior but does not satisfy a future claim that Direct resources open without a
-Tunnel: the current manager still calls `ensureConnected()`. That improvement requires its own launcher/Exit
-activation and tests.
-
-## 14. P8 Web Resource Workspace acceptance
-
-“P8” is the Web Resource Workspace Beta milestone in the Revision 5 execution plan. This document
-defines its gates but does not itself authorize production changes.
-
-P8 is complete only when all of the following are true.
-
-### Domain and migration
-
-- versioned internal/view schemas and exact enum/bounds tests exist;
-- current built-in/local Web resources migrate idempotently with order, route and editability preserved;
-- profile/account/workspace isolation tests show zero cross-scope resource, favorite, recent or LaunchHandle
-  visibility;
-- source and trust badges cannot be forged by local/server payloads;
-- unknown resource types and schema versions fail closed.
-
-### Catalogue and authorization
-
-- production still reports resource catalogue/authorization as unsupported until authenticated retrieval,
-  refresh, expiry and value semantics have evidence;
-- synthetic server catalogues test revision replacement, expiry, withdrawal and authorization-unknown behavior;
-- stale or expired catalogues authorize zero launches;
-- the control Renderer receives no exact server target or raw authorization material.
-
-### Search and workspace UX
-
-- search covers Web and unsupported view presentation fields without indexing private targets;
-- favorites and recent activity are profile/account/workspace scoped, bounded and durable;
-- unavailable, denied, expired and unsupported resources remain distinguishable and actionable;
-- keyboard navigation, bilingual labels and basic accessibility are covered by real Electron tests;
-- 10,000 synthetic views remain searchable and cancellable without blocking the control window.
-
-### Launcher
-
-- every Web open goes through the broker transaction and a one-use LaunchHandle;
-- existing Web shortcut launch behavior has packaged Electron parity after migration;
-- resource refresh, profile/account switch, route revision or Engine restart invalidates an old handle;
-- partial Browser resources are cleaned after cancellation and 100 repeated launch/close cycles;
-- SSH, HPC, TCP/UDP, database, Jupyter, file, Remote Desktop and WebVPN expose no P8 launch action or network
-  session; unknown schema presence never counts as support;
-- Direct-without-Tunnel may be claimed only for the existing validated Browser Direct route after a packaged
-  P8 test proves it starts/waits for the Campus Engine zero times; it does not claim ControlledDirectExit-level
-  resolved-address protection before P12.
-
-### Security and packaging
-
-- exact IPC sender/key/length validation, secret scans and architecture cycle gates pass;
-- logs, error text, diagnostics and crash paths contain zero private targets, queries, authorization values,
-  LaunchHandles or credentials;
-- package verification excludes synthetic catalogues, test launchers and fixture targets;
-- macOS, Windows and Linux packages retain the current loopback-only, no-global-network-mutation behavior;
-- no vendor authorization field, SSH/HPC/Jupyter/database target, WebVPN endpoint, Remote Desktop protocol or
-  forwarding behavior is guessed.
-
-P8 may be called the first Resource Workspace Beta only after the Web gates above and the independently defined
-External Tool Integration Center gates in
-[`ADR-0005`](../adr/0005-external-tool-integration-center.md) all pass. No non-Web resource launcher or scoped
-forwarding capability is implied.
+- [HKUST(GZ) Academic Registry Services — Systems & Tools](https://ars.hkust-gz.edu.cn/systems-tools/) is the
+  reviewed discovery source for SIS, class schedule/quota, examination, grade reporting, room booking, class
+  enrollment and Canvas entries. Each final target is still checked individually before entering a packaged
+  Profile; the name of a system alone is not a URL contract.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -1,13 +1,12 @@
 # Campus Connect 2.0 — Campus Workspace + Secure Access Runtime Execution Plan
 
-- Status: Approved direction; P1 begins only after this preparation PR merges and the governance gate is active
-- Revision: 5 — Web-only first Beta, profile/account/workspace isolation, External Tool Integration Center and
-  reviewed-school-first rollout
+- Status: Approved direction; P1 is merged and later phases remain independently gated
+- Revision: 6 — lightweight WebResource, P7 External Tool Integration Center and multi-school-first rollout
 - Scope: research and architecture preparation only
 - Production behavior change: none
 - Version/release change: none
 - Baseline: HKUST(GZ) Connect `main` at
-  `ed47f93f6594c7ae41ef344f08fa0aa6b5c47fc2`
+  `df3124714d878a80922090cda9ce3963331d2827`
 - zju-connect protocol reference: `2c71a34c17ea7ecf04c5fe862c4c315344128653`; reviewed current-main
   configuration delta: `4b2bcaa0acc34a33de672c26e3b2cb83bd583b15`
 
@@ -49,8 +48,8 @@ HKUST(GZ)是首个reviewed profile，不再是协议、存储或产品能力的�
   → 显式export或受管install/update/remove；不扫描磁盘、覆盖subscription/unowned block或启动工具
 ```
 
-学校选择器默认只展示reviewed profiles。任意 `Other` Gateway不作为首发主入口；P5先完成安全
-connector，P10用第二个reviewed school证明多学校隔离，P11才在“高级设置 → 添加自定义组织”
+学校选择器默认只展示reviewed profiles。任意 `Other` Gateway不作为普通主入口；P5先完成安全
+connector，P6用第二个reviewed school证明多学校隔离，P6b才在“高级设置 → 添加自定义组织”
 开放实验性、明确未验证的domain onboarding。
 
 本准备阶段做七件事：
@@ -60,9 +59,9 @@ connector，P10用第二个reviewed school证明多学校隔离，P11才在“�
 3. 逐功能记录三项目实现方式和2.0迁移决策；
 4. 建立SchoolProfile、CampusAccount、WorkspaceScope与数据隔离边界；
 5. 把Campus Workspace、Student/Advanced/Headless模式写成正式产品定义；
-6. 建立Web ResourceDescriptor、non-authorizing resourceHandle、one-use Web LaunchHandle、资源优先
-   首页和独立的External Tool Integration transaction合同；
-7. 建立Provider、Routing、Exit、Ingress、Underlay与分阶段PR顺序。
+6. 建立轻量WebResource、资源优先首页和独立的External Tool Integration transaction合同；
+7. 建立Provider、Profile Network Rules、多学校隔离与分阶段PR顺序；Router/Forwarding不作为首个
+   Beta前置条件。
 
 本阶段不启动厂商客户端、不登录网关、不读取凭据/会话，不提交任何厂商二进制、解包文件、
 抓包或反编译内容。
@@ -79,7 +78,7 @@ connector，P10用第二个reviewed school证明多学校隔离，P11才在“�
 
 | Source | Fixed identity | Evidence class | Permitted conclusion |
 | --- | --- | --- | --- |
-| HKUST(GZ) Connect | `ed47f93` | Current production source and green CI | 1.x password + Modern L3 foundation and current extension seams |
+| HKUST(GZ) Connect | `df31247` | Current merged source and green CI | reviewed Profile foundation, password + Modern L3 and current extension seams |
 | Released client | `v1.2.3` → `5d8323d` | Published package evidence | Released behavior only; excludes post-release convergence fixes |
 | Installed EasyConnect macOS | [7.6.7 x86_64 sample](../research/easyconnect/sample-manifest.md) | Installed-mutated authorized static extraction | [Electron/Web/native feature topology](../research/easyconnect/macos-7.6.7-static-observation.md); school activation still unknown |
 | EasyConnect Linux | public 7.6.7.3 package baseline | Sanitized static evidence | Named binary/capability marker and legacy transport clues |
@@ -346,7 +345,7 @@ The full deployment/account records remain Main/Engine-owned. Renderer receives 
 Engine config references, credential bindings or provider/session state. Detailed account decisions are fixed by
 [`ADR-0004`](../adr/0004-profile-account-workspace-scope.md).
 
-P11 custom Gateway profiles are Advanced/experimental, local and minimal: standard PKI, no private DNS
+P6b custom Gateway profiles are Advanced/experimental, local and minimal: standard PKI, no private DNS
 fallback, no bundled routes, no Gateway-driven updater, no system mutation, a neutral app-owned start page and
 no site-based health target
 until a provider validates one. Their optional label is always marked `Custom / unverified` and cannot confer
@@ -364,9 +363,9 @@ Application coordinator + sanitized Control/Event API
 
 Web resource search / favorites / recents / catalogue
         ↓
-Web ResourceDescriptorView + non-authorizing resourceHandle
+lightweight WebResource + stable resource ID
         ↓
-ResourceLaunchBroker → one-use Web LaunchHandle → Campus Workspace Browser
+Main revalidation → Campus Workspace Browser
 
 External Tool Integration Center
         ↓
@@ -374,7 +373,7 @@ closed IntegrationAdapterRegistry + profile/account-bound transaction
         ↓
 Clash / Mihomo / Clash Verge Rev / OpenSSH / VS Code / PAC / manual export
 
-Advanced custom Gateway onboarding (P11 only)
+Advanced custom Gateway onboarding (P6b only)
         ↓
 GatewayOriginVerifier + one-shot GatewayConfirmation
         ↓
@@ -394,17 +393,19 @@ AuthenticatedGatewaySession | PendingAuthTransaction
           GatewayUnderlayPolicy / GatewayDialer
 
 Ingress
-  ├── Campus Browser (multi-exit policy)
+  ├── Campus Browser (shared Profile Network Rules)
   ├── campus-only SOCKS / HTTP
   ├── profile-bound external tool adapters pinned to Campus by default
   └── optional future TUN
         ↓
-Versioned RoutingPolicyIR + RouteEvaluationContext
-        ↓
-Ingress Router / Exit Registry
-  ├── CampusModernL3Exit
-  ├── ControlledDirectExit → DirectResolver + ControlledDirectDialer
-  └── evidence-gated WebVpnExit
+Profile Network Rules
+  ├── Campus Browser evaluator
+  ├── PAC generator
+  ├── Clash/Mihomo/Clash Verge Rev generator
+  └── OpenSSH/Profile binding generator
+
+Optional later Router / ControlledDirectExit / WebVpnExit
+  (not a P7/P8 prerequisite)
 ```
 
 Authentication does not depend on Routing/Ingress; DNS and frontends do not depend on concrete auth;
@@ -428,37 +429,34 @@ Capability truth has four layers: compiled capability, selected provider/backend
 availability and current ingress-mode capability. Expose it through an additive bounded capability response;
 do not change or reinterpret the existing Event API v1 hello schema.
 
-### 5.5 RoutingPolicyIR v1
+### 5.5 Profile Network Rules v1
 
-One versioned canonical policy must drive JS, internal PAC, external PAC and a Rust evaluator. Minimum types:
+One versioned Profile/Account rule source must drive Campus Browser, PAC and external-tool generators. Minimum
+shape:
 
 ```text
-RoutingPolicyIR
-  version / profileId / profileRevision / accountId?
-  canonical rules / defaults / policyRevision
-
-RouteIntent
-  scheme / host / literalIp / port / protocol
-  initiatorClass / topLevelSite / profile / account
-
-RouteEvaluationContext
-  profileEpoch / accountEpoch / routerGeneration / selectedExitGeneration?
-  navigation and bounded stickiness context
-
-RouteDecision
-  exitId / source / policyRevision
-  routerGeneration / selectedExitGeneration?
-  safetyClass / dnsPolicy / fallbackPolicy
+ProfileNetworkRules
+  schemaVersion
+  profileId / profileRevision
+  accountRevision / policyRevision
+  campusDomains[]
+  directDomains[]
+  campusCidrs[]
+  gatewayBypass[]
+  defaultWebRoute
 ```
 
-The canonical IR stores no runtime generation, full URL/query or secrets. Unknown version/schema fails closed.
-Current 1.x route outcomes and persisted-rule compatibility must remain semantically equivalent before
-activation; generated PAC source is not required to remain byte-for-byte identical.
+The rule source stores no full URL/query, proxy credential, runtime generation or third-party path. Unknown
+version/schema fails closed. Current 1.x Browser/PAC outcomes and persisted-rule compatibility remain
+semantically equivalent before activation. Clash/Mihomo/Clash Verge Rev rules and OpenSSH profile binding are
+generated from the same Profile identity instead of duplicating HKUST constants. A future Router may compile a
+richer private IR from this source, but P7 does not create a Router process or expose Exit terminology to users.
 
-### 5.6 Exit and Ingress Router boundary
+### 5.6 Deferred Exit and Ingress Router boundary
 
 The current frontend directly owns `VirtualNetstack`, while Chromium `DIRECT` bypasses application-owned
-resolution/socket policy. A 2.0 `ControlledDirectExit` therefore needs a stable router lifecycle.
+resolution/socket policy. A future `ControlledDirectExit` may need a stable router lifecycle, but this is not a
+P7 External Tool Integration or P8 WebResource prerequisite.
 
 Evaluate and decide through an ADR before production code:
 
@@ -467,8 +465,8 @@ Evaluate and decide through an ADR before production code:
 | Separate long-lived `ec-router` with Campus Engine as an upstream Exit | Direct remains available independently; stable Browser port; clear multi-Exit ownership | Extra process/control/auth lifecycle |
 | Convert `ec-engine` into a long-lived router with replaceable Campus session | One process and shared observability | High-risk change to mature auth/stop lifecycle |
 
-Recommended preparation: test-only prototype of the separate router first. No production DirectExit is enabled
-until the ADR, threat model and three-platform lifecycle tests choose an option.
+If a measured need later justifies this work, evaluate a test-only separate router first. No production
+DirectExit is enabled until an independent ADR, threat model and three-platform lifecycle tests choose an option.
 
 The ADR/prototype must resolve four integration contracts before any frontend refactor:
 
@@ -512,8 +510,9 @@ unchanged.
 ### 5.8 Session services
 
 The current `ResourceProvider` is an offline parser scaffold, not a final production ABI. A real session
-service needs authenticated request ownership, revision/expiry, session generation, opaque launch material
-and explicit authorization semantics. Define only after a real official resource retrieval observation.
+service needs authenticated request ownership, revision/expiry, session generation and explicit authorization
+semantics. Define it only after a real official Web-resource retrieval observation; it does not add non-Web
+resource types.
 
 ### 5.9 Campus Workspace as the ordinary-user product surface
 
@@ -540,12 +539,11 @@ to Profile B.
 
 The ordinary-user home is resource-first rather than connection-first: global search, categories, favorites,
 recent activity and actionable notices lead to one-click Web open. Connection becomes an on-demand dependency
-of the selected Web resource. The first-Beta `ResourceDescriptor` represents reviewed built-in and local Web
-resources; authenticated-server support stays unavailable until its evidence gate. Unknown/non-Web records are
-not guessed into SSH/HPC/TCP/Jupyter/Database launchers and expose no launch action. Renderer sees only a bounded
-display view and non-authorizing resource handle. Main prepares/consumes a short-lived one-use Web LaunchHandle
-only after an explicit open request; authorization fields, hidden URL parameters, Cookies and raw server
-configuration remain Main/Engine-owned. The complete contract is in
+of the selected Web resource. P8 uses the lightweight reviewed/local `WebResource` value; authenticated-server
+support stays unavailable until its evidence gate. Unknown/non-Web records are not guessed into
+SSH/HPC/TCP/Jupyter/Database launchers and expose no open action. A click submits only the stable resource ID;
+Main resolves and revalidates the active Profile/Account URL and route on every open. No generic descriptor,
+authorization handle or launch broker is introduced. The complete contract is in
 [`resource-domain-model.md`](../architecture/resource-domain-model.md).
 
 External tool configuration is a parallel domain, not a resource type. Its profile/account credential rotation,
@@ -562,21 +560,21 @@ automatic 2.0 scope.
 | --- | --- | --- |
 | Multi-school profiles | Missing; one hard-coded HKUST context | Profile registry, exact Gateway origin, isolated stores/partition and journaled HKUST migration |
 | Account/workspace scope | Missing; account identity and school deployment share one flat namespace | Introduce single `primary` account now, but migrate directly to profile/account/workspace paths and dual-epoch lifecycle |
-| Safe Gateway connection | Current sockets lack one common generation owner | First route reviewed HKUST HTTP/special-TLS sockets through a behavior-preserving connector; P11 adds public-address validation and one-shot custom confirmation |
-| Custom Gateway onboarding | Missing | Advanced/experimental only after a second reviewed school; probe reports only public auth surface while L3/DNS/transport remain unknown until authenticated runtime evidence |
+| Safe Gateway connection | Current sockets lack one common generation owner | P5 routes reviewed HKUST HTTP/special-TLS sockets through a behavior-preserving connector; P6b reuses its public-address validation and one-shot custom confirmation |
+| Custom Gateway onboarding | Missing | P6b Advanced/experimental only after the second reviewed school; probe reports only public auth surface while L3/DNS/transport remain unknown until authenticated runtime evidence |
 | Password + Modern L3 | Production foundation | Preserve as regression oracle |
 | Gateway MFA | Generic `I2/E2`; real provider absent | Implement only the first school-enabled method after the EC-6 evidence/activation gate |
-| Resource catalogue | Offline `I2/E2` | First define neutral ResourceDescriptor/opaque launcher; later observe authenticated retrieval/refresh/authorization before enabling server resources |
+| Resource catalogue | Offline `I2/E2` | P8 uses only reviewed/local lightweight WebResource; later observe authenticated Web retrieval/refresh/authorization before enabling a server source |
 | Campus Workspace | HKUST-only multi-tab Browser with local vault/pins/rules | Make account-workspace-scoped and resource-first; preserve it as the principal 2.0 ordinary-user interface |
 | Web resource search/launcher | Current bounded Web shortcut list only | P8 requires search/category/favorite/recent + reviewed/local Web open only; non-Web launch actions are absent |
-| External Tool Integration Center | Scattered PAC/Clash/OpenSSH copy actions; no profile-bound adapter transaction | P8 adds generic export, Clash Verge Rev owned-extension lifecycle, OpenSSH managed Include/profile conf and user-selected managed blocks with credential rotation, diff/backup/atomic validate/rollback; no scan/unowned overwrite/launch |
-| Second reviewed school | None | Prove profile/account isolation and real canary before exposing arbitrary Gateway UI |
+| External Tool Integration Center | Scattered PAC/Clash/OpenSSH copy actions; no profile-bound adapter transaction | P7 adds generic export, Clash Verge Rev owned-extension lifecycle, OpenSSH managed Include/profile conf and user-selected managed blocks with credential rotation, diff/backup/atomic validate/rollback; no scan/unowned overwrite/launch |
+| Second reviewed school | None | P6 proves profile/account isolation and real canary before P7/P8 user-visible work or P6b custom-domain onboarding |
 | CLI/headless/service | Development CLI only; no formal product contract | Separate config/secrets, loopback strict auth, no root; add scoped TCP/UDP forwarding before TUN |
 | Notices/kick/password expiry/upgrade | Classifier/event scaffold | Observe real server states and add typed session services |
 | WebVPN | Typed slot only | Require an L3-disabled school profile and official parity |
 | Multi-line | Offline endpoint parse only | Prove discovery, auth/data endpoint relation and token portability |
-| RoutingPolicyIR | Missing | First neutral 2.0 core implementation |
-| Exit/Ingress Router | Missing | ADR + test-only lifecycle prototype |
+| Profile Network Rules | Current JS/PAC rules exist | P7 makes Browser, PAC and external integration generators consume one Profile/account rule source |
+| Exit/Ingress Router | Missing | Deferred ADR + test-only lifecycle prototype only after a measured ControlledDirect/other Exit need |
 | ControlledDirectExit | Missing | Only after router decision; resolved-address/rebinding deny tests |
 | Underlay binding | Missing | No-op common dial boundary, then explicit fail-closed binding |
 | aTrust | No HKUST evidence | Research-only; no near-term production backend |
@@ -664,96 +662,59 @@ Deliver it as three review units:
 - distinguish outer Gateway addresses from private destinations carried inside the authenticated L3 tunnel;
 - run HKUST regression, same-peer, rebinding, network-change and performance tests before accepting the seam.
 
-### 2.0-P6 — Account-scoped RoutingPolicyIR v1, offline first
+### 2.0-P6 — School selector, second reviewed Profile and gated custom domain
 
-- canonical schema/serialization/revision including profile/account identity;
-- runtime profile/account/router/Exit generations remain in evaluation context;
-- compile current rules and resources without changing outcomes;
-- JS/PAC/Rust differential evaluator with 100,000 deterministic/property cases;
-- semantic route equivalence and persisted-rule compatibility;
-- no production traffic switch until profile/account migration and switch E2E pass.
+- onboard one independently maintained reviewed school Profile with fixed evidence, compiled provider/backend and
+  school-specific fixtures;
+- add the school selector while keeping one active Profile/Account/Engine;
+- prove password/Cookie/pin/rule/resource/event isolation and 100 switch cycles across two real Profiles;
+- complete package manifest validation, official parity, canary and independent rollback;
+- after those gates, P6b may expose **Advanced settings → Add custom organization**, clearly experimental and
+  unverified, through the P5 safe connector;
+- P6b accepts only a bounded HTTPS domain/port, validates CNAME/A/AAAA and connected peer, uses standard PKI and
+  one-shot confirmation, inherits no reviewed branding/routes/DNS/updater/credential, and advertises no L3/DNS
+  capability before authenticated evidence.
 
-### 2.0-P7 — Router ADR, test-only ec-router and Campus Exit adapter
+### 2.0-P7 — Shared Profile Network Rules and External Tool Integration Center
 
-- compare a separate long-lived `ec-router` with a unified Engine before changing production frontends;
-- specify policy activation transaction, private Campus upstream authorization and dual-process ownership;
-- define `ExitId`, capabilities and typed failures, then wrap current VirtualNetstack/DNS as
-  `CampusModernL3Exit` without changing production routing;
-- keep external SOCKS/HTTP and every Integration Center adapter Campus-pinned while Campus Workspace may later
-  evaluate multiple Exits;
-- test strict local auth, profile/account/revision/generation, loop prevention and 100-cycle cleanup;
-- prototype stays out of packages until the ADR selects a topology.
-
-### 2.0-P8 — Web Resource Workspace and External Tool Integration Center Beta
-
-Deliver the first user-visible 2.0 value without adding another school or protocol. P8 has two independently
-reviewable parts, and both must pass before the Beta label is used.
-
-**P8a — Web Resource Workspace**
-
-- introduce `ResourceDescriptorInternal`, bounded `ResourceDescriptorView` with opaque non-authorizing
-  `resourceHandle`, plus Main-owned short-lived one-use Web `LaunchHandle`;
-- distinguish reviewed built-in, authenticated-server and local-user source/trust classes;
-- production-enable only reviewed/local Web resources; unknown and non-Web records remain unsupported/opaque
-  and expose no launch action;
-- replace the connection-first home with search, categories, favorites, recent activity and actionable notices;
-- launch validated Direct Web resources without starting Campus under the documented 1.x Chromium-DIRECT risk
-  boundary; Campus resources call `ensureConnected()` and surface MFA; P12 later adds ControlledDirectExit;
-- keep authorization state, raw server fields, Cookies and hidden parameters outside Renderer;
-- preserve the existing Campus Browser multi-tab/Cookie/POST/SAML behavior and migration compatibility.
-
-**P8b — External Tool Integration Center**
-
+- define one Profile/Account rule source for campus domains, direct domains, campus CIDRs, Gateway bypass and
+  profile identity;
+- make Campus Browser evaluation, PAC generation, Clash/Mihomo/Clash Verge Rev rules and OpenSSH binding consume
+  that source without introducing a Router process;
 - provide generic Clash/Mihomo/PAC/manual export, Clash Verge Rev owned-extension install/update/remove, one
-  managed OpenSSH `Include` plus profile conf, VS Code Remote-SSH guidance over OpenSSH, and exact user-selected
-  managed blocks for other reviewed clients;
-- bind each adapter record and proxy credential to profile/account, active-context, listener/auth and policy/PAC
-  revisions; a profile/account switch rotates/revokes old credentials before activating the new listener;
-- use Main-owned redacted diff/preview followed by explicit copy/save/install/update/remove;
-- backup existing targets, atomically replace, parse/read back and commit non-secret integration metadata;
-  rollback/revoke partial blocks, sidecars and credentials on failure;
-- keep OpenSSH `Port` as the remote service port and express Campus proxying only through the packaged
-  `ProxyCommand`; never derive a host/port from an HPC/resource record;
-- keep Browser domain rules from sending external integrations Direct;
-- do not scan disks/processes, overwrite subscriptions/unowned blocks, install VS Code extensions, launch
-  terminal/apps or weaken strict proxy authentication.
+  managed `Include ~/.ssh/campus-connect/*.conf`, profile-scoped OpenSSH config and VS Code Remote-SSH guidance;
+- require exact user-selected targets for any other reviewed managed adapter;
+- implement `inspect → plan → preview → backup → atomic apply → validate → commit`, and remove only the matching
+  managed block rather than restoring an entire historical file;
+- persist only adapter/profile/target/revision/digest/managed-block/backup references inside the account workspace;
+- bind proxy credentials to Profile/Account and revoke old credentials on switch; warn that generated configs
+  contain local proxy credentials and must not be uploaded, synchronized or shared;
+- keep OpenSSH `Port` as the remote service port and Campus proxying only in the packaged `ProxyCommand`;
+- do not scan disks/processes, overwrite subscriptions/unowned blocks, launch/install third-party tools or weaken
+  strict local proxy authentication;
+- do not add Router, ForwardLease, SSH/HPC/Jupyter/database modules or an integrated SSH client.
 
-P8 does not include typed SSH/HPC/Jupyter/database/file/Remote Desktop/WebVPN resources, `ForwardLease`, scoped
-TCP/UDP forwarding or an integrated SSH client.
+### 2.0-P8 — Lightweight WebResource and ordinary-user Campus Workspace upgrade
+
+- introduce only `WebResource { id, localizedName, localizedDescription, url, route, category, keywords,
+  iconKey?, reviewed }` for packaged and local Web pages;
+- a click sends a stable resource ID; Main re-resolves and validates the active Profile/Account URL/route on every
+  open, with no descriptor hierarchy, authorization handle, launch-handle table or generic launch broker;
+- add categories, local search, favorites, recent successful opens, user-defined websites and one-click open;
+- confirm every reviewed academic/campus-service URL from an official school source before packaging it;
+- open validated Direct pages without starting Campus; Campus pages call `ensureConnected()` and never fall back
+  Direct on failure;
+- preserve Campus Browser multi-tab/Cookie/POST/SAML, password-vault, certificate and route-rule behavior;
+- keep all SSH/HPC/TCP/Jupyter/database/file/Remote Desktop/WebVPN types and launch actions absent.
 
 ### 2.0-P9 — First evidence-gated official capability
 
-- choose one current-school capability with real evidence: authenticated resource catalogue, session notices,
+- choose one current-school capability with real evidence: authenticated Web catalogue, session notices,
   password expiry/concurrent-session state or the first actually enabled MFA method;
-- require EC-6 parity/canary/rollback for the exact HKUST profile/account;
+- require EC-6 parity/canary/rollback for the exact school Profile/Account;
 - keep WebVPN, aTrust, multi-line and unrelated providers disabled.
 
-### 2.0-P10 — Second reviewed school profile
-
-- onboard one staff/community-maintained school profile with fixed evidence, compiled provider/backend and
-  school-specific fixtures;
-- prove password/Cookie/pin/rule/resource/event isolation across profile and account boundaries;
-- prove an integration created for Profile A is stale and unauthorized after activating Profile B, with zero
-  credential/sidecar/listener residue;
-- complete official parity, package manifest validation, canary and independent rollback;
-- only after this phase may the product claim production multi-school support.
-
-### 2.0-P11 — Advanced custom organization onboarding
-
-Expose `Other` only under **Advanced settings → Add custom organization**, marked experimental and unverified:
-
-- compile a closed `PublicProbeSpec`; no profile/user-defined path, method, header, parser or unbounded candidate
-  list;
-- validate bounded CNAME/A/AAAA answers, mixed/unsafe sets, actual peer, hostname SNI/PKI, redirect/body/deadline,
-  no proxy/Cookie/cache and a short-lived one-shot confirmation;
-- report only a candidate public auth surface; L3/DNS/resource/transport remain unknown until authenticated;
-- consume confirmation to create a new opaque profile/account workspace, then validate target/config/binding
-  before decrypting a credential;
-- no provider guessing with a password, no inherited reviewed branding/routes/DNS/updater and no automatic
-  connection of an unverified draft;
-- require two synthetic Gateways plus one explicitly accepted real custom canary before broader availability.
-
-### 2.0-P12 — Controlled Direct, explicit Underlay and evidence-backed multi-line
+### 2.0-P10 — Controlled Direct, explicit Underlay and evidence-backed multi-line
 
 Keep these as separate review units even if they share a milestone:
 
@@ -766,7 +727,7 @@ Keep these as separate review units even if they share a milestone:
   back and cycle detection prevents Gateway traffic from entering Campus SOCKS;
 - enable multi-line only after endpoint discovery, auth/data relation and token-portability evidence.
 
-### 2.0-P13 — CLI, headless service and scoped forwarding
+### 2.0-P11 — CLI, headless service and scoped forwarding
 
 - provide `campus-connect-cli` / service mode over the same Rust providers and profile/account schema;
 - merge non-secret config with explicit precedence `defaults < file < environment < CLI`, where only supplied
@@ -774,16 +735,57 @@ Keep these as separate review units even if they share a milestone:
 - separate non-secret configuration from credentials; accept secrets through OS store, stdin/FD, Docker secret or
   owner-only control pipe, never ordinary argv/TOML or default environment variables;
 - run unprivileged, default listeners to loopback with strict authentication and preserve generation cleanup;
-- expose reviewed TCP and bounded UDP forwarding for server/lab/Jupyter/database use only as a separate
-  post-Beta Headless capability; it is not a P8 `ForwardLease` or Integration Center feature;
+- expose reviewed TCP and bounded UDP forwarding only after a separate post-Beta Headless product decision; it
+  is not a P7 Integration Center or P8 WebResource feature;
 - add launchd/systemd/Docker examples only after package and restart-residue tests; TUN remains separate.
 
-### 2.0-P14+ — Additional evidence-triggered products and protocols
+### 2.0-P12+ — Additional evidence-triggered products and protocols
 
 Continue one capability per PR/profile: aTrust, WebVPN, legacy backend, optional TUN/mobile or an independently
 threat-modeled RemoteApp product. Do not combine these or infer support from static EasyConnect modules.
 
-## 8. Common quality and security gates
+## 8. Target repository layout
+
+The target layout keeps Web resources and external-tool adapters small and separate:
+
+```text
+desktop/
+├── assets/profiles/<profileId>/
+│   ├── school-profile.json
+│   ├── engine-config.json
+│   ├── resources.json
+│   └── routing.json
+├── lib/profiles/
+│   ├── schema/
+│   ├── registry.js
+│   ├── runtime.js
+│   └── active-profile.js
+├── lib/integrations/
+│   ├── clash/
+│   │   ├── generator.js
+│   │   ├── clash-verge-rev.js
+│   │   ├── managed-extension.js
+│   │   └── integration-state.js
+│   └── openssh/
+│       ├── config-generator.js
+│       ├── include-manager.js
+│       ├── managed-profile.js
+│       └── integration-state.js
+├── lib/browser/
+├── lib/routing/
+├── lib/credentials/
+└── renderer/
+    ├── connect/
+    ├── websites/
+    ├── integrations/
+    └── settings/
+```
+
+Migration follows useful module boundaries and does not move working files merely for visual symmetry. The first
+Beta explicitly does not create `hpc/`, `ssh-client/`, `jupyter/`, `database-launcher/` or
+`forwarding-workbench/` directories.
+
+## 9. Common quality and security gates
 
 Every implementation PR must pass:
 
@@ -806,8 +808,8 @@ Every implementation PR must pass:
 - public probe request is selected only from compiled bounded `PublicProbeSpec`; no profile/user-defined probe;
 - Gateway confirmation is exact-origin/provider/draft/expiry bound and consumed once;
 - credential target/config/binding validation completes before secure-store decryption;
-- Web resource view/launch handles are bounded and opaque; Renderer never receives server authorization material,
-  Cookie/token, hidden query/form values or raw endpoint configuration;
+- Web resource IDs and values are bounded; Main re-resolves URL/route on every open, and Renderer never receives
+  server authorization material, Cookie/token or hidden query/form values;
 - expired/unauthorized/unsupported resources fail closed with actionable typed errors;
 - Direct resources do not start Campus; Campus resources cannot silently Direct on failure;
 - integration export/managed lifecycle binds exact profile/account/listener/auth/policy revisions; old
@@ -824,12 +826,11 @@ Every implementation PR must pass:
 - CLI/headless secrets never enter argv/TOML/default environment; listener defaults remain loopback + strict auth;
 - explicit rollback and capability downgrade rules.
 
-## 9. Approval gate and immediate next step
+## 10. Approval gate and immediate next step
 
-After this preparation PR is reviewed, implementation begins with **2.0-P1 Profile/account identity schema and
-single-HKUST registry** only. It is deliberately behavior-preserving: the sole `hkustgz` profile and synthetic
-`primary` account emit the current Gateway/config/resources/branding, but do not move user data, change the UI or
-expose another school/account.
+P1 merged in PR #9: the reviewed `hkustgz` Profile, config/resource asset binding and compatibility views are now
+the current baseline. The immediate implementation step is **P2 behavior-preserving Provider Composition Seam**;
+it must not move user data, change login behavior or advertise unsupported capability.
 
 Before any broader EasyConnect dynamic analysis, the school must also:
 
@@ -840,12 +841,11 @@ Before any broader EasyConnect dynamic analysis, the school must also:
 
 No 2.0 production feature or release is authorized by this plan alone.
 
-P1–P7 remain behavior-preserving foundation. P8 is the first user-visible Web Campus Workspace + External Tool
-Integration Center Beta. P9 requires
-real same-school evidence; P10 requires a second reviewed-school canary; advanced custom Gateway onboarding is
-explicitly deferred to P11. P12–P14 capabilities retain independent evidence, canary and rollback gates.
+P2–P5 remain behavior-preserving foundation. P6 proves the school selector and second reviewed Profile; P6b is
+the separately gated Advanced custom-domain path. P7 delivers External Tool Integration, P8 delivers the
+ordinary-user Web Campus Workspace upgrade, and P9 requires real school evidence. P10–P12+ capabilities retain
+independent evidence, canary and rollback gates.
 
-Before the first P1 production-code PR, `main` must require pull requests plus the CI, package-verifier and
-exact-tree secret-scan checks according to
+`main` continues to require pull requests plus CI, package-verifier and exact-tree secret-scan checks according to
 [`main-branch-protection.md`](../governance/main-branch-protection.md). Green advisory CI without branch
 protection and a read-back receipt is not the governance gate.

--- a/docs/product/2.0-product-definition.md
+++ b/docs/product/2.0-product-definition.md
@@ -1,14 +1,16 @@
 # Campus Connect 2.0 Product Definition
 
 - Status: Product direction; does not authorize unverified protocol capability or a production release
-- Current implementation baseline: `ed47f93f6594c7ae41ef344f08fa0aa6b5c47fc2`
-- Architecture preparation: PR #7; exact head remains authoritative in GitHub and the merge commit
-- First user-visible Beta: HKUST(GZ)-only
+- Current implementation baseline: `df3124714d878a80922090cda9ce3963331d2827`
+- Profile foundation: PR #9; exact merged tree remains authoritative in GitHub
+- First user-visible Beta: at least two reviewed school Profiles; advanced custom-domain onboarding remains
+  conditional on the safe Gateway connector gate
 
-HKUST(GZ)-only describes first-Beta rollout sequencing, not the product boundary. P10 still adds the second
-reviewed school and P11 retains separately gated custom-organization onboarding. Resource, Browser and External
-Tool Integration state is profile/account-bound from the first Beta so multi-school does not require another
-storage or credential-boundary rewrite.
+HKUST(GZ) is the first reviewed Profile, not the product boundary. P6 adds the school selector and a second
+reviewed Profile before the user-visible P7/P8 work. An `Other` domain can enter Advanced mode only after the P5
+safe connector and P6 isolation gates pass; it never inherits HKUST branding, credentials, routes or trust.
+Resource, Browser and External Tool Integration state is profile/account-bound so multi-school does not require
+another storage or credential-boundary rewrite.
 
 ## 1. Product definition
 
@@ -92,7 +94,7 @@ it appear supported.
 This document uses four labels:
 
 - **Current:** present in the fixed 1.x production source and backed by repository tests or package evidence;
-- **Beta target:** required before the first HKUST-only 2.0 user Beta;
+- **Beta target:** required before the first multi-school 2.0 user Beta;
 - **Evidence-gated:** designed, but visible only after the selected school profile and production path have the
   evidence required by the capability matrix;
 - **Deferred:** deliberately outside the first Beta and not implied by the 2.0 name.
@@ -133,15 +135,17 @@ Student Home becomes the default ordinary-user page and provides:
 - school notices only when backed by a typed, evidence-supported session event;
 - an expandable connection summary rather than a connection-first home page.
 
-The first Beta resource catalogue remains bounded and local. It may introduce a versioned display model, but
-it must not claim authenticated server-resource retrieval or authorization semantics that production does not
-yet implement.
+The first Beta resource catalogue remains bounded and local. Its versioned display value is the small
+`WebResource` contract in [`resource-domain-model.md`](../architecture/resource-domain-model.md): localized
+name/description, canonical URL, Campus/Direct route, category, keywords, optional packaged icon and reviewed
+provenance. It does not claim authenticated server-resource retrieval or authorization semantics.
 
 ### Resource-priority interaction
 
 ```text
-select resource
-  -> resolve its trusted source, type and route
+select WebResource
+  -> trusted IPC sends only the bounded resource ID
+  -> Main resolves the active Profile/Account source, URL and route again
   -> Direct: open without starting or waiting for the Campus Engine
   -> Campus: ensure the current Engine generation is ready
        -> request credentials/challenge only if required
@@ -156,12 +160,10 @@ resource.
 
 ### P8 Beta resource domain
 
-P8 introduces a Web-only `ResourceDescriptorView` with a non-authorizing opaque `resourceHandle`. An explicit
-Web open request lets Main prepare and immediately consume a short-lived one-use `LaunchHandle`; it is never
-stored in the list view. The first Beta production-enables only reviewed/local Web resources. Unknown or
-non-Web server records remain opaque unsupported input and receive no launch action. Renderer receives display
-fields and `resourceHandle` only, never raw server authorization data, hidden session parameters, Cookies or
-vendor configuration.
+P8 introduces only the lightweight `WebResource` value and ordinary Web actions. A click sends a stable bounded
+resource ID; Main looks it up again in the active Profile/Account store and revalidates its canonical URL and
+route before opening. There is no `ResourceDescriptor`, authorization-shaped `resourceHandle`, one-use
+`LaunchHandle` table or generic `ResourceLaunchBroker` in the first Beta.
 
 SSH, HPC, TCP/UDP forwarding, database, Jupyter, file, Remote Desktop and WebVPN are not first-Beta resource
 types or launchers. A Jupyter page may be added as an ordinary reviewed Web URL without creating typed Jupyter
@@ -259,8 +261,9 @@ Integration Center. It adds clearer ownership and explanation, not speculative p
   behavior.
 
 The Center is not a resource launcher. General TCP/UDP forwarding, typed SSH/HPC/Jupyter/database resources and
-an integrated terminal/SSH client are post-Beta features. The complete adapter, transaction and rollback contract
-is [`ADR-0005`](../adr/0005-external-tool-integration-center.md).
+an integrated terminal/SSH client are not planned first-Beta modules and require a later independent product
+decision backed by a real need. The complete adapter, transaction and rollback contract is
+[`ADR-0005`](../adr/0005-external-tool-integration-center.md).
 
 ## 7. Connection Center
 
@@ -315,7 +318,7 @@ Headless Mode becomes a separately documented CLI/service distribution sharing t
 - no root requirement for the proxy-first runtime;
 - no default TUN, DNS hijack or wildcard listener.
 
-Headless Mode is not required for the first HKUST-only Desktop Beta and does not inherit Desktop credentials
+Headless Mode is not required for the first multi-school Desktop Beta and does not inherit Desktop credentials
 without explicit user authorization.
 
 ## 9. Ordinary, Advanced and Headless modes
@@ -325,7 +328,7 @@ without explicit user authorization.
 | Primary entry | Student Home and resource search | External Tool Integration Center and Connection Center | CLI/service control |
 | Login | School, account, password and supported challenge | Profile identity and capability details | Explicit profile plus secret channel |
 | Network wording | Available / needs connection / needs action | route source, DNS mode, Exit and generation | stable state/error JSON |
-| Resources | Web search, favorite, recent and Open | Web route details; no non-Web launcher | opaque resource ID where supported |
+| Resources | Web search, favorite, recent and Open | Web route details; no non-Web launcher | bounded Web resource ID where supported |
 | Proxy tools | hidden | export plus scoped managed lifecycle for reviewed adapters | configured loopback listener |
 | Custom Gateway | absent from first Beta | experimental only after reviewed admission gates | unsupported until the same gates pass |
 | TUN | absent | Deferred experimental component | absent by default |
@@ -335,11 +338,11 @@ Advanced Mode is a presentation choice, not permission to bypass TLS, destinatio
 profile isolation or capability evidence. Switching modes does not duplicate credentials or start another
 Engine.
 
-## 10. First HKUST-only 2.0 Beta
+## 10. First multi-school 2.0 Beta
 
 ### Included
 
-- one packaged and reviewed HKUST(GZ) profile;
+- HKUST(GZ) plus at least one independently reviewed school Profile and a school selector;
 - internal profile/workspace namespace and journaled migration of current HKUST data;
 - Student Home with resource search, categories, favorites and recent items;
 - bounded reviewed and local Web resources with clear source and route;
@@ -357,7 +360,8 @@ Engine.
 
 ### Explicitly not included
 
-- a public `Other` Gateway entry or a second school;
+- an unvalidated arbitrary-URL loader; Advanced `Other` domain onboarding appears only after the P5 connector
+  and P6 isolation/adversarial gates pass;
 - claimed support for CAPTCHA, SMS, TOTP, certificate, SSO or another Gateway MFA method without current school
   evidence and a production provider;
 - authenticated server resource retrieval;
@@ -468,7 +472,7 @@ URLs, response bodies and secrets do not enter default logs or diagnostic payloa
 | Current macOS Engine wrapper | [`hkustgzconnect`](../../hkustgzconnect) | Keychain/stdin, loopback auth, launchd and status tooling; not cross-platform product proof |
 | Multi-school security boundary | [`ADR-0003`](../adr/0003-multi-school-profile-and-custom-gateway.md) | immutable profile/Gateway identity, probe and storage isolation design |
 | Profile/account/workspace boundary | [`ADR-0004`](../adr/0004-profile-account-workspace-scope.md) | account-ready storage, Browser/vault/rule ownership, switch and migration contracts |
-| Web resource/launcher boundary | [`resource-domain-model.md`](../architecture/resource-domain-model.md) | Web descriptor/view/handle, authorization, launch, search/favorite/recent and P8 gates |
+| Web resource boundary | [`resource-domain-model.md`](../architecture/resource-domain-model.md) | lightweight WebResource, stable-ID open, routing, search/favorite/recent and P8 gates |
 | External tool integration boundary | [`ADR-0005`](../adr/0005-external-tool-integration-center.md), [`external-proxy-config.js`](../../desktop/lib/external-proxy-config.js), [`proxy-credential.js`](../../desktop/lib/proxy-credential.js), [`pac-file.js`](../../desktop/lib/pac-file.js) | profile-bound adapter/managed-lifecycle target and current low-level generation primitives; not proof of current Mihomo/Clash Verge Rev/VS Code integration |
 | 2.0 network architecture | [`2.0 Vision`](../architecture/2.0-vision.md) | Ingress, Router, Exit and Underlay target boundaries |
 | Capability support truth | [`2.0 Capability Matrix`](../architecture/2.0-capability-matrix.md) | current implementation/evidence and promotion rules |


### PR DESCRIPTION
## 目标

纠正 PR #9 合并后仍残留的 2.0 产品范围偏差，使执行合同与维护者确认的产品结构一致：

> 普通用户使用 Campus Browser 和常用网页；高级用户通过外部工具集成把校园代理接入 Clash、OpenSSH 和 VS Code。应用不实现 SSH 客户端、HPC 管理器或 Jupyter/TensorBoard 专用转发器。

本 PR 修改产品/架构/执行文档，并增加一个只读合同测试防止后续路线回退；不启用任何未来功能。

## 核心修正

### 1. 轻量 WebResource

删除首个 Beta 中的通用 `ResourceDescriptor/resourceHandle/LaunchHandle/ResourceLaunchBroker` 设计。点击只提交稳定资源 ID，Main 每次从 active Profile/Account store 重新查找并校验 URL 与 route。

### 2. 重新排列阶段

- P2 Provider composition
- P3 Profile/Account/Workspace 存储隔离
- P4 Active Profile/Account 切换事务
- P5 安全 Gateway connector
- P6 学校选择器 + 第二个 reviewed Profile
- P6b 受控 Advanced custom domain
- P7 Profile Network Rules + External Tool Integration Center
- P8 普通用户 WebResource/Campus Workspace 升级
- P9 第一个真实学校证据支持的 EasyConnect 能力

Router、ForwardLease、通用端口转发不再是 P7/P8 前置条件。

### 3. 外部工具集成合同

P7 定义 Clash/Mihomo/PAC/manual export、Clash Verge Rev 受管扩展、OpenSSH managed Include、VS Code Remote-SSH 复用，以及用户明确选择文件中的独占 managed block。

所有写入遵循 `inspect → plan → preview → backup → atomic apply → validate → commit`。卸载只删除匹配受管区块。配置包含本机代理凭据时必须警告不要上传、同步或分享；严格本地代理认证不会自动关闭。

OpenSSH `Port` 始终是远端 SSH 服务端口；Campus 代理只通过 packaged `ProxyCommand`。

### 4. 多学校核心

P6 在 P7/P8 前完成第二个 reviewed Profile 与学校选择器。每个 Profile/Account 隔离 Gateway、VPN 凭据、Cookie、网站密码、证书 pin、路由、资源和集成状态。P6b custom domain 不继承 HKUST 信任或配置。

### 5. CI 范围棘轮

新增 `desktop/test/product-scope-contract.test.js`，持续验证：

- WebResource 与 External Tool Integration 是独立产品域；
- P6 → P7 → P8 顺序不回退；
- 不重新引入 descriptor/launch-handle hierarchy；
- 不创建 SSH/HPC/Jupyter/database/forwarding workbench 产品目录；
- Clash/OpenSSH 凭据与受管配置安全说明仍存在。

## 已核验的当前基础

当前代码已有 Clash YAML、OpenSSH `ProxyCommand`、跨平台 `ec-proxy-command`、owner-only proxy sidecar，以及 `ssh-config` / `copy-clash-node` IPC。PR #9 已合并，其 Engine config consume-time binding 与内置 Web 资源唯一事实源修复保持不变。

## 验证

- required GitHub checks：上一 HEAD 全部通过；新 test-only HEAD 正在重新运行
- 9 份核心文档、60 个本地 Markdown 链接：0 missing
- Desktop：604 passed，0 failed，1 Windows-only skip
- Product scope contract：3 passed
- Architecture gate：PASS（213 files、275 edges、0 cycles）
- Secret gate、`git diff --check`：PASS
- 禁止产品目录：0

## 不包含

- 不修改生产代码、1.x 行为、版本号或发布包
- 不增加未验证的学校 URL
- 不启用 custom Gateway、MFA、WebVPN、aTrust、TUN 或通用 forwarding
