### PR TITLE
2.0 P2: compose production providers and capability snapshots

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,6 +88,11 @@ Desktop Renderer
 - secret 输入的有界、内存化、zeroizing 生命周期；
 - 产出 `AuthenticatedGatewaySession` 或稳定失败。
 
+生产 provider 选择由闭合、编译期 `ProductionProviderSet` 统一装配。Profile 只能选择已编译
+`ProtocolFamily`；不能通过 JSON 加载任意实现。能力报告以 compiled/provider/profile/ingress
+四层相交，任何后续层只能收紧，不能提升缺失能力。详细合同见
+[`ADR-0006`](docs/adr/0006-production-provider-composition.md)。
+
 绝不负责：
 
 - L3、DNS、SOCKS、PAC、浏览器路由；

--- a/desktop/e2e/main-engine-fixture.js
+++ b/desktop/e2e/main-engine-fixture.js
@@ -32,6 +32,15 @@ if (!Number.isSafeInteger(generation) || generation <= 0 ||
 const configBytes = fs.readFileSync(configPath);
 const configSha256 = crypto.createHash('sha256').update(configBytes).digest('hex');
 const configOrigin = new URL(JSON.parse(configBytes.toString('utf8')).base_url).origin;
+const providerCapabilities = Object.fromEntries([
+  'auth.password', 'auth.captcha', 'auth.sms', 'auth.token', 'auth.certificate',
+  'auth.hid', 'auth.sso', 'auth.device', 'auth.unknown_secondary',
+  'resource.catalogue', 'resource.authorization_decision', 'transport.l3',
+  'transport.web_vpn',
+].map((capability) => [
+  capability,
+  ['auth.password', 'transport.l3'].includes(capability) ? 'supported' : 'unsupported',
+]));
 
 const attemptFile = path.join(userData, 'synthetic-engine-attempt.txt');
 const observationFile = path.join(userData, 'synthetic-engine-observations.jsonl');
@@ -96,9 +105,11 @@ input.on('line', (line) => {
     const keys = Object.keys(binding || {}).sort();
     if (JSON.stringify(keys) !== JSON.stringify([
       'apiVersion', 'configSha256', 'gatewayOrigin', 'profileId', 'profileRevision', 'type',
-    ]) || binding.type !== 'engine_config_binding' || binding.apiVersion !== 1 ||
+      'protocolFamily',
+    ].sort()) || binding.type !== 'engine_config_binding' || binding.apiVersion !== 1 ||
         binding.configSha256 !== configSha256 || binding.gatewayOrigin !== configOrigin ||
-        binding.profileId !== 'hkustgz' || binding.profileRevision !== 1) {
+        binding.profileId !== 'hkustgz' || binding.profileRevision !== 1 ||
+        binding.protocolFamily !== 'easyconnect-password-modern-l3-v1') {
       process.exit(64);
     }
     bindingSeen = true;
@@ -164,7 +175,20 @@ input.on('line', (line) => {
       type: 'control_hello',
       apiVersion: 2,
       requestId: frame.requestId,
-      capabilities: ['engine.shutdown'],
+      capabilities: ['engine.shutdown', 'provider.capabilities'],
+    });
+  } else if (frame?.type === 'request' && frame.apiVersion === 2 &&
+      frame.command?.name === 'provider_capabilities' && Number.isSafeInteger(frame.requestId)) {
+    observe('provider_capabilities_requested');
+    send({
+      type: 'provider_capabilities',
+      apiVersion: 2,
+      requestId: frame.requestId,
+      profileId: 'hkustgz',
+      profileRevision: 1,
+      engineGeneration: generation,
+      compiled: providerCapabilities,
+      provider: providerCapabilities,
     });
   } else if (frame?.type === 'request' && frame.apiVersion === 2 &&
       frame.command?.name === 'shutdown' && Number.isSafeInteger(frame.requestId)) {

--- a/desktop/e2e/main-engine-lifecycle.electron.js
+++ b/desktop/e2e/main-engine-lifecycle.electron.js
@@ -147,6 +147,15 @@ async function run() {
   assert.equal(connected.phase, 'connected');
   assert.equal(connected.dnsMode, 'gateway');
   assert.ok(connected.clientIp);
+  assert.equal(connected.capabilitySnapshot.profileId, 'hkustgz');
+  assert.equal(connected.capabilitySnapshot.effective['auth.password'], 'supported');
+  assert.equal(connected.capabilitySnapshot.effective['transport.l3'], 'supported');
+  assert.equal(connected.capabilitySnapshot.effective['auth.sms'], 'unsupported');
+  assert.equal(
+    connected.capabilitySnapshot.accountHandle,
+    connected.campusAccount.accountHandle,
+  );
+  assert.equal(JSON.stringify(connected.capabilitySnapshot).includes('accountKey'), false);
   assert.equal(await loopbackConnects(port), true,
     'listener_ready must correspond to a real owned loopback listener');
   const opened = await opening;
@@ -169,6 +178,8 @@ async function run() {
   control = await controlWindow(oldContentsId);
   const recovered = await invoke(control, 'window.api.getState()');
   assert.equal(recovered.connected, true, 'renderer recovery must not stop the healthy Engine');
+  assert.equal(recovered.capabilitySnapshot.engineGeneration,
+    connected.capabilitySnapshot.engineGeneration);
 
   const stopped = await invoke(control, 'window.api.disconnect()');
   assert.equal(stopped.ok, true);
@@ -177,6 +188,7 @@ async function run() {
     return !state.connected && !state.connecting ? state : null;
   }, 'graceful disconnect');
   assert.equal(disconnected.phase, 'idle');
+  assert.equal(disconnected.capabilitySnapshot, null);
   await waitFor(async () => !await loopbackConnects(port), 'loopback listener release');
 
   const events = observations();
@@ -195,6 +207,7 @@ async function run() {
   assert.ok(events.some((entry) => entry.type === 'stale_generation_sent'));
   assert.ok(events.some((entry) => entry.type === 'listener_ready_sent'));
   assert.ok(events.some((entry) => entry.type === 'shutdown_received'));
+  assert.ok(events.filter((entry) => entry.type === 'provider_capabilities_requested').length >= 2);
   process.stdout.write('main synthetic Engine lifecycle: PASS\n');
 }
 

--- a/desktop/lib/control-state-snapshot.js
+++ b/desktop/lib/control-state-snapshot.js
@@ -18,6 +18,7 @@ function createControlStateSnapshot({
   getFallbackResources,
   getProfilePresentation,
   getAuthChallenge,
+  getCapabilitySnapshot,
 } = {}) {
   const dependencies = {
     getStatus: requiredFunction(getStatus, 'getStatus'),
@@ -31,6 +32,7 @@ function createControlStateSnapshot({
     getFallbackResources: requiredFunction(getFallbackResources, 'getFallbackResources'),
     getProfilePresentation: requiredFunction(getProfilePresentation, 'getProfilePresentation'),
     getAuthChallenge: requiredFunction(getAuthChallenge, 'getAuthChallenge'),
+    getCapabilitySnapshot: requiredFunction(getCapabilitySnapshot, 'getCapabilitySnapshot'),
   };
   if (typeof platform !== 'string' || !platform) throw new TypeError('platform is required');
 
@@ -42,6 +44,7 @@ function createControlStateSnapshot({
     version: dependencies.getVersion(),
     update: dependencies.getUpdate(),
     authChallenge: dependencies.getAuthChallenge(),
+    capabilitySnapshot: dependencies.getCapabilitySnapshot(),
   });
 
   return function controlStateSnapshot() {

--- a/desktop/lib/engine-connection-runtime.js
+++ b/desktop/lib/engine-connection-runtime.js
@@ -50,6 +50,7 @@ class EngineConnectionRuntime {
       onFatalError: handlers.onFatalError || NOOP,
       onStopped: handlers.onStopped || NOOP,
       onProtocolTimeout: handlers.onProtocolTimeout || NOOP,
+      onProviderCapabilities: handlers.onProviderCapabilities || NOOP,
     };
     for (const handler of Object.values(this.handlers)) {
       if (typeof handler !== 'function') throw new TypeError('Engine runtime handler is invalid');
@@ -92,7 +93,14 @@ class EngineConnectionRuntime {
     // Control v2 negotiation starts during authentication. It remains
     // optional for the current password-only provider and must not turn a
     // failed graceful-control handshake into a connection failure.
-    this.control.handshake().catch(NOOP);
+    this.control.handshake()
+      .then(() => this.control.providerCapabilities())
+      .then((report) => {
+        if (!this.disposed && this.isCurrent(this.generation)) {
+          this.handlers.onProviderCapabilities(report);
+        }
+      })
+      .catch(NOOP);
     return true;
   }
 

--- a/desktop/lib/engine-control-client.js
+++ b/desktop/lib/engine-control-client.js
@@ -7,9 +7,21 @@ const DEFAULT_CONTROL_REQUEST_TIMEOUT_MS = 2_000;
 
 const CAPABILITY_TOKEN = /^[a-z][a-z0-9_.-]{0,95}$/u;
 const ERROR_CODE = /^[a-z][a-z0-9_]{0,63}$/u;
+const PROFILE_ID = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/u;
+const CAPABILITY_STATES = new Set(['supported', 'unsupported', 'unavailable']);
 
 function validRequestId(value) {
   return Number.isSafeInteger(value) && value > 0;
+}
+
+function normalizeCapabilityLayer(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) return null;
+  const entries = Object.entries(value);
+  if (!entries.length || entries.length > 64 || entries.some(([capability, state]) => (
+    !CAPABILITY_TOKEN.test(capability) || !CAPABILITY_STATES.has(state)
+  ))) return null;
+  return Object.fromEntries(entries.sort(([left], [right]) => left.localeCompare(right)));
 }
 
 function normalizeControlResponse(value) {
@@ -36,6 +48,30 @@ function normalizeControlResponse(value) {
       apiVersion: ENGINE_CONTROL_API_VERSION,
       requestId: value.requestId,
       status: value.status,
+    };
+  }
+  if (value.type === 'provider_capabilities') {
+    const keys = Object.keys(value).sort();
+    if (JSON.stringify(keys) !== JSON.stringify([
+      'apiVersion', 'compiled', 'engineGeneration', 'profileId', 'profileRevision',
+      'provider', 'requestId', 'type',
+    ])) return null;
+    if (typeof value.profileId !== 'string' || !PROFILE_ID.test(value.profileId) ||
+        !Number.isSafeInteger(value.profileRevision) || value.profileRevision <= 0 ||
+        !Number.isSafeInteger(value.engineGeneration) || value.engineGeneration <= 0) return null;
+    const compiled = normalizeCapabilityLayer(value.compiled);
+    const provider = normalizeCapabilityLayer(value.provider);
+    if (!compiled || !provider ||
+        JSON.stringify(Object.keys(compiled)) !== JSON.stringify(Object.keys(provider))) return null;
+    return {
+      type: 'provider_capabilities',
+      apiVersion: ENGINE_CONTROL_API_VERSION,
+      requestId: value.requestId,
+      profileId: value.profileId,
+      profileRevision: value.profileRevision,
+      engineGeneration: value.engineGeneration,
+      compiled,
+      provider,
     };
   }
   if (value.type === 'control_error') {
@@ -159,6 +195,18 @@ class EngineControlClient {
       }
       return response;
     });
+  }
+
+  providerCapabilities() {
+    if (!this.negotiated) {
+      return Promise.reject(new Error('engine control handshake is incomplete'));
+    }
+    return this.#request('provider_capabilities', (requestId) => ({
+      type: 'request',
+      apiVersion: ENGINE_CONTROL_API_VERSION,
+      requestId,
+      command: { name: 'provider_capabilities' },
+    }));
   }
 
   feed(value) {

--- a/desktop/lib/engine-control-suite.js
+++ b/desktop/lib/engine-control-suite.js
@@ -16,6 +16,8 @@ class EngineControlSuite {
 
   shutdown() { return this.v2.shutdown(); }
 
+  providerCapabilities() { return this.v2.providerCapabilities(); }
+
   feed(value) {
     this.v2.feed(value);
     this.auth.feed(value);
@@ -65,6 +67,11 @@ class EngineControlRegistry {
   shutdown() {
     if (!this.active?.client.negotiated) return false;
     return this.active.client.shutdown().then(() => true);
+  }
+
+  providerCapabilities() {
+    if (!this.active?.client.negotiated) return null;
+    return this.active.client.providerCapabilities();
   }
 }
 

--- a/desktop/lib/school-profile-controller.js
+++ b/desktop/lib/school-profile-controller.js
@@ -23,7 +23,9 @@ function createSchoolProfileController(options = {}) {
   if (!Buffer.isBuffer(accountEntropy) || accountEntropy.length !== 18) {
     throw new TypeError('account handle entropy is invalid');
   }
-  const accountHandle = `account-${accountEntropy.toString('base64url')}`;
+  // Hex has a fixed alphanumeric alphabet. Base64URL can legitimately end in
+  // "-" or "_", which the bounded handle schema rejects at random.
+  const accountHandle = `account-${accountEntropy.toString('hex')}`;
   accountEntropy.fill(0);
   const activeContextEpoch = 1;
   let currentCapabilitySnapshot = null;

--- a/desktop/lib/school-profile-controller.js
+++ b/desktop/lib/school-profile-controller.js
@@ -1,12 +1,52 @@
 'use strict';
 
+const crypto = require('node:crypto');
 const { mergeCampusResources, projectCampusResources } = require('./campus-resources');
 const { createActiveSchoolProfileContext } = require('./school-profile-runtime');
+const { createCapabilitySnapshot } = require('./school-profile-schema');
+
+const CURRENT_PROFILE_CAPABILITIES = new Set(['auth.password', 'transport.l3']);
+
+function selectedCapabilityLayer(keys) {
+  return Object.fromEntries(keys.map((capability) => [
+    capability,
+    CURRENT_PROFILE_CAPABILITIES.has(capability) ? 'supported' : 'unsupported',
+  ]));
+}
 
 function createSchoolProfileController(options = {}) {
   const context = createActiveSchoolProfileContext(options);
   const { profile } = context;
   const builtInResources = context.builtinResources;
+  const randomBytes = typeof options.randomBytes === 'function' ? options.randomBytes : crypto.randomBytes;
+  const accountEntropy = randomBytes(18);
+  if (!Buffer.isBuffer(accountEntropy) || accountEntropy.length !== 18) {
+    throw new TypeError('account handle entropy is invalid');
+  }
+  const accountHandle = `account-${accountEntropy.toString('base64url')}`;
+  accountEntropy.fill(0);
+  const activeContextEpoch = 1;
+  let currentCapabilitySnapshot = null;
+
+  function capabilitySnapshotFromReport(report) {
+    if (!report || report.profileId !== profile.profileId ||
+        report.profileRevision !== profile.profileRevision ||
+        !Number.isSafeInteger(report.engineGeneration) || report.engineGeneration <= 0) {
+      throw new TypeError('provider capability report does not match the active profile');
+    }
+    const keys = Object.keys(report.compiled).sort();
+    return createCapabilitySnapshot({
+      profileId: profile.profileId,
+      profileRevision: profile.profileRevision,
+      accountHandle,
+      activeContextEpoch,
+      engineGeneration: report.engineGeneration,
+      compiled: report.compiled,
+      provider: report.provider,
+      profile: selectedCapabilityLayer(keys),
+      ingress: selectedCapabilityLayer(keys),
+    });
+  }
 
   return Object.freeze({
     gatewayHost: context.gatewayHost,
@@ -27,6 +67,7 @@ function createSchoolProfileController(options = {}) {
         gatewayOrigin: profile.gateway.origin.origin,
         profileId: profile.profileId,
         profileRevision: profile.profileRevision,
+        protocolFamily: profile.gateway.protocolFamily,
       });
       if (Buffer.byteLength(stdinFrame, 'utf8') > 1024) {
         throw new Error('engine profile binding frame is too large');
@@ -42,6 +83,23 @@ function createSchoolProfileController(options = {}) {
     projectResources(customResources = []) {
       return projectCampusResources(builtInResources, customResources);
     },
+    createCapabilitySnapshot: capabilitySnapshotFromReport,
+    observeCapabilityReport(report) {
+      try {
+        currentCapabilitySnapshot = capabilitySnapshotFromReport(report);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    clearCapabilitySnapshot() {
+      const changed = currentCapabilitySnapshot !== null;
+      currentCapabilitySnapshot = null;
+      return changed;
+    },
+    capabilitySnapshot() {
+      return currentCapabilitySnapshot;
+    },
     createPresentation({
       locale = 'zh',
       hasCredential = false,
@@ -50,10 +108,11 @@ function createSchoolProfileController(options = {}) {
       return Object.freeze({
         schoolProfile: context.createProfileView({ locale, compatibility: 'reviewed' }),
         campusAccount: context.createLegacyPrimaryAccountView({
+          accountHandle,
           hasCredential,
           isActive: true,
         }),
-        workspace: context.createLegacyWorkspaceView({ resourceCount }),
+        workspace: context.createLegacyWorkspaceView({ accountHandle, resourceCount }),
       });
     },
   });

--- a/desktop/lib/school-profile-schema.js
+++ b/desktop/lib/school-profile-schema.js
@@ -451,33 +451,38 @@ function createWorkspaceView(value) {
 }
 
 function createLegacyPrimaryAccountView(value = {}) {
-  const source = exactKeys(value, ['label', 'hasCredential', 'isActive'], [],
+  const source = exactKeys(value, ['accountHandle', 'label', 'hasCredential', 'isActive'], [],
     'legacy primary account view');
   if (source.hasCredential != null && typeof source.hasCredential !== 'boolean' ||
       source.isActive != null && typeof source.isActive !== 'boolean') {
     throw new TypeError('legacy primary account state is invalid');
   }
-  return Object.freeze({
+  const view = {
     kind: 'legacy-primary',
     role: 'primary',
     state: 'legacy',
     label: source.label == null ? null : boundedText(source.label, 40, 'account label'),
     hasCredential: source.hasCredential === true,
     isActive: source.isActive !== false,
-  });
+  };
+  if (source.accountHandle != null) view.accountHandle = opaqueAccountHandle(source.accountHandle);
+  return Object.freeze(view);
 }
 
 function createLegacyWorkspaceView(value = {}) {
-  const source = exactKeys(value, ['resourceCount', 'favoriteCount', 'recentCount'], [],
+  const source = exactKeys(value,
+    ['accountHandle', 'resourceCount', 'favoriteCount', 'recentCount'], [],
     'legacy workspace view');
-  return Object.freeze({
+  const view = {
     kind: 'legacy-workspace',
     accountRole: 'primary',
     persistentScope: false,
     resourceCount: boundedCount(source.resourceCount ?? 0, 'resourceCount'),
     favoriteCount: boundedCount(source.favoriteCount ?? 0, 'favoriteCount'),
     recentCount: boundedCount(source.recentCount ?? 0, 'recentCount'),
-  });
+  };
+  if (source.accountHandle != null) view.accountHandle = opaqueAccountHandle(source.accountHandle);
+  return Object.freeze(view);
 }
 
 function normalizeCapabilityLayer(value, name) {

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -472,7 +472,7 @@ function beginLifecycleIntent() {
 function clearConnectionPresentation() {
   connectedAt = null;
   state.clientIp = null;
-  state.dnsMode = 'unknown';
+  state.dnsMode = 'unknown'; activeSchoolProfile.clearCapabilitySnapshot();
   telemetryCoordinator?.stop();
 }
 
@@ -719,7 +719,7 @@ async function connectOnce(isRetry, intent) {
   let engineConfigBinding;
   state.lastError = null;
   state.clientIp = null;
-  state.dnsMode = 'unknown';
+  state.dnsMode = 'unknown'; activeSchoolProfile.clearCapabilitySnapshot();
   emit();
   if (!connectionState.canAttempt(intent)) {
     emit();
@@ -1009,6 +1009,7 @@ async function connectOnce(isRetry, intent) {
         engineSupervisor.stop({ graceMs: 1000, forceWaitMs: STOP_FORCE_WAIT_MS })
           .catch(() => {});
       },
+      onProviderCapabilities: (report) => activeSchoolProfile.observeCapabilityReport(report) && emit(),
     },
   });
   // An engine that dies before reading stdin (missing library, wrong
@@ -1322,6 +1323,7 @@ const controlStateSnapshot = createControlStateSnapshot({
   getFallbackResources: () => safeCampusResources({ customResources: [] }),
   getProfilePresentation: (options) => activeSchoolProfile.createPresentation(options),
   getAuthChallenge: () => authChallengeCoordinator.snapshot(),
+  getCapabilitySnapshot: () => activeSchoolProfile.capabilitySnapshot(),
 });
 
 for (const [channel, handler] of Object.entries(authChallengeCoordinator.ipcHandlers())) {

--- a/desktop/test/cli-proxy-auth.test.js
+++ b/desktop/test/cli-proxy-auth.test.js
@@ -96,6 +96,7 @@ test('root CLI always uses strict stdin auth and its authenticated helper', () =
   assert.match(source, /source "\$PROXY_CREDENTIAL_LIBRARY"/);
   assert.match(source, /--socks-auth-stdin/);
   assert.match(source, /--profile-binding-v1-stdin/);
+  assert.match(source, /"protocolFamily":"easyconnect-password-modern-l3-v1"/u);
   assert.doesNotMatch(source, /shasum[^\n]*ENGINE_CONFIG/u);
   assert.ok(source.indexOf('printf -v binding_frame') < source.indexOf('pw="$(get_pw)"'));
   assert.ok(source.indexOf('engine_config_binding') < source.indexOf('printf \'%s\\n\' "$ACC"'));

--- a/desktop/test/control-state-snapshot.test.js
+++ b/desktop/test/control-state-snapshot.test.js
@@ -28,6 +28,7 @@ function fixture(overrides = {}) {
       };
     },
     getAuthChallenge: () => null,
+    getCapabilitySnapshot: () => null,
     ...overrides,
   });
   return { calls, snapshot };
@@ -39,6 +40,7 @@ test('projects settings, resources and key-free profile compatibility views', ()
   assert.equal(value.connected, true);
   assert.equal(value.loggedIn, true);
   assert.equal(value.hasPassword, true);
+  assert.equal(value.capabilitySnapshot, null);
   assert.deepEqual(value.campusResources.map(({ id }) => id), ['home', 'hpc']);
   assert.deepEqual(calls, [{ locale: 'zh-CN', hasCredential: true, resourceCount: 2 }]);
   for (const forbidden of ['engineConfigRef', 'reviewedDnsFallback', 'accountKey', 'workspaceKey']) {
@@ -59,6 +61,22 @@ test('settings failure returns the bounded fallback without probing credentials'
   assert.deepEqual(value.campusResources, [{ id: 'home' }]);
   assert.equal(credentialReads, 0);
   assert.deepEqual(calls, [{ locale: 'zh-CN' }]);
+});
+
+test('get-state carries only the already-sanitized additive capability snapshot', () => {
+  const capabilitySnapshot = Object.freeze({
+    schemaVersion: 1,
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    accountHandle: 'ephemeral-account-handle',
+    activeContextEpoch: 1,
+    engineGeneration: 7,
+    layers: {},
+    effective: { 'auth.password': 'supported', 'transport.l3': 'supported' },
+  });
+  const { snapshot } = fixture({ getCapabilitySnapshot: () => capabilitySnapshot });
+  assert.equal(snapshot().capabilitySnapshot, capabilitySnapshot);
+  assert.equal(JSON.stringify(snapshot()).includes('accountKey'), false);
 });
 
 test('legacy custom URL conflicts cannot make get-state fail', () => {

--- a/desktop/test/engine-connection-runtime.test.js
+++ b/desktop/test/engine-connection-runtime.test.js
@@ -8,9 +8,21 @@ const { EngineConnectionRuntime } = require('../lib/engine-connection-runtime');
 class FakeControl {
   constructor() {
     this.handshakes = 0;
+    this.capabilityQueries = 0;
     this.chunks = [];
   }
   handshake() { this.handshakes += 1; return Promise.resolve(); }
+  providerCapabilities() {
+    this.capabilityQueries += 1;
+    return Promise.resolve({
+      type: 'provider_capabilities',
+      profileId: 'hkustgz',
+      profileRevision: 1,
+      engineGeneration: 7,
+      compiled: { 'auth.password': 'supported', 'transport.l3': 'supported' },
+      provider: { 'auth.password': 'supported', 'transport.l3': 'supported' },
+    });
+  }
   feed(chunk) { this.chunks.push(Buffer.from(chunk)); }
 }
 
@@ -33,6 +45,7 @@ function fixture(overrides = {}) {
     'onFatalError',
     'onStopped',
     'onProtocolTimeout',
+    'onProviderCapabilities',
   ].map((name) => [name, (...args) => calls.push([name, ...args])]));
   const runtime = new EngineConnectionRuntime({
     generation: 7,
@@ -117,6 +130,25 @@ test('runtime binds one generation, negotiates before readiness, and dispatches 
   ]);
   assert.equal(f.control.chunks.length, 1, 'v2/v3 control sees the same stdout chunk');
   assert.ok(f.clearedTimer, 'the Event API hello clears its deadline');
+});
+
+test('runtime queries additive provider capabilities without changing Event API v1', async () => {
+  const f = fixture();
+  f.runtime.start(f.stdout);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(f.control.handshakes, 1);
+  assert.equal(f.control.capabilityQueries, 1);
+  assert.deepEqual(f.calls, [[
+    'onProviderCapabilities',
+    {
+      type: 'provider_capabilities',
+      profileId: 'hkustgz',
+      profileRevision: 1,
+      engineGeneration: 7,
+      compiled: { 'auth.password': 'supported', 'transport.l3': 'supported' },
+      provider: { 'auth.password': 'supported', 'transport.l3': 'supported' },
+    },
+  ]]);
 });
 
 test('listener mismatch and stale generation output fail closed before UI callbacks', () => {

--- a/desktop/test/engine-control-client.test.js
+++ b/desktop/test/engine-control-client.test.js
@@ -63,6 +63,28 @@ test('client negotiates v2 then requests typed graceful shutdown', async () => {
   assert.equal((await shutdown).status, 'accepted');
 });
 
+test('provider capability query is bounded typed and profile-generation bound', async () => {
+  const writable = new FakeWritable();
+  const client = new EngineControlClient({ writable });
+  const hello = client.handshake();
+  client.feed('{"type":"control_hello","apiVersion":2,"requestId":1,"capabilities":["provider.capabilities"]}\n');
+  await hello;
+  const request = client.providerCapabilities();
+  assert.deepEqual(writable.frames[1], {
+    type: 'request', apiVersion: 2, requestId: 2,
+    command: { name: 'provider_capabilities' },
+  });
+  client.feed('{"type":"provider_capabilities","apiVersion":2,"requestId":2,"profileId":"hkustgz","profileRevision":1,"engineGeneration":9,"compiled":{"auth.password":"supported","auth.sms":"unsupported","transport.l3":"supported"},"provider":{"auth.password":"supported","auth.sms":"unsupported","transport.l3":"supported"}}\n');
+  const report = await request;
+  assert.equal(report.profileId, 'hkustgz');
+  assert.equal(report.engineGeneration, 9);
+  assert.equal(report.provider['auth.sms'], 'unsupported');
+  assert.equal(normalizeControlResponse({ ...report, cookie: 'private' }), null);
+  assert.equal(normalizeControlResponse({
+    ...report, provider: { ...report.provider, 'auth.token': 'supported' },
+  }), null);
+});
+
 test('typed errors and stream close reject pending requests without leaking payloads', async () => {
   const writable = new FakeWritable();
   const client = new EngineControlClient({ writable });

--- a/desktop/test/main-engine-protocol-contract.test.js
+++ b/desktop/test/main-engine-protocol-contract.test.js
@@ -45,5 +45,8 @@ test('desktop opts into the private Control v2 stream and retains signal fallbac
   assert.ok(credentials > 0 && runtimeStart > credentials,
     'runtime/handshake starts only after the credential prefix');
   assert.match(runtime, /this\.control\.handshake\(\)/);
+  assert.match(runtime, /this\.control\.providerCapabilities\(\)/);
+  assert.match(source, /activeSchoolProfile\.observeCapabilityReport\(report\)/u);
+  assert.match(source, /getCapabilitySnapshot: \(\) => activeSchoolProfile\.capabilitySnapshot\(\)/u);
   assert.match(source, /requestGracefulStop: requestActiveEngineControlShutdown/);
 });

--- a/desktop/test/school-profile-controller.test.js
+++ b/desktop/test/school-profile-controller.test.js
@@ -109,7 +109,10 @@ test('provider capability reports become profile-bound key-free renderer snapsho
 test('process-lifetime account handles require exact entropy and erase the source buffer', () => {
   const entropy = Buffer.alloc(18, 7);
   const profile = controller({ randomBytes: () => entropy });
-  assert.match(profile.createPresentation().campusAccount.accountHandle, /^account-/u);
+  assert.equal(
+    profile.createPresentation().campusAccount.accountHandle,
+    `account-${'07'.repeat(18)}`,
+  );
   assert.deepEqual(entropy, Buffer.alloc(18));
   assert.throws(
     () => controller({ randomBytes: () => Buffer.alloc(17) }),

--- a/desktop/test/school-profile-controller.test.js
+++ b/desktop/test/school-profile-controller.test.js
@@ -7,10 +7,11 @@ const { createSchoolProfileController } = require('../lib/school-profile-control
 
 const desktopRoot = path.join(__dirname, '..');
 
-function controller() {
+function controller(options = {}) {
   return createSchoolProfileController({
     packageRoot: desktopRoot,
     desktopDir: desktopRoot,
+    ...options,
   });
 }
 
@@ -38,16 +39,86 @@ test('composes the reviewed HKUST deployment without persistent account scope', 
     gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
     profileId: 'hkustgz',
     profileRevision: 1,
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
   });
 
   const presentation = profile.createPresentation();
   assert.equal(presentation.schoolProfile.profileId, 'hkustgz');
   assert.equal(presentation.schoolProfile.schoolName, '香港科技大学(广州)');
   assert.equal(presentation.campusAccount.kind, 'legacy-primary');
+  assert.match(presentation.campusAccount.accountHandle, /^account-/u);
+  assert.equal(
+    presentation.workspace.accountHandle,
+    presentation.campusAccount.accountHandle,
+  );
   assert.equal(presentation.workspace.persistentScope, false);
   for (const forbidden of ['engineConfigRef', 'reviewedDnsFallback', 'accountKey', 'workspaceKey']) {
     assert.equal(JSON.stringify(presentation).includes(forbidden), false);
   }
+});
+
+test('provider capability reports become profile-bound key-free renderer snapshots', () => {
+  const profile = controller({ randomBytes: () => Buffer.alloc(18, 7) });
+  const capabilities = [
+    'auth.password', 'auth.captcha', 'auth.sms', 'auth.token', 'auth.certificate',
+    'auth.hid', 'auth.sso', 'auth.device', 'auth.unknown_secondary',
+    'resource.catalogue', 'resource.authorization_decision', 'transport.l3',
+    'transport.web_vpn',
+  ];
+  const layer = Object.fromEntries(capabilities.map((capability) => [
+    capability,
+    ['auth.password', 'transport.l3'].includes(capability) ? 'supported' : 'unsupported',
+  ]));
+  const snapshot = profile.createCapabilitySnapshot({
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    engineGeneration: 9,
+    compiled: layer,
+    provider: layer,
+  });
+  assert.equal(snapshot.profileId, 'hkustgz');
+  assert.equal(snapshot.engineGeneration, 9);
+  assert.equal(snapshot.effective['auth.password'], 'supported');
+  assert.equal(snapshot.effective['transport.l3'], 'supported');
+  assert.equal(snapshot.effective['auth.sms'], 'unsupported');
+  assert.equal(snapshot.accountHandle, profile.createPresentation().campusAccount.accountHandle);
+  for (const forbidden of ['accountKey', 'workspaceKey', 'protocolFamily', 'cookie', 'token']) {
+    assert.equal(Object.hasOwn(snapshot, forbidden), false);
+  }
+  assert.throws(() => profile.createCapabilitySnapshot({
+    profileId: 'other-school',
+    profileRevision: 1,
+    engineGeneration: 9,
+    compiled: layer,
+    provider: layer,
+  }), /active profile/u);
+  assert.equal(profile.observeCapabilityReport({
+    profileId: 'hkustgz', profileRevision: 1, engineGeneration: 9,
+    compiled: layer, provider: layer,
+  }), true);
+  assert.equal(profile.capabilitySnapshot().engineGeneration, 9);
+  assert.equal(profile.observeCapabilityReport({
+    profileId: 'other-school', profileRevision: 1, engineGeneration: 10,
+    compiled: layer, provider: layer,
+  }), false);
+  assert.equal(profile.capabilitySnapshot().engineGeneration, 9);
+  assert.equal(profile.clearCapabilitySnapshot(), true);
+  assert.equal(profile.clearCapabilitySnapshot(), false);
+});
+
+test('process-lifetime account handles require exact entropy and erase the source buffer', () => {
+  const entropy = Buffer.alloc(18, 7);
+  const profile = controller({ randomBytes: () => entropy });
+  assert.match(profile.createPresentation().campusAccount.accountHandle, /^account-/u);
+  assert.deepEqual(entropy, Buffer.alloc(18));
+  assert.throws(
+    () => controller({ randomBytes: () => Buffer.alloc(17) }),
+    /account handle entropy is invalid/u,
+  );
+  assert.throws(
+    () => controller({ randomBytes: () => 'not-random-bytes' }),
+    /account handle entropy is invalid/u,
+  );
 });
 
 test('presentation uses an explicit locale and bounded resource count', () => {

--- a/docs/adr/0006-production-provider-composition.md
+++ b/docs/adr/0006-production-provider-composition.md
@@ -1,0 +1,104 @@
+# ADR-0006: Production provider composition and capability reporting
+
+- Status: Accepted P2 implementation contract
+- Production activation: behavior-preserving only
+- Protocol families enabled by this ADR: `easyconnect-password-modern-l3-v1`
+
+## Context
+
+Authentication and Modern L3 already have typed Rust provider/backend traits, but production `ec-engine` still
+constructed their concrete adapters directly. Desktop also had a strict `CapabilitySnapshot` schema that was not
+fed by the Engine. Adding a second provider in that state would spread protocol selection and capability claims
+across process startup, session code and UI.
+
+P2 creates a narrow composition seam without enabling another protocol or authentication method.
+
+## Decision
+
+### Closed production family
+
+The private reviewed Profile binding carries one `protocolFamily`. Rust accepts only a compiled
+`ProductionProviderFamily` enum. JSON cannot name a module, library, class, endpoint or plugin path.
+
+The current mapping is exact:
+
+```text
+easyconnect-password-modern-l3-v1
+  authentication = ProductionPasswordAuthProvider
+  resources      = UnsupportedResourceProvider
+  transport      = ModernL3TransportBackend
+```
+
+Unknown families fail as `CONFIGURATION_INVALID` before authentication network work. No dynamic plugin ABI,
+`dlopen`, configuration-driven provider registry or endpoint guessing is introduced.
+
+### One coordinator
+
+`ProviderCoordinator<Auth, Resource, Transport>` owns one type-compatible provider set. The transport session
+type must equal the authentication session type at compile time. Production and synthetic tests instantiate this
+same coordinator rather than maintaining a second test-only orchestration path.
+
+The binary's `CapabilityModel` is an upper bound. A selected provider may keep or tighten a capability to
+`unavailable`/`unsupported`; it cannot promote a capability that the compiled layer lacks.
+
+### Additive capability API
+
+Event API v1 remains byte/schema compatible. Control API v2 adds the private, secret-free
+`provider.capabilities` query and returns:
+
+```text
+profileId / profileRevision / engineGeneration
+compiled capability layer
+selected provider capability layer
+```
+
+The response contains every stable capability with one state: `supported`, `unsupported` or `unavailable`. It
+contains no Gateway origin, username, account key, Cookie, token, endpoint, DNS target or transport material.
+
+Desktop rejects a report whose Profile or generation does not match the active Engine. It adds the reviewed
+Profile and current ingress layers, intersects all four layers, and publishes only the existing sanitized
+`CapabilitySnapshot` view.
+
+### P2 account boundary
+
+P3—not P2—owns durable account/workspace key generation and journaled migration. Until P3 commits that state,
+the single legacy primary account receives a random process-lifetime `accountHandle` and
+`activeContextEpoch = 1`. Renderer may see that handle; it never sees or implies a persistent account key.
+
+Restart changes the short-lived handle. Disconnect clears the current generation-bound capability snapshot.
+P3 will replace the internal legacy binding with the journaled account key/revision while preserving the same
+Renderer schema.
+
+## Compatibility
+
+- Password authentication requests and Modern token/Data Plane code are unchanged.
+- Resource catalogue, WebVPN and every secondary authentication capability remain `unsupported`.
+- Event API v1 hello remains `password`, `l3`, `udp`; P2 does not reinterpret it.
+- A failed capability query is non-fatal for the password connection path and cannot downgrade TLS, DNS,
+  destination safety or local proxy authentication.
+- Existing CLI invocations without Control v2 retain their current behavior. Official Desktop always supplies
+  the reviewed Profile binding and Control v2 stream.
+
+## Security invariants
+
+1. Profile `protocolFamily` is verified before provider construction.
+2. Provider capability state can only tighten compiled capability state.
+3. Profile and ingress claims cannot elevate compiled/provider state.
+4. Stale Profile/generation reports update Renderer state zero times.
+5. Persistent account/workspace keys, credentials, Cookies and tokens cross the capability API zero times.
+6. Unknown/unsupported authentication remains fail-closed and performs no guessed continuation request.
+7. Provider composition introduces no network listener or configuration-driven code loading.
+
+## Verification gates
+
+- production `ec-engine` constructs `ProductionProviderSet`, not concrete auth/transport adapters;
+- synthetic auth/resource/transport providers run through `ProviderCoordinator`;
+- Control v2 codec/query tests cover bounds, unknown fields, Profile/generation binding and secret-free output;
+- real Electron Main E2E observes the sanitized snapshot, renderer restart retention and disconnect clearing;
+- Event API v1 schema test remains unchanged;
+- password-only/Modern L3, module-boundary, package and three-platform CI remain green.
+
+## Rollback
+
+Rollback removes the provider-set factory and additive Control v2 query while retaining the existing concrete
+password/Modern implementations and Event API v1. No user data migration or persistent state is created by P2.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -606,9 +606,9 @@ automatic 2.0 scope.
 Implementation contract: [`ADR-0006`](../adr/0006-production-provider-composition.md).
 
 - map current `easyconnect-password-modern-l3-v1` family to one compiled provider set;
-- derive a sanitized runtime capability snapshot internally bound to profile ID/revision + persistent
-  account key/revision + active-context epoch + Engine generation; Renderer receives only the short-lived
-  `accountHandle`, never the persistent account key;
+- derive a sanitized runtime capability snapshot internally bound to profile ID/revision + process-lifetime
+  `accountHandle` + active-context epoch + Engine generation; P3 replaces this temporary binding with its
+  journaled persistent account key/revision, which Renderer never receives;
 - run production and synthetic providers through the same coordinator;
 - use only a narrow compile-time enum/factory; no plugin ABI or speculative provider contract;
 - publish capabilities through an additive API while Event API v1 remains unchanged;

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -603,6 +603,8 @@ automatic 2.0 scope.
 
 ### 2.0-P2 — Production Provider Composition Seam
 
+Implementation contract: [`ADR-0006`](../adr/0006-production-provider-composition.md).
+
 - map current `easyconnect-password-modern-l3-v1` family to one compiled provider set;
 - derive a sanitized runtime capability snapshot internally bound to profile ID/revision + persistent
   account key/revision + active-context epoch + Engine generation; Renderer receives only the short-lived

--- a/hkustgzconnect
+++ b/hkustgzconnect
@@ -85,7 +85,7 @@ report_up(){
 
 run_engine(){
   local binding_frame pw
-  printf -v binding_frame '{"type":"engine_config_binding","apiVersion":1,"configSha256":"%s","gatewayOrigin":"https://remote.hkust-gz.edu.cn","profileId":"hkustgz","profileRevision":1}' \
+  printf -v binding_frame '{"type":"engine_config_binding","apiVersion":1,"configSha256":"%s","gatewayOrigin":"https://remote.hkust-gz.edu.cn","profileId":"hkustgz","profileRevision":1,"protocolFamily":"easyconnect-password-modern-l3-v1"}' \
     "$REVIEWED_ENGINE_CONFIG_SHA256"
   pw="$(get_pw)" || true
   [ -n "${pw:-}" ] || die "no password in Keychain — run: $(basename "$0") set-password"

--- a/independent/ARCHITECTURE.md
+++ b/independent/ARCHITECTURE.md
@@ -12,6 +12,7 @@ editing the SOCKS frontend, desktop UI, or unrelated protocol generations.
 | `gateway_auth.rs` | Redacted/zeroizing artifacts of completed Gateway authentication | Modern token, Data Plane, DNS or proxy policy |
 | `credentials.rs` | Bounded two-line gateway credential stdin contract | Gateway HTTP, provider policy or protocol formats |
 | `engine/provider.rs` | Stable AuthProvider/ResourceProvider/TransportBackend traits, capability states, typed unsupported/unavailable errors | Vendor wire formats, UI state, credentials at rest |
+| `engine/provider_composition.rs` | Closed production protocol-family factory and one capability-bounded provider coordinator | Dynamic plugins, user-selected implementation names, vendor endpoint guessing or UI state |
 | `engine/auth_transaction.rs` | Engine-owned generation/transaction/epoch/request binding, sanitized challenge view, zeroizing response, resend/cancel/abort invariants | Vendor endpoint, OTP shape, Renderer state or Data Plane |
 | `engine/auth_control.rs` | Bounded zeroizing secret-bearing Control API v3 codec/session for synthetic/future interactive providers | Public listener, vendor endpoint or password-only capability claims |
 | `engine/control_mux.rs` | Ordered v2/v3 decoding on the inherited private pipe; generic secret-free framing errors | Provider state, public listener or cross-schema coercion |
@@ -113,8 +114,10 @@ The local engine APIs also have separate directions:
   a 2048-byte frame limit, version negotiation and request IDs. It opens no
   listener and cannot represent credentials, tokens, URLs or destinations.
   Its handshake is answered during authentication, before L3/listener setup.
-  Its currently advertised capabilities are shutdown, cancellation and
-  control-channel close. The process assembler applies accepted actions;
+  Its currently advertised capabilities are shutdown, cancellation,
+  control-channel close and the additive secret-free provider-capability query.
+  That query is bound to the reviewed Profile revision and Engine generation;
+  Event API v1 remains unchanged. The process assembler applies accepted actions;
   `engine/control.rs` itself never terminates a process.
 - **Interactive Auth Control API v3** is a separate, secret-bearing bounded
   schema over the same inherited private pipe. It supports sanitized challenge

--- a/independent/spec/ENGINE_CONTROL_API_V2.md
+++ b/independent/spec/ENGINE_CONTROL_API_V2.md
@@ -46,7 +46,7 @@ The first successful exchange negotiates version 2:
 
 ```json
 {"type":"hello","requestId":1,"versions":[2]}
-{"type":"control_hello","apiVersion":2,"requestId":1,"capabilities":["engine.shutdown","request.cancel","control.close"]}
+{"type":"control_hello","apiVersion":2,"requestId":1,"capabilities":["engine.shutdown","request.cancel","control.close","provider.capabilities"]}
 ```
 
 All later requests include `apiVersion: 2`. A missing handshake, duplicate ID,
@@ -82,3 +82,28 @@ closed enum in `ControlCapability`. They always fail explicitly, for example:
 This is not a WebVPN, resource, or MFA implementation. The schema has no
 arbitrary command payload and therefore cannot carry credentials, challenge
 answers, gateway tokens, or destination addresses.
+
+## Additive provider capability query
+
+An official Profile-bound Desktop may request the selected production provider layers:
+
+```json
+{"type":"request","apiVersion":2,"requestId":4,"command":{"name":"provider_capabilities"}}
+```
+
+The response is exact-schema and contains the Profile revision and Engine generation plus two maps with the same
+bounded capability keys:
+
+```json
+{"type":"provider_capabilities","apiVersion":2,"requestId":4,"profileId":"hkustgz","profileRevision":1,"engineGeneration":9,"compiled":{"auth.password":"supported","transport.l3":"supported"},"provider":{"auth.password":"supported","transport.l3":"supported"}}
+```
+
+The abbreviated example shows the shape; production reports every stable capability. A state is exactly one of
+`supported`, `unsupported`, or `unavailable`. The selected provider layer may only keep or tighten the compiled
+layer. The response never contains a username, account key, Gateway origin, endpoint, Cookie, token, DNS target,
+credential or transport material.
+
+If the Engine was not launched with a reviewed Profile binding, the request returns
+`capability_context_unavailable`. Desktop binds the report to its short-lived account handle and active-context
+epoch, adds Profile/ingress layers, and rejects a stale Profile or generation. Event API v1 hello and lifecycle
+events are unchanged.

--- a/independent/src/bin/ec-engine.rs
+++ b/independent/src/bin/ec-engine.rs
@@ -15,11 +15,10 @@ use ec_compat::engine::event::{
 };
 use ec_compat::engine::ip_packet::stack_mtu;
 use ec_compat::engine::netstack::VirtualNetstack;
-use ec_compat::engine::provider::ProviderError;
+use ec_compat::engine::provider::{ProviderCapabilityReport, ProviderError};
+use ec_compat::engine::provider_composition::{ProductionProviderFamily, ProductionProviderSet};
 use ec_compat::engine::proxy::{NameResolver, RejectDomainResolver, SystemDnsResolver};
-use ec_compat::engine::session::{
-    AuthenticatedGatewaySession, ModernL3Connection, ModernL3TransportBackend,
-};
+use ec_compat::engine::session::{AuthenticatedGatewaySession, ModernL3Connection};
 use ec_compat::engine::socks::SocksServer;
 use ec_compat::engine::socks_auth::{
     EngineCredentials, ProxyAuthentication, ProxyAuthenticationMode, read_engine_credentials,
@@ -77,6 +76,14 @@ enum ControlInput {
 #[derive(Default)]
 struct PendingControlActions {
     shutdowns: std::collections::BTreeMap<u64, tokio::time::Instant>,
+}
+
+#[derive(Clone)]
+struct ProviderControlContext {
+    profile_id: String,
+    profile_revision: u64,
+    engine_generation: u64,
+    report: ProviderCapabilityReport,
 }
 
 impl PendingControlActions {
@@ -343,13 +350,15 @@ fn parse_arguments(args: &[String]) -> Result<EngineArguments> {
     })
 }
 
-fn start_control_reader() -> Result<tokio::sync::mpsc::Receiver<ControlInput>> {
+fn start_control_reader(
+    provider_context: Option<ProviderControlContext>,
+) -> Result<tokio::sync::mpsc::Receiver<ControlInput>> {
     let (sender, receiver) = tokio::sync::mpsc::channel(MAX_ACTIVE_REQUESTS);
     std::thread::Builder::new()
         .name("ec-engine-control".into())
         .spawn(move || {
             let stdin = std::io::stdin();
-            if control_reader_loop(stdin.lock(), sender).is_err() {
+            if control_reader_loop(stdin.lock(), sender, provider_context).is_err() {
                 // Framing errors are intentionally generic: never echo a raw
                 // control line that might have been supplied by a faulty
                 // caller. EOF is a normal control-channel close and does not
@@ -364,9 +373,18 @@ fn start_control_reader() -> Result<tokio::sync::mpsc::Receiver<ControlInput>> {
 fn control_reader_loop<R: std::io::Read>(
     reader: R,
     sender: tokio::sync::mpsc::Sender<ControlInput>,
+    provider_context: Option<ProviderControlContext>,
 ) -> Result<()> {
     let mut reader = InheritedControlFrameReader::new(reader);
-    let mut session = ControlSession::new();
+    let mut session = match provider_context {
+        Some(context) => ControlSession::with_provider_capabilities(
+            context.profile_id,
+            context.profile_revision,
+            context.engine_generation,
+            context.report,
+        )?,
+        None => ControlSession::new(),
+    };
     while let Some(request) = reader.read_request()? {
         let (input, closes_channel) = match request {
             InheritedControlRequest::V2(request) => {
@@ -691,17 +709,16 @@ fn cancelled_connection_attempt_failure(message: &'static str) -> EngineFailure 
 }
 
 async fn authenticate_password_with_lifecycle<W: Write>(
-    config: &serde_json::Value,
+    providers: &ProductionProviderSet,
     gateway_username: zeroize::Zeroizing<String>,
     gateway_password: zeroize::Zeroizing<String>,
     control_receiver: &mut Option<tokio::sync::mpsc::Receiver<ControlInput>>,
     pending_control_actions: &mut PendingControlActions,
     lifecycle: &mut EngineLifecycle<W>,
 ) -> EngineResult<Option<AuthenticatedGatewaySession>> {
-    let worker_config = config.clone();
+    let authentication_provider = providers.authentication_provider();
     let mut authentication = BlockingOperation::spawn(move |cancellation| {
-        AuthenticatedGatewaySession::authenticate_with_provider_error_cancellable(
-            &worker_config,
+        authentication_provider.authenticate_password_cancellable(
             &gateway_username,
             &gateway_password,
             &cancellation,
@@ -786,12 +803,13 @@ fn authentication_completion_cleanup_unconfirmed(
 }
 
 async fn prepare_transport_with_lifecycle<W: Write>(
-    backend: ModernL3TransportBackend,
+    providers: &ProductionProviderSet,
     session: AuthenticatedGatewaySession,
     control_receiver: &mut Option<tokio::sync::mpsc::Receiver<ControlInput>>,
     pending_control_actions: &mut PendingControlActions,
     lifecycle: &mut EngineLifecycle<W>,
 ) -> EngineResult<Option<(AuthenticatedGatewaySession, ModernL3Connection)>> {
+    let backend = providers.transport_backend();
     let mut transport = BlockingOperation::spawn(move |cancellation| {
         backend.connect_or_logout_cancellable(session, &cancellation)
     });
@@ -987,15 +1005,41 @@ async fn run_engine<W: Write>(
             error,
         )
     })?;
+    let provider_family = config_binding
+        .as_ref()
+        .map(|binding| binding.protocol_family())
+        .unwrap_or(ProductionProviderFamily::EasyConnectPasswordModernL3V1);
+    let provider_control_context = config_binding
+        .as_ref()
+        .map(|binding| {
+            provider_family
+                .capability_report()
+                .map(|report| ProviderControlContext {
+                    profile_id: binding.profile_id().to_owned(),
+                    profile_revision: binding.profile_revision(),
+                    engine_generation: arguments.generation,
+                    report,
+                })
+        })
+        .transpose()
+        .map_err(|_| {
+            failure(
+                EngineErrorCode::ConfigurationInvalid,
+                StopReason::StartupFailed,
+                Error("engine provider capability composition is invalid".into()),
+            )
+        })?;
     drop(inherited_stdin);
     let mut control_receiver = if arguments.control_api_v2_stdin {
-        Some(start_control_reader().map_err(|error| {
-            failure(
-                EngineErrorCode::LocalListenerFailed,
-                StopReason::StartupFailed,
-                error,
-            )
-        })?)
+        Some(
+            start_control_reader(provider_control_context).map_err(|error| {
+                failure(
+                    EngineErrorCode::LocalListenerFailed,
+                    StopReason::StartupFailed,
+                    error,
+                )
+            })?,
+        )
     } else {
         None
     };
@@ -1005,6 +1049,13 @@ async fn run_engine<W: Write>(
         lifecycle.begin_stopping().map_err(event_output_failure)?;
         return Ok(StopReason::UserRequested);
     }
+    let providers = ProductionProviderSet::from_config(provider_family, &config).map_err(|_| {
+        failure(
+            EngineErrorCode::ConfigurationInvalid,
+            StopReason::StartupFailed,
+            Error("engine provider composition is invalid".into()),
+        )
+    })?;
     // Accepted control actions belong to the whole connection attempt, not one
     // phase. A shutdown acknowledged just before Auth or Transport completes
     // must remain pending in the next phase until its cancellation window ends.
@@ -1069,7 +1120,7 @@ async fn run_engine<W: Write>(
         .await;
     }
     let Some(session) = authenticate_password_with_lifecycle(
-        &config,
+        &providers,
         gateway_username,
         gateway_password,
         &mut control_receiver,
@@ -1088,19 +1139,8 @@ async fn run_engine<W: Write>(
         ));
     }
 
-    let transport_backend = match ModernL3TransportBackend::new(&config) {
-        Ok(backend) => backend,
-        Err(error) => {
-            let failure = failure(
-                data_plane_setup_error_code(&error),
-                StopReason::StartupFailed,
-                error,
-            );
-            return Err(failure_after_gateway_cleanup(session, failure));
-        }
-    };
     let Some((session, transport)) = prepare_transport_with_lifecycle(
-        transport_backend,
+        &providers,
         session,
         &mut control_receiver,
         &mut pending_control_actions,
@@ -1696,7 +1736,7 @@ mod tests {
     fn synthetic_control_reader_preserves_eof_and_typed_actions() {
         let wire = b"{\"type\":\"hello\",\"requestId\":1,\"versions\":[2]}\n{\"type\":\"request\",\"apiVersion\":2,\"requestId\":2,\"command\":{\"name\":\"require_capability\",\"capability\":\"transport.web_vpn\"}}\n{\"type\":\"request\",\"apiVersion\":2,\"requestId\":3,\"command\":{\"name\":\"shutdown\"}}\n{\"type\":\"cancel\",\"apiVersion\":2,\"requestId\":4,\"requestToCancel\":3}\n{\"type\":\"close\",\"apiVersion\":2,\"requestId\":5}\n";
         let (sender, mut receiver) = tokio::sync::mpsc::channel(MAX_ACTIVE_REQUESTS);
-        control_reader_loop(wire.as_slice(), sender).unwrap();
+        control_reader_loop(wire.as_slice(), sender, None).unwrap();
 
         let hello = receiver.blocking_recv().unwrap();
         let ControlInput::V2(hello) = hello else {
@@ -1753,7 +1793,7 @@ mod tests {
     fn control_reader_multiplexes_v3_without_changing_v2_session_state() {
         let wire = b"{\"type\":\"auth_request\",\"apiVersion\":3,\"requestId\":7,\"generation\":9,\"transactionId\":\"04040404040404040404040404040404\",\"challengeEpoch\":1,\"command\":{\"name\":\"respond\",\"response\":\"private-fixture\"}}\n{\"type\":\"hello\",\"requestId\":8,\"versions\":[2]}\n{\"type\":\"close\",\"apiVersion\":2,\"requestId\":9}\n";
         let (sender, mut receiver) = tokio::sync::mpsc::channel(MAX_ACTIVE_REQUESTS);
-        control_reader_loop(wire.as_slice(), sender).unwrap();
+        control_reader_loop(wire.as_slice(), sender, None).unwrap();
 
         let ControlInput::V3(request) = receiver.blocking_recv().unwrap() else {
             panic!("expected v3 auth request");

--- a/independent/src/bin/ec-engine.rs
+++ b/independent/src/bin/ec-engine.rs
@@ -1049,13 +1049,6 @@ async fn run_engine<W: Write>(
         lifecycle.begin_stopping().map_err(event_output_failure)?;
         return Ok(StopReason::UserRequested);
     }
-    let providers = ProductionProviderSet::from_config(provider_family, &config).map_err(|_| {
-        failure(
-            EngineErrorCode::ConfigurationInvalid,
-            StopReason::StartupFailed,
-            Error("engine provider composition is invalid".into()),
-        )
-    })?;
     // Accepted control actions belong to the whole connection attempt, not one
     // phase. A shutdown acknowledged just before Auth or Transport completes
     // must remain pending in the next phase until its cancellation window ends.
@@ -1119,6 +1112,13 @@ async fn run_engine<W: Write>(
         )
         .await;
     }
+    let providers = ProductionProviderSet::from_config(provider_family, &config).map_err(|_| {
+        failure(
+            EngineErrorCode::ConfigurationInvalid,
+            StopReason::StartupFailed,
+            Error("engine provider composition is invalid".into()),
+        )
+    })?;
     let Some(session) = authenticate_password_with_lifecycle(
         &providers,
         gateway_username,

--- a/independent/src/engine/config_binding.rs
+++ b/independent/src/engine/config_binding.rs
@@ -1,3 +1,4 @@
+use crate::engine::provider_composition::ProductionProviderFamily;
 use crate::{Error, ErrorKind, Result};
 use serde::Deserialize;
 use serde_json::Value;
@@ -21,6 +22,7 @@ struct ConfigBindingFrame {
     gateway_origin: String,
     profile_id: String,
     profile_revision: u64,
+    protocol_family: String,
 }
 
 pub struct ExpectedConfigBinding {
@@ -28,6 +30,7 @@ pub struct ExpectedConfigBinding {
     gateway_origin: String,
     profile_id: String,
     profile_revision: u64,
+    protocol_family: ProductionProviderFamily,
 }
 
 impl ExpectedConfigBinding {
@@ -36,6 +39,7 @@ impl ExpectedConfigBinding {
         gateway_origin: &str,
         profile_id: &str,
         profile_revision: u64,
+        protocol_family: &str,
     ) -> Result<Self> {
         let digest = hex::decode(sha256)
             .ok()
@@ -53,11 +57,14 @@ impl ExpectedConfigBinding {
         {
             return Err(config_binding_error());
         }
+        let protocol_family =
+            ProductionProviderFamily::parse(protocol_family).map_err(|_| config_binding_error())?;
         Ok(Self {
             sha256: digest,
             gateway_origin,
             profile_id: profile_id.to_owned(),
             profile_revision,
+            protocol_family,
         })
     }
 
@@ -67,6 +74,10 @@ impl ExpectedConfigBinding {
 
     pub const fn profile_revision(&self) -> u64 {
         self.profile_revision
+    }
+
+    pub const fn protocol_family(&self) -> ProductionProviderFamily {
+        self.protocol_family
     }
 }
 
@@ -114,6 +125,7 @@ pub fn read_expected_config_binding<R: Read>(mut stream: R) -> Result<ExpectedCo
         &frame.gateway_origin,
         &frame.profile_id,
         frame.profile_revision,
+        &frame.protocol_family,
     )
 }
 
@@ -223,6 +235,7 @@ pub fn load_engine_config(path: &Path, binding: Option<&ExpectedConfigBinding>) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::provider_composition::EASYCONNECT_PASSWORD_MODERN_L3_V1;
     use std::io::Write;
 
     fn fixture() -> (std::path::PathBuf, Vec<u8>) {
@@ -247,13 +260,14 @@ mod tests {
             "https://vpn.example.edu",
             "school-a",
             7,
+            "easyconnect-password-modern-l3-v1",
         )
         .unwrap()
     }
 
     fn binding_frame(payload: &[u8]) -> Vec<u8> {
         format!(
-            "{{\"type\":\"engine_config_binding\",\"apiVersion\":1,\"configSha256\":\"{}\",\"gatewayOrigin\":\"https://vpn.example.edu\",\"profileId\":\"school-a\",\"profileRevision\":7}}\ncredential-line\n",
+            "{{\"type\":\"engine_config_binding\",\"apiVersion\":1,\"configSha256\":\"{}\",\"gatewayOrigin\":\"https://vpn.example.edu\",\"profileId\":\"school-a\",\"profileRevision\":7,\"protocolFamily\":\"easyconnect-password-modern-l3-v1\"}}\ncredential-line\n",
             hex::encode(Sha256::digest(payload)),
         )
         .into_bytes()
@@ -267,6 +281,10 @@ mod tests {
         assert_eq!(value["base_url"], "https://vpn.example.edu");
         assert_eq!(expected.profile_id(), "school-a");
         assert_eq!(expected.profile_revision(), 7);
+        assert_eq!(
+            expected.protocol_family().name(),
+            EASYCONNECT_PASSWORD_MODERN_L3_V1
+        );
         std::fs::remove_file(path).unwrap();
     }
 
@@ -295,22 +313,44 @@ mod tests {
     fn digest_origin_profile_and_shape_mismatches_fail_closed_without_echoing_values() {
         let (path, payload) = fixture();
         for result in [
-            ExpectedConfigBinding::new(&"00".repeat(32), "https://vpn.example.edu", "school-a", 7)
-                .and_then(|binding| load_engine_config(&path, Some(&binding))),
+            ExpectedConfigBinding::new(
+                &"00".repeat(32),
+                "https://vpn.example.edu",
+                "school-a",
+                7,
+                EASYCONNECT_PASSWORD_MODERN_L3_V1,
+            )
+            .and_then(|binding| load_engine_config(&path, Some(&binding))),
             ExpectedConfigBinding::new(
                 &hex::encode(Sha256::digest(&payload)),
                 "https://other.example.edu",
                 "school-a",
                 7,
+                EASYCONNECT_PASSWORD_MODERN_L3_V1,
             )
             .and_then(|binding| load_engine_config(&path, Some(&binding))),
-            ExpectedConfigBinding::new("private-digest", "https://vpn.example.edu", "school-a", 7)
-                .and_then(|binding| load_engine_config(&path, Some(&binding))),
+            ExpectedConfigBinding::new(
+                &hex::encode(Sha256::digest(&payload)),
+                "https://vpn.example.edu",
+                "school-a",
+                7,
+                "dynamic-provider-name",
+            )
+            .and_then(|binding| load_engine_config(&path, Some(&binding))),
+            ExpectedConfigBinding::new(
+                "private-digest",
+                "https://vpn.example.edu",
+                "school-a",
+                7,
+                EASYCONNECT_PASSWORD_MODERN_L3_V1,
+            )
+            .and_then(|binding| load_engine_config(&path, Some(&binding))),
             ExpectedConfigBinding::new(
                 &hex::encode(Sha256::digest(&payload)),
                 "https://vpn.example.edu",
                 "../school-a",
                 7,
+                EASYCONNECT_PASSWORD_MODERN_L3_V1,
             )
             .and_then(|binding| load_engine_config(&path, Some(&binding))),
         ] {

--- a/independent/src/engine/control.rs
+++ b/independent/src/engine/control.rs
@@ -11,6 +11,7 @@
 //! messages contain no free-form payload fields, so credentials, gateway
 //! tokens, URLs, and network destinations cannot be represented on this wire.
 
+use crate::engine::provider::{CapabilityAvailability, ProviderCapabilityReport};
 use crate::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, VecDeque};
@@ -30,6 +31,8 @@ pub enum ControlCapability {
     RequestCancel,
     #[serde(rename = "control.close")]
     ControlClose,
+    #[serde(rename = "provider.capabilities")]
+    ProviderCapabilities,
     #[serde(rename = "auth.captcha")]
     AuthCaptcha,
     #[serde(rename = "auth.sms")]
@@ -54,16 +57,18 @@ pub enum ControlCapability {
     TransportWebVpn,
 }
 
-const CONTROL_CAPABILITIES: [ControlCapability; 3] = [
+const CONTROL_CAPABILITIES: [ControlCapability; 4] = [
     ControlCapability::EngineShutdown,
     ControlCapability::RequestCancel,
     ControlCapability::ControlClose,
+    ControlCapability::ProviderCapabilities,
 ];
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(tag = "name", rename_all = "snake_case", deny_unknown_fields)]
 pub enum ControlCommand {
     Shutdown,
+    ProviderCapabilities,
     RequireCapability { capability: ControlCapability },
 }
 
@@ -139,6 +144,7 @@ pub enum ControlProtocolError {
     TooManyActiveRequests,
     RequestNotFound,
     ConnectionClosed,
+    CapabilityContextUnavailable,
     UnsupportedCapability {
         capability: ControlCapability,
     },
@@ -153,7 +159,7 @@ pub enum ControlResponse {
         api_version: u8,
         #[serde(rename = "requestId")]
         request_id: u64,
-        capabilities: [ControlCapability; 3],
+        capabilities: [ControlCapability; 4],
     },
     #[serde(rename = "control_result")]
     Result {
@@ -162,6 +168,21 @@ pub enum ControlResponse {
         #[serde(rename = "requestId")]
         request_id: u64,
         status: ControlStatus,
+    },
+    #[serde(rename = "provider_capabilities")]
+    ProviderCapabilities {
+        #[serde(rename = "apiVersion")]
+        api_version: u8,
+        #[serde(rename = "requestId")]
+        request_id: u64,
+        #[serde(rename = "profileId")]
+        profile_id: String,
+        #[serde(rename = "profileRevision")]
+        profile_revision: u64,
+        #[serde(rename = "engineGeneration")]
+        engine_generation: u64,
+        compiled: std::collections::BTreeMap<String, CapabilityAvailability>,
+        provider: std::collections::BTreeMap<String, CapabilityAvailability>,
     },
     #[serde(rename = "control_error")]
     Error {
@@ -216,11 +237,44 @@ pub struct ControlSession {
     active_requests: BTreeSet<u64>,
     recent_request_ids: BTreeSet<u64>,
     request_order: VecDeque<u64>,
+    provider_context: Option<ProviderCapabilityContext>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ProviderCapabilityContext {
+    profile_id: String,
+    profile_revision: u64,
+    engine_generation: u64,
+    report: ProviderCapabilityReport,
 }
 
 impl ControlSession {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn with_provider_capabilities(
+        profile_id: String,
+        profile_revision: u64,
+        engine_generation: u64,
+        report: ProviderCapabilityReport,
+    ) -> Result<Self> {
+        if profile_id.is_empty()
+            || profile_id.len() > 64
+            || profile_revision == 0
+            || engine_generation == 0
+        {
+            return Err(Error("provider capability context is invalid".into()));
+        }
+        Ok(Self {
+            provider_context: Some(ProviderCapabilityContext {
+                profile_id,
+                profile_revision,
+                engine_generation,
+                report,
+            }),
+            ..Self::default()
+        })
     }
 
     pub fn handle(&mut self, request: ControlRequest) -> ControlExchange {
@@ -314,6 +368,23 @@ impl ControlSession {
                     self.result(request_id, ControlStatus::Accepted),
                     ControlAction::Shutdown { request_id },
                 )
+            }
+            ControlCommand::ProviderCapabilities => {
+                let Some(context) = &self.provider_context else {
+                    return self.error(
+                        request_id,
+                        ControlProtocolError::CapabilityContextUnavailable,
+                    );
+                };
+                ControlExchange::response(ControlResponse::ProviderCapabilities {
+                    api_version: ENGINE_CONTROL_API_VERSION,
+                    request_id,
+                    profile_id: context.profile_id.clone(),
+                    profile_revision: context.profile_revision,
+                    engine_generation: context.engine_generation,
+                    compiled: context.report.compiled().clone(),
+                    provider: context.report.provider().clone(),
+                })
             }
             ControlCommand::RequireCapability { capability } => {
                 if CONTROL_CAPABILITIES.contains(&capability) {
@@ -469,6 +540,7 @@ pub fn encode_control_response(response: &ControlResponse) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::provider::CapabilityModel;
     use serde_json::{Value, json};
     use std::io::Cursor;
 
@@ -489,12 +561,62 @@ mod tests {
                 "type": "control_hello",
                 "apiVersion": 2,
                 "requestId": 7,
-                "capabilities": ["engine.shutdown", "request.cancel", "control.close"],
+                "capabilities": [
+                    "engine.shutdown",
+                    "request.cancel",
+                    "control.close",
+                    "provider.capabilities"
+                ],
             })
         );
         assert!(
             encode_control_response(&exchange.response).unwrap().len() <= MAX_CONTROL_FRAME_BYTES
         );
+    }
+
+    #[test]
+    fn provider_capabilities_are_additive_profile_and_generation_bound() {
+        let report = ProviderCapabilityReport::new(
+            CapabilityModel::production_password_l3(),
+            CapabilityModel::production_password_l3(),
+        )
+        .unwrap();
+        let mut session =
+            ControlSession::with_provider_capabilities("hkustgz".into(), 1, 9, report).unwrap();
+        session.handle(hello(1));
+        let exchange = session.handle(ControlRequest::Request {
+            api_version: 2,
+            request_id: 2,
+            command: ControlCommand::ProviderCapabilities,
+        });
+        assert_eq!(exchange.action, None);
+        assert!(
+            encode_control_response(&exchange.response).unwrap().len() <= MAX_CONTROL_FRAME_BYTES
+        );
+        let value = serde_json::to_value(exchange.response).unwrap();
+        assert_eq!(value["type"], "provider_capabilities");
+        assert_eq!(value["profileId"], "hkustgz");
+        assert_eq!(value["profileRevision"], 1);
+        assert_eq!(value["engineGeneration"], 9);
+        assert_eq!(value["compiled"]["auth.password"], "supported");
+        assert_eq!(value["provider"]["transport.l3"], "supported");
+        assert_eq!(value["provider"]["auth.sms"], "unsupported");
+
+        let mut unbound = ControlSession::new();
+        unbound.handle(hello(10));
+        assert!(matches!(
+            unbound
+                .handle(ControlRequest::Request {
+                    api_version: 2,
+                    request_id: 11,
+                    command: ControlCommand::ProviderCapabilities,
+                })
+                .response,
+            ControlResponse::Error {
+                error: ControlProtocolError::CapabilityContextUnavailable,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/independent/src/engine/mod.rs
+++ b/independent/src/engine/mod.rs
@@ -17,6 +17,7 @@ pub mod event;
 pub mod ip_packet;
 pub mod netstack;
 pub mod provider;
+pub mod provider_composition;
 pub mod proxy;
 pub mod session;
 pub mod socks;

--- a/independent/src/engine/provider.rs
+++ b/independent/src/engine/provider.rs
@@ -8,12 +8,15 @@
 use crate::resource_catalogue::{ResourceCatalogue, parse_resource_catalogue};
 use crate::xml::MAX_XML_BYTES;
 use crate::{Error, ErrorKind, Result};
+use serde::Serialize;
+use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 use zeroize::Zeroizing;
 
 pub use crate::engine::auth_transaction::AuthProgress;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CapabilityAvailability {
     /// The provider has an implemented path for this capability.
     Supported,
@@ -208,6 +211,118 @@ impl CapabilityModel {
     }
 }
 
+/// Stable, secret-free capability layers reported by a composed provider set.
+///
+/// The compiled layer is the binary's upper bound. The selected provider may
+/// only keep or reduce availability; a configuration/profile can never make a
+/// missing implementation appear supported.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ProviderCapabilityReport {
+    compiled: BTreeMap<String, CapabilityAvailability>,
+    provider: BTreeMap<String, CapabilityAvailability>,
+}
+
+impl ProviderCapabilityReport {
+    pub fn new(compiled: CapabilityModel, provider: CapabilityModel) -> Result<Self> {
+        for capability in Capability::ALL {
+            if availability_rank(provider.availability(capability))
+                > availability_rank(compiled.availability(capability))
+            {
+                return Err(Error::classified(
+                    ErrorKind::Configuration,
+                    "selected provider exceeds the compiled capability boundary",
+                ));
+            }
+        }
+        Ok(Self {
+            compiled: capability_states(compiled),
+            provider: capability_states(provider),
+        })
+    }
+
+    pub fn compiled(&self) -> &BTreeMap<String, CapabilityAvailability> {
+        &self.compiled
+    }
+
+    pub fn provider(&self) -> &BTreeMap<String, CapabilityAvailability> {
+        &self.provider
+    }
+}
+
+fn capability_states(model: CapabilityModel) -> BTreeMap<String, CapabilityAvailability> {
+    Capability::ALL
+        .into_iter()
+        .map(|capability| (capability.name().to_owned(), model.availability(capability)))
+        .collect()
+}
+
+const fn availability_rank(availability: CapabilityAvailability) -> u8 {
+    match availability {
+        CapabilityAvailability::Unsupported => 0,
+        CapabilityAvailability::Unavailable => 1,
+        CapabilityAvailability::Supported => 2,
+    }
+}
+
+/// Compile-time provider composition used by both production and synthetic
+/// tests. It owns no protocol routing or plugin discovery; it only proves that
+/// auth/resource/transport adapters form one capability-bounded set.
+pub struct ProviderCoordinator<A, R, T> {
+    authentication: A,
+    resources: R,
+    transport: T,
+    model: CapabilityModel,
+    report: ProviderCapabilityReport,
+}
+
+impl<A, R, T> ProviderCoordinator<A, R, T>
+where
+    A: AuthProvider,
+    R: ResourceProvider,
+    T: TransportBackend<Session = A::Session>,
+{
+    pub fn new(
+        authentication: A,
+        resources: R,
+        transport: T,
+        compiled: CapabilityModel,
+    ) -> Result<Self> {
+        let model = CapabilityModel {
+            authentication: authentication.capabilities(),
+            resources: resources.capabilities(),
+            transport: transport.capabilities(),
+        };
+        let report = ProviderCapabilityReport::new(compiled, model)?;
+        Ok(Self {
+            authentication,
+            resources,
+            transport,
+            model,
+            report,
+        })
+    }
+
+    pub const fn model(&self) -> CapabilityModel {
+        self.model
+    }
+
+    pub fn report(&self) -> &ProviderCapabilityReport {
+        &self.report
+    }
+
+    pub fn authentication(&self) -> &A {
+        &self.authentication
+    }
+
+    pub fn resources(&self) -> &R {
+        &self.resources
+    }
+
+    pub fn transport(&self) -> &T {
+        &self.transport
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AuthMethod {
     Password,
@@ -389,6 +504,7 @@ pub trait TransportBackend: Send + Sync {
 /// The parser exists, but the production engine has no reviewed authenticated
 /// resource-fetch/provider contract. Returning a catalogue would be a false
 /// claim of feature support.
+#[derive(Clone, Copy, Debug, Default)]
 pub struct UnsupportedResourceProvider;
 
 impl ResourceProvider for UnsupportedResourceProvider {
@@ -446,6 +562,7 @@ impl ResourceProvider for OfflineResourceDocumentProvider {
 
 /// Explicit placeholder for the observed WebVPN configuration family. It is a
 /// hard failure until sanitized fixtures and an approved implementation exist.
+#[derive(Clone, Copy, Debug, Default)]
 pub struct UnsupportedWebVpnBackend;
 
 impl TransportBackend for UnsupportedWebVpnBackend {
@@ -509,6 +626,33 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn selected_provider_can_only_tighten_the_compiled_capability_ceiling() {
+        let compiled = CapabilityModel::production_password_l3();
+        let mut authentication = AuthenticationCapabilities::password_only();
+        authentication.sms = CapabilityAvailability::Supported;
+        let elevated = CapabilityModel {
+            authentication,
+            resources: ResourceCapabilities::unsupported(),
+            transport: TransportCapabilities::modern_l3_only(),
+        };
+        assert!(ProviderCapabilityReport::new(compiled, elevated).is_err());
+
+        let tightened = CapabilityModel {
+            authentication: AuthenticationCapabilities::password_only(),
+            resources: ResourceCapabilities::unsupported(),
+            transport: TransportCapabilities {
+                l3: CapabilityAvailability::Unavailable,
+                web_vpn: CapabilityAvailability::Unsupported,
+            },
+        };
+        let report = ProviderCapabilityReport::new(compiled, tightened).unwrap();
+        assert_eq!(
+            report.provider()[Capability::TransportL3.name()],
+            CapabilityAvailability::Unavailable
+        );
     }
 
     #[test]

--- a/independent/src/engine/provider_composition.rs
+++ b/independent/src/engine/provider_composition.rs
@@ -1,0 +1,150 @@
+//! Compile-time production provider selection.
+//!
+//! A school profile selects one closed protocol family. The family maps to a
+//! reviewed provider set; JSON cannot name arbitrary implementations and no
+//! dynamic plugin ABI exists. Adding another family requires a new compiled
+//! branch and its own evidence/tests.
+
+use crate::engine::provider::{
+    CapabilityModel, ProviderCapabilityReport, ProviderCoordinator, UnsupportedResourceProvider,
+};
+use crate::engine::session::{ModernL3TransportBackend, ProductionPasswordAuthProvider};
+use crate::{Error, ErrorKind, Result};
+use serde_json::Value;
+
+pub const EASYCONNECT_PASSWORD_MODERN_L3_V1: &str = "easyconnect-password-modern-l3-v1";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProductionProviderFamily {
+    EasyConnectPasswordModernL3V1,
+}
+
+impl ProductionProviderFamily {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value {
+            EASYCONNECT_PASSWORD_MODERN_L3_V1 => Ok(Self::EasyConnectPasswordModernL3V1),
+            _ => Err(Error::classified(
+                ErrorKind::Configuration,
+                "production provider family is unsupported",
+            )),
+        }
+    }
+
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::EasyConnectPasswordModernL3V1 => EASYCONNECT_PASSWORD_MODERN_L3_V1,
+        }
+    }
+
+    pub const fn compiled_capabilities(self) -> CapabilityModel {
+        match self {
+            Self::EasyConnectPasswordModernL3V1 => CapabilityModel::production_password_l3(),
+        }
+    }
+
+    pub const fn selected_capabilities(self) -> CapabilityModel {
+        match self {
+            Self::EasyConnectPasswordModernL3V1 => CapabilityModel::production_password_l3(),
+        }
+    }
+
+    pub fn capability_report(self) -> Result<ProviderCapabilityReport> {
+        ProviderCapabilityReport::new(self.compiled_capabilities(), self.selected_capabilities())
+    }
+}
+
+type CurrentProductionCoordinator = ProviderCoordinator<
+    ProductionPasswordAuthProvider,
+    UnsupportedResourceProvider,
+    ModernL3TransportBackend,
+>;
+
+pub struct ProductionProviderSet {
+    family: ProductionProviderFamily,
+    coordinator: CurrentProductionCoordinator,
+}
+
+impl ProductionProviderSet {
+    pub fn from_config(family: ProductionProviderFamily, config: &Value) -> Result<Self> {
+        match family {
+            ProductionProviderFamily::EasyConnectPasswordModernL3V1 => {
+                let coordinator = ProviderCoordinator::new(
+                    ProductionPasswordAuthProvider::new(config),
+                    UnsupportedResourceProvider,
+                    ModernL3TransportBackend::new(config)?,
+                    family.compiled_capabilities(),
+                )?;
+                Ok(Self {
+                    family,
+                    coordinator,
+                })
+            }
+        }
+    }
+
+    pub const fn family(&self) -> ProductionProviderFamily {
+        self.family
+    }
+
+    pub const fn capabilities(&self) -> CapabilityModel {
+        self.coordinator.model()
+    }
+
+    pub fn capability_report(&self) -> &ProviderCapabilityReport {
+        self.coordinator.report()
+    }
+
+    pub fn authentication_provider(&self) -> ProductionPasswordAuthProvider {
+        self.coordinator.authentication().clone()
+    }
+
+    pub fn transport_backend(&self) -> ModernL3TransportBackend {
+        self.coordinator.transport().clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::provider::{Capability, CapabilityAvailability};
+    use serde_json::json;
+
+    fn config() -> Value {
+        json!({
+            "base_url": "https://gateway.example.test",
+            "endpoints": { "session_config": "/por/conf.csp" }
+        })
+    }
+
+    #[test]
+    fn current_family_builds_one_password_modern_l3_provider_set() {
+        let family = ProductionProviderFamily::parse(EASYCONNECT_PASSWORD_MODERN_L3_V1).unwrap();
+        let providers = ProductionProviderSet::from_config(family, &config()).unwrap();
+        assert_eq!(providers.family().name(), EASYCONNECT_PASSWORD_MODERN_L3_V1);
+        assert_eq!(
+            providers
+                .capabilities()
+                .availability(Capability::AuthPassword),
+            CapabilityAvailability::Supported
+        );
+        assert_eq!(
+            providers
+                .capabilities()
+                .availability(Capability::TransportL3),
+            CapabilityAvailability::Supported
+        );
+        assert_eq!(
+            providers
+                .capabilities()
+                .availability(Capability::ResourceCatalogue),
+            CapabilityAvailability::Unsupported
+        );
+    }
+
+    #[test]
+    fn unknown_family_and_invalid_transport_config_fail_before_network_work() {
+        assert!(ProductionProviderFamily::parse("dynamic-provider-name").is_err());
+        let family = ProductionProviderFamily::EasyConnectPasswordModernL3V1;
+        assert!(ProductionProviderSet::from_config(family, &json!({})).is_err());
+    }
+}

--- a/independent/src/engine/session.rs
+++ b/independent/src/engine/session.rs
@@ -16,6 +16,7 @@ use reqwest::Method;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::net::Ipv4Addr;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use url::Url;
 use zeroize::{Zeroize, Zeroizing};
@@ -68,6 +69,7 @@ impl ModernL3Connection {
     }
 }
 
+#[derive(Clone)]
 pub struct ModernL3TransportBackend {
     base_url: String,
     gateway_host: String,
@@ -77,17 +79,34 @@ pub struct ModernL3TransportBackend {
     configured_certificate_pin: Option<[u8; 32]>,
 }
 
-pub struct ProductionPasswordAuthProvider<'a> {
-    config: &'a Value,
+#[derive(Clone)]
+pub struct ProductionPasswordAuthProvider {
+    config: Arc<Value>,
 }
 
-impl<'a> ProductionPasswordAuthProvider<'a> {
-    pub const fn new(config: &'a Value) -> Self {
-        Self { config }
+impl ProductionPasswordAuthProvider {
+    pub fn new(config: &Value) -> Self {
+        Self {
+            config: Arc::new(config.clone()),
+        }
+    }
+
+    pub fn authenticate_password_cancellable(
+        &self,
+        username: &str,
+        password: &str,
+        cancellation: &AuthenticationCancellation,
+    ) -> ProviderResult<AuthenticatedGatewaySession> {
+        AuthenticatedGatewaySession::authenticate_password_with_cancellation(
+            &self.config,
+            username,
+            password,
+            Some(cancellation),
+        )
     }
 }
 
-impl AuthProvider for ProductionPasswordAuthProvider<'_> {
+impl AuthProvider for ProductionPasswordAuthProvider {
     type Session = AuthenticatedGatewaySession;
     type Challenge = NoAuthChallenge;
 
@@ -101,7 +120,7 @@ impl AuthProvider for ProductionPasswordAuthProvider<'_> {
     ) -> ProviderResult<AuthOutcome<Self::Session, Self::Challenge>> {
         match request {
             AuthRequest::Password { username, password } => {
-                AuthenticatedGatewaySession::authenticate_password(self.config, username, password)
+                AuthenticatedGatewaySession::authenticate_password(&self.config, username, password)
                     .map(AuthOutcome::Authenticated)
                     .map_err(|error| error.with_failure_kind(ErrorKind::Authentication))
             }

--- a/independent/tests/engine_api.rs
+++ b/independent/tests/engine_api.rs
@@ -212,7 +212,7 @@ fn engine_rechecks_config_digest_and_origin_before_reading_credentials() {
     ] {
         let private_credential = "must-not-appear-in-config-binding-errors";
         let binding = format!(
-            "{{\"type\":\"engine_config_binding\",\"apiVersion\":1,\"configSha256\":\"{expected_digest}\",\"gatewayOrigin\":\"{expected_origin}\",\"profileId\":\"hkustgz\",\"profileRevision\":1}}\n",
+            "{{\"type\":\"engine_config_binding\",\"apiVersion\":1,\"configSha256\":\"{expected_digest}\",\"gatewayOrigin\":\"{expected_origin}\",\"profileId\":\"hkustgz\",\"profileRevision\":1,\"protocolFamily\":\"easyconnect-password-modern-l3-v1\"}}\n",
         );
         let mut child = engine()
             .args([
@@ -251,7 +251,7 @@ fn matching_config_binding_reaches_the_credential_boundary() {
         .join("hkustgz.json");
     let digest = hex::encode(Sha256::digest(std::fs::read(&config).unwrap()));
     let binding = format!(
-        "{{\"type\":\"engine_config_binding\",\"apiVersion\":1,\"configSha256\":\"{digest}\",\"gatewayOrigin\":\"https://remote.hkust-gz.edu.cn\",\"profileId\":\"hkustgz\",\"profileRevision\":1}}\n",
+        "{{\"type\":\"engine_config_binding\",\"apiVersion\":1,\"configSha256\":\"{digest}\",\"gatewayOrigin\":\"https://remote.hkust-gz.edu.cn\",\"profileId\":\"hkustgz\",\"profileRevision\":1,\"protocolFamily\":\"easyconnect-password-modern-l3-v1\"}}\n",
     );
     let output = engine()
         .args([

--- a/independent/tests/module_boundaries.rs
+++ b/independent/tests/module_boundaries.rs
@@ -33,6 +33,28 @@ fn production_engine_never_imports_probe_workflows() {
 }
 
 #[test]
+fn production_engine_composes_one_closed_provider_set_instead_of_concrete_adapters() {
+    let engine = source("src/bin/ec-engine.rs");
+    assert!(engine.contains("ProductionProviderSet::from_config"));
+    assert!(engine.contains("providers.authentication_provider()"));
+    assert!(engine.contains("providers.transport_backend()"));
+    assert!(!engine.contains("ModernL3TransportBackend::new"));
+    assert!(
+        !engine
+            .contains("AuthenticatedGatewaySession::authenticate_with_provider_error_cancellable")
+    );
+
+    let composition = source("src/engine/provider_composition.rs").to_ascii_lowercase();
+    assert!(composition.contains("easyconnect-password-modern-l3-v1"));
+    for forbidden in ["libloading", "dlopen", "library::new", "loadlibrary"] {
+        assert!(
+            !composition.contains(forbidden),
+            "composition contains {forbidden}"
+        );
+    }
+}
+
+#[test]
 fn gateway_http_is_neutral_to_probe_transport_and_local_frontends() {
     let gateway = source("src/gateway_http.rs");
     for forbidden in [

--- a/independent/tests/provider_contracts.rs
+++ b/independent/tests/provider_contracts.rs
@@ -1,16 +1,19 @@
 use ec_compat::ErrorKind;
 use ec_compat::engine::provider::{
     AuthMethod, AuthOutcome, AuthProvider, AuthRequest, AuthenticationCapabilities, Capability,
-    CapabilityAvailability, CapabilityModel, OfflineResourceDocumentProvider, ProviderError,
-    ProviderResult, ResourceCapabilities, ResourceProvider, TransportBackend,
+    CapabilityAvailability, CapabilityModel, OfflineResourceDocumentProvider, ProviderCoordinator,
+    ProviderError, ProviderResult, ResourceCapabilities, ResourceProvider, TransportBackend,
     TransportCapabilities, UnsupportedResourceProvider, UnsupportedWebVpnBackend,
     require_supported,
+};
+use ec_compat::engine::provider_composition::{
+    EASYCONNECT_PASSWORD_MODERN_L3_V1, ProductionProviderFamily, ProductionProviderSet,
 };
 use ec_compat::engine::session::{ModernL3TransportBackend, ProductionPasswordAuthProvider};
 use serde_json::json;
 
 #[derive(Eq, PartialEq)]
-struct MockSession;
+struct MockSession(bool);
 
 struct MockAuthProvider;
 
@@ -41,7 +44,7 @@ impl AuthProvider for MockAuthProvider {
             AuthRequest::ChallengeResponse {
                 method: AuthMethod::Sms,
                 ..
-            } => Ok(AuthOutcome::Authenticated(MockSession)),
+            } => Ok(AuthOutcome::Authenticated(MockSession(true))),
             _ => Err(ProviderError::unavailable(capability)),
         }
     }
@@ -67,7 +70,7 @@ impl ResourceProvider for MockResourceProvider {
 struct MockTransportBackend;
 
 impl TransportBackend for MockTransportBackend {
-    type Session = bool;
+    type Session = MockSession;
     type DataPlane = &'static str;
 
     fn capabilities(&self) -> TransportCapabilities {
@@ -78,7 +81,7 @@ impl TransportBackend for MockTransportBackend {
     }
 
     fn connect(&self, session: &Self::Session) -> ProviderResult<Self::DataPlane> {
-        if *session {
+        if session.0 {
             Ok("mock-l3")
         } else {
             Err(ProviderError::unavailable(Capability::TransportL3))
@@ -108,29 +111,45 @@ fn connect_transport<B: TransportBackend>(
 
 #[test]
 fn generic_consumers_can_swap_mock_providers_without_vendor_protocol_types() {
-    let challenge = match authenticate_password(&MockAuthProvider).unwrap() {
+    let compiled = CapabilityModel {
+        authentication: MockAuthProvider.capabilities(),
+        resources: MockResourceProvider.capabilities(),
+        transport: MockTransportBackend.capabilities(),
+    };
+    let coordinator = ProviderCoordinator::new(
+        MockAuthProvider,
+        MockResourceProvider,
+        MockTransportBackend,
+        compiled,
+    )
+    .unwrap();
+    let challenge = match authenticate_password(coordinator.authentication()).unwrap() {
         AuthOutcome::ChallengeRequired(challenge) => challenge,
         AuthOutcome::Authenticated(_) => panic!("mock should exercise the challenge contract"),
     };
     assert!(challenge == MockChallenge::Sms);
-    let session = MockAuthProvider
+    let session = coordinator
+        .authentication()
         .authenticate(AuthRequest::ChallengeResponse {
             method: AuthMethod::Sms,
             challenge_id: b"mock-challenge",
             response: b"mock-response",
         })
         .unwrap();
-    assert!(matches!(session, AuthOutcome::Authenticated(MockSession)));
+    assert!(matches!(
+        session,
+        AuthOutcome::Authenticated(MockSession(true))
+    ));
     assert_eq!(
-        load_resources(&MockResourceProvider).unwrap(),
+        load_resources(coordinator.resources()).unwrap(),
         ["sanitized-resource"]
     );
     assert_eq!(
-        connect_transport(&MockTransportBackend, &true).unwrap(),
+        connect_transport(coordinator.transport(), &MockSession(true)).unwrap(),
         "mock-l3"
     );
     assert!(matches!(
-        connect_transport(&MockTransportBackend, &false),
+        connect_transport(coordinator.transport(), &MockSession(false)),
         Err(ProviderError::Unavailable(Capability::TransportL3))
     ));
 }
@@ -160,6 +179,16 @@ fn current_production_adapters_advertise_only_password_and_l3() {
         CapabilityModel::production_password_l3()
             .availability(Capability::ResourceAuthorizationDecision),
         CapabilityAvailability::Unsupported
+    );
+    let family = ProductionProviderFamily::parse(EASYCONNECT_PASSWORD_MODERN_L3_V1).unwrap();
+    let providers = ProductionProviderSet::from_config(family, &transport_config).unwrap();
+    assert_eq!(
+        providers.capabilities(),
+        CapabilityModel::production_password_l3()
+    );
+    assert_eq!(
+        providers.capability_report().compiled(),
+        providers.capability_report().provider()
     );
 }
 


### PR DESCRIPTION
## 目标

建立 2.0 的生产 Provider 组合边界与可验证 CapabilitySnapshot，同时保持当前 password-only + Modern L3 行为不变。

## 主要变化

- 以闭合的 ProductionProviderFamily 将 reviewed Profile 映射到唯一编译期 ProviderSet；未知 family 在网络认证前 fail closed。
- Production 和 synthetic 测试共用 ProviderCoordinator，并在编译期约束 Auth Session 与 Transport Session 类型一致。
- Control API v2 新增 secret-free provider capability query；Event API v1 保持不变。
- Desktop 将 Engine 报告绑定到 Profile revision、Engine generation、短生命周期 account handle，再与 Profile/ingress 层取交集。
- 断开或新连接时清除旧 generation snapshot；无效/过期报告不能覆盖当前状态。
- 新增 ADR-0006、模块边界测试、Rust/Node/真实 Electron 生命周期回归。

## 明确不做

- 不启用或猜测学校真实 MFA endpoint、字段、OTP 形状或渠道。
- 不新增动态插件 ABI、配置驱动代码加载或第三方 Provider。
- 不实现 SSH 客户端、HPC/Jupyter/Database 模块或 ForwardLease。
- 不创建持久 account/workspace key；该事务化迁移属于 P3。

## 本地验证

- Rust cargo fmt: PASS
- Rust cargo clippy --release --all-targets -D warnings: PASS
- Rust full release tests: PASS，0 failed，2 explicit performance gates ignored
- Desktop node tests: 609 passed，0 failed，1 Windows-only skip
- Architecture gate: PASS，213 files / 276 edges / 0 cycles
- Secret gate on staged Git snapshot: PASS
- All JavaScript syntax checks: PASS
- Real Electron synthetic Engine lifecycle: PASS

三平台构建与精确 CI 由 GitHub Actions 执行，避免在本机生成大型产物。