### PR TITLE
2.0 P3a: establish profile/account/workspace storage foundation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -125,6 +125,22 @@ Desktop 负责用户意图、Engine 进程、浏览器、设置、安全存储�
 稳定的 Engine event/error code，不持有 Gateway Cookie、TwfID、CSRF、Modern token、
 transport token 或原始认证响应。
 
+### 4.6 Profile / Account / Workspace storage
+
+持久用户状态按 `SchoolProfile -> CampusAccount -> WorkspaceScope` 归属。路径只能由安装本地生成的
+opaque `profileKey` / `accountKey` 派生；Profile ID、Gateway、用户名、标签和 Renderer handle
+不得成为路径组件。Browser partition 只能由 `workspaceKey` 的稳定摘要派生；现有
+`persist:hkustgz-campus-browser` 仅允许经 HKUST primary 的 P3 迁移 journal 显式收养。
+
+迁移必须先建立 owner-only、no-follow、single-link 的 journal，并保持单调
+`prepared -> committed -> cleared`。journal 只能保存身份/版本绑定和有界 SHA-256 收据，不保存
+用户名、密码、Cookie、token 或旧文件内容。`prepared` 不得覆盖或删除；commit 必须保持同一
+Profile/origin/family/key/source binding 并采用同目录临时文件、文件 fsync、原子 rename、目录
+fsync。Windows 文件还必须在提交前后通过 current-user-only DACL 保护与验证。
+
+P3 完整激活前，flat 1.x `userData` 仍是唯一生产权威；基础 layout/journal 模块不得由
+`desktop/main.js` 导入。详细合同见 [`ADR-0007`](docs/adr/0007-p3-storage-foundation.md)。
+
 ## 5. Connection state machine
 
 ### 5.1 唯一权威状态

--- a/desktop/lib/profile-workspace-layout.js
+++ b/desktop/lib/profile-workspace-layout.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const path = require('node:path');
+const { validateOpaqueKey } = require('./school-profile-schema');
+
+const LEGACY_HKUST_BROWSER_PARTITION = 'persist:hkustgz-campus-browser';
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const entry of Object.values(value)) deepFreeze(entry);
+  return value;
+}
+
+function normalizedUserData(value) {
+  if (typeof value !== 'string' || !path.isAbsolute(value)) {
+    throw new TypeError('userData must be an absolute normalized path');
+  }
+  const normalized = path.resolve(value);
+  if (normalized !== value || normalized === path.parse(normalized).root) {
+    throw new TypeError('userData must be an absolute normalized path');
+  }
+  return normalized;
+}
+
+function browserPartition(workspaceKey) {
+  const digest = crypto.createHash('sha256')
+    .update('campus-connect-workspace-partition-v1\0', 'utf8')
+    .update(workspaceKey, 'utf8')
+    .digest('hex')
+    .slice(0, 32);
+  return `persist:campus-workspace-${digest}`;
+}
+
+function createProfileAccountWorkspaceLayout({
+  userData,
+  profileKey,
+  accountKey,
+  workspaceKey,
+  adoptLegacyHkustBrowserPartition = false,
+} = {}) {
+  const root = normalizedUserData(userData);
+  const keys = {
+    profileKey: validateOpaqueKey(profileKey, 'profileKey'),
+    accountKey: validateOpaqueKey(accountKey, 'accountKey'),
+    workspaceKey: validateOpaqueKey(workspaceKey, 'workspaceKey'),
+  };
+  if (new Set(Object.values(keys)).size !== 3) {
+    throw new TypeError('profile, account and workspace keys must be distinct');
+  }
+  if (typeof adoptLegacyHkustBrowserPartition !== 'boolean') {
+    throw new TypeError('legacy Browser partition adoption must be explicit');
+  }
+
+  const globalRoot = path.join(root, 'global');
+  const profileRoot = path.join(root, 'profiles', keys.profileKey);
+  const accountRoot = path.join(profileRoot, 'accounts', keys.accountKey);
+  const workspaceRoot = path.join(accountRoot, 'workspace');
+  return deepFreeze({
+    root,
+    identity: keys,
+    global: {
+      root: globalRoot,
+      settings: path.join(globalRoot, 'settings.json'),
+      proxyCredential: path.join(globalRoot, 'proxy-credential.bin'),
+      proxyHelperCredential: path.join(globalRoot, 'proxy-helper-credential.txt'),
+      engineOwner: path.join(globalRoot, 'engine-owner.json'),
+      updateState: path.join(globalRoot, 'update-state.json'),
+      activeContextSwitch: path.join(globalRoot, 'active-context-switch.json'),
+      migrationJournal: path.join(globalRoot, 'profile-account-workspace-migration.json'),
+    },
+    profile: {
+      root: profileRoot,
+      settings: path.join(profileRoot, 'profile-settings.json'),
+      state: path.join(profileRoot, 'profile-state.json'),
+    },
+    account: {
+      root: accountRoot,
+      document: path.join(accountRoot, 'account.json'),
+      vpnCredential: path.join(accountRoot, 'vpn-credential.bin'),
+      credentialTransaction: path.join(accountRoot, 'credential-transaction.json'),
+      deletionTombstone: path.join(accountRoot, 'deletion-tombstone.json'),
+    },
+    workspace: {
+      root: workspaceRoot,
+      state: path.join(workspaceRoot, 'workspace-state.json'),
+      siteCredentials: path.join(workspaceRoot, 'campus-credentials.json'),
+      certificateTrust: path.join(workspaceRoot, 'campus-certificate-trust.json'),
+      routingRules: path.join(workspaceRoot, 'routing-rules.json'),
+      externalPac: path.join(workspaceRoot, 'routing.pac'),
+      browserPac: path.join(workspaceRoot, 'browser-routing.pac'),
+      localResources: path.join(workspaceRoot, 'local-resources.json'),
+      favorites: path.join(workspaceRoot, 'favorites.json'),
+      recentResources: path.join(workspaceRoot, 'recent-resources.json'),
+      externalIntegrations: path.join(workspaceRoot, 'external-integrations.json'),
+      engineLog: path.join(workspaceRoot, 'engine.log'),
+    },
+    browserPartition: adoptLegacyHkustBrowserPartition
+      ? LEGACY_HKUST_BROWSER_PARTITION
+      : browserPartition(keys.workspaceKey),
+  });
+}
+
+module.exports = {
+  LEGACY_HKUST_BROWSER_PARTITION,
+  createProfileAccountWorkspaceLayout,
+};

--- a/desktop/lib/profile-workspace-migration-journal.js
+++ b/desktop/lib/profile-workspace-migration-journal.js
@@ -1,0 +1,291 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const {
+  normalizeGatewayOrigin,
+  validateOpaqueKey,
+  validateProfileId,
+  validateProtocolFamily,
+} = require('./school-profile-schema');
+const { LEGACY_HKUST_BROWSER_PARTITION } = require('./profile-workspace-layout');
+
+const MIGRATION_JOURNAL_VERSION = 1;
+const LEGACY_SOURCE_IDS = Object.freeze([
+  'settings',
+  'settingsBackup',
+  'vpnCredential',
+  'routingRules',
+  'externalPac',
+  'browserPac',
+  'siteCredentials',
+  'certificateTrust',
+  'engineLog',
+]);
+const DESTINATION_RECEIPT_IDS = Object.freeze([
+  'globalSettings',
+  'profileSettings',
+  'profileState',
+  'account',
+  'vpnCredential',
+  'workspaceState',
+  'siteCredentials',
+  'certificateTrust',
+  'routingRules',
+  'externalPac',
+  'browserPac',
+  'localResources',
+  'favorites',
+  'recentResources',
+  'externalIntegrations',
+  'engineLog',
+]);
+const JOURNAL_STATES = Object.freeze(['prepared', 'committed']);
+const HEX_DIGEST = /^[a-f0-9]{64}$/u;
+
+function plainObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+  return value;
+}
+
+function exactKeys(value, allowed, name) {
+  const object = plainObject(value, name);
+  const keys = Object.keys(object).sort();
+  const expected = [...allowed].sort();
+  if (keys.length !== expected.length || keys.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${name} has an invalid schema`);
+  }
+  return object;
+}
+
+function positiveInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const entry of Object.values(value)) deepFreeze(entry);
+  return value;
+}
+
+function normalizeReceipt(value, name) {
+  const source = exactKeys(value, ['present', 'bytes', 'sha256'], name);
+  if (typeof source.present !== 'boolean' || !Number.isSafeInteger(source.bytes) ||
+      source.bytes < 0 || source.bytes > 64 * 1024 * 1024) {
+    throw new TypeError(`${name} is invalid`);
+  }
+  if (!source.present) {
+    if (source.bytes !== 0 || source.sha256 !== null) throw new TypeError(`${name} is invalid`);
+  } else if (source.bytes < 1 || typeof source.sha256 !== 'string' ||
+      !HEX_DIGEST.test(source.sha256)) {
+    throw new TypeError(`${name} is invalid`);
+  }
+  return Object.freeze({
+    present: source.present,
+    bytes: source.bytes,
+    sha256: source.sha256,
+  });
+}
+
+function normalizeReceiptSet(value, ids, name) {
+  const source = exactKeys(value, ids, name);
+  return Object.freeze(Object.fromEntries(ids.map((id) => [
+    id,
+    normalizeReceipt(source[id], `${name} ${id}`),
+  ])));
+}
+
+function receiptSetDigest(receipts, ids) {
+  const canonical = ids.map((id) => [
+    id,
+    receipts[id].present,
+    receipts[id].bytes,
+    receipts[id].sha256,
+  ]);
+  return crypto.createHash('sha256').update(JSON.stringify(canonical), 'utf8').digest('hex');
+}
+
+function journalKey(prefix, randomBytes) {
+  const entropy = randomBytes(16);
+  if (!Buffer.isBuffer(entropy) || entropy.length !== 16) {
+    throw new TypeError('migration journal entropy is invalid');
+  }
+  try {
+    return `${prefix}-${entropy.toString('hex')}`;
+  } finally {
+    entropy.fill(0);
+  }
+}
+
+function normalizedIdentity(value) {
+  const source = exactKeys(value, ['profileKey', 'accountKey', 'workspaceKey'], 'migration identity');
+  const identity = {
+    profileKey: validateOpaqueKey(source.profileKey, 'profileKey'),
+    accountKey: validateOpaqueKey(source.accountKey, 'accountKey'),
+    workspaceKey: validateOpaqueKey(source.workspaceKey, 'workspaceKey'),
+  };
+  if (new Set(Object.values(identity)).size !== 3) {
+    throw new TypeError('migration identity keys must be distinct');
+  }
+  return Object.freeze(identity);
+}
+
+function validateMigrationJournal(value) {
+  const source = exactKeys(value, [
+    'schemaVersion', 'state', 'migrationId', 'profileId', 'profileRevision',
+    'profileCredentialBindingRevision', 'gatewayOrigin', 'protocolFamily', 'identity',
+    'accountRevision', 'accountCredentialRevision', 'activeContextEpoch',
+    'legacyBrowserPartition', 'sourceReceipts', 'sourceSetSha256',
+    'destinationReceipts', 'destinationSetSha256', 'createdAt', 'committedAt',
+  ], 'migration journal');
+  if (source.schemaVersion !== MIGRATION_JOURNAL_VERSION ||
+      !JOURNAL_STATES.includes(source.state)) {
+    throw new TypeError('migration journal version or state is unsupported');
+  }
+  const sourceReceipts = normalizeReceiptSet(
+    source.sourceReceipts,
+    LEGACY_SOURCE_IDS,
+    'source receipt set',
+  );
+  const expectedSourceDigest = receiptSetDigest(sourceReceipts, LEGACY_SOURCE_IDS);
+  if (source.sourceSetSha256 !== expectedSourceDigest) {
+    throw new TypeError('source receipt set digest does not match');
+  }
+  let destinationReceipts = null;
+  let destinationSetSha256 = null;
+  let committedAt = null;
+  if (source.state === 'prepared') {
+    if (source.destinationReceipts !== null || source.destinationSetSha256 !== null ||
+        source.committedAt !== null) {
+      throw new TypeError('prepared migration journal contains committed state');
+    }
+  } else {
+    destinationReceipts = normalizeReceiptSet(
+      source.destinationReceipts,
+      DESTINATION_RECEIPT_IDS,
+      'destination receipt set',
+    );
+    destinationSetSha256 = receiptSetDigest(destinationReceipts, DESTINATION_RECEIPT_IDS);
+    if (source.destinationSetSha256 !== destinationSetSha256) {
+      throw new TypeError('destination receipt set digest does not match');
+    }
+    committedAt = positiveInteger(source.committedAt, 'committedAt');
+  }
+  const createdAt = positiveInteger(source.createdAt, 'createdAt');
+  if (committedAt !== null && committedAt < createdAt) {
+    throw new TypeError('migration journal timestamps are inconsistent');
+  }
+  if (source.legacyBrowserPartition !== LEGACY_HKUST_BROWSER_PARTITION) {
+    throw new TypeError('migration journal Browser partition is invalid');
+  }
+  const profileId = validateProfileId(source.profileId);
+  if (profileId !== 'hkustgz') {
+    throw new TypeError('legacy Browser partition migration is limited to the HKUST profile');
+  }
+  return deepFreeze({
+    schemaVersion: MIGRATION_JOURNAL_VERSION,
+    state: source.state,
+    migrationId: validateOpaqueKey(source.migrationId, 'migrationId'),
+    profileId,
+    profileRevision: positiveInteger(source.profileRevision, 'profileRevision'),
+    profileCredentialBindingRevision: positiveInteger(
+      source.profileCredentialBindingRevision,
+      'profileCredentialBindingRevision',
+    ),
+    gatewayOrigin: normalizeGatewayOrigin(source.gatewayOrigin).origin,
+    protocolFamily: validateProtocolFamily(source.protocolFamily),
+    identity: normalizedIdentity(source.identity),
+    accountRevision: positiveInteger(source.accountRevision, 'accountRevision'),
+    accountCredentialRevision: positiveInteger(
+      source.accountCredentialRevision,
+      'accountCredentialRevision',
+    ),
+    activeContextEpoch: positiveInteger(source.activeContextEpoch, 'activeContextEpoch'),
+    legacyBrowserPartition: source.legacyBrowserPartition,
+    sourceReceipts,
+    sourceSetSha256: expectedSourceDigest,
+    destinationReceipts,
+    destinationSetSha256,
+    createdAt,
+    committedAt,
+  });
+}
+
+function createPreparedMigrationJournal({
+  profileId,
+  profileRevision,
+  profileCredentialBindingRevision,
+  gatewayOrigin,
+  protocolFamily,
+  sourceReceipts,
+  randomBytes = crypto.randomBytes,
+  now = Date.now,
+} = {}) {
+  if (typeof randomBytes !== 'function' || typeof now !== 'function') {
+    throw new TypeError('migration journal dependencies are invalid');
+  }
+  const document = {
+    schemaVersion: MIGRATION_JOURNAL_VERSION,
+    state: 'prepared',
+    migrationId: journalKey('migration', randomBytes),
+    profileId,
+    profileRevision,
+    profileCredentialBindingRevision,
+    gatewayOrigin,
+    protocolFamily,
+    identity: {
+      profileKey: journalKey('profile', randomBytes),
+      accountKey: journalKey('account', randomBytes),
+      workspaceKey: journalKey('workspace', randomBytes),
+    },
+    accountRevision: 1,
+    accountCredentialRevision: 1,
+    activeContextEpoch: 1,
+    legacyBrowserPartition: LEGACY_HKUST_BROWSER_PARTITION,
+    sourceReceipts,
+    sourceSetSha256: receiptSetDigest(
+      normalizeReceiptSet(sourceReceipts, LEGACY_SOURCE_IDS, 'source receipt set'),
+      LEGACY_SOURCE_IDS,
+    ),
+    destinationReceipts: null,
+    destinationSetSha256: null,
+    createdAt: now(),
+    committedAt: null,
+  };
+  return validateMigrationJournal(document);
+}
+
+function commitMigrationJournal(document, { destinationReceipts, now = Date.now } = {}) {
+  const prepared = validateMigrationJournal(document);
+  if (prepared.state !== 'prepared') {
+    throw new TypeError('only a prepared migration journal can commit');
+  }
+  if (typeof now !== 'function') throw new TypeError('migration journal clock is invalid');
+  const normalizedDestinations = normalizeReceiptSet(
+    destinationReceipts,
+    DESTINATION_RECEIPT_IDS,
+    'destination receipt set',
+  );
+  return validateMigrationJournal({
+    ...prepared,
+    state: 'committed',
+    destinationReceipts: normalizedDestinations,
+    destinationSetSha256: receiptSetDigest(normalizedDestinations, DESTINATION_RECEIPT_IDS),
+    committedAt: now(),
+  });
+}
+
+module.exports = {
+  DESTINATION_RECEIPT_IDS,
+  LEGACY_SOURCE_IDS,
+  MIGRATION_JOURNAL_VERSION,
+  commitMigrationJournal,
+  createPreparedMigrationJournal,
+  validateMigrationJournal,
+};

--- a/desktop/lib/profile-workspace-migration-store.js
+++ b/desktop/lib/profile-workspace-migration-store.js
@@ -1,0 +1,242 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { readPrivateFileBounded } = require('./private-file');
+const { validateMigrationJournal } = require('./profile-workspace-migration-journal');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+const MAX_MIGRATION_JOURNAL_BYTES = 256 * 1024;
+let temporarySequence = 0;
+
+function normalizedJournalPath(value) {
+  if (typeof value !== 'string' || !path.isAbsolute(value)) {
+    throw new TypeError('migration journal path must be an absolute normalized path');
+  }
+  const normalized = path.resolve(value);
+  const root = path.parse(normalized).root;
+  if (normalized !== value || normalized === root || path.dirname(normalized) === root) {
+    throw new TypeError('migration journal path must be an absolute normalized path');
+  }
+  return normalized;
+}
+
+function fsyncDirectory(directory, fileSystem, platform) {
+  let descriptor = null;
+  try {
+    descriptor = fileSystem.openSync(directory, 'r');
+    fileSystem.fsyncSync?.(descriptor);
+    return true;
+  } catch {
+    return platform === 'win32';
+  } finally {
+    if (descriptor !== null) {
+      try { fileSystem.closeSync(descriptor); } catch {}
+    }
+  }
+}
+
+function serializedJournal(document) {
+  const normalized = validateMigrationJournal(document);
+  const data = Buffer.from(JSON.stringify(normalized), 'utf8');
+  if (data.length < 2 || data.length > MAX_MIGRATION_JOURNAL_BYTES) {
+    throw new TypeError('migration journal exceeds its storage bound');
+  }
+  return { normalized, data };
+}
+
+function sameBinding(current, next) {
+  return current.migrationId === next.migrationId &&
+    current.profileId === next.profileId &&
+    current.profileRevision === next.profileRevision &&
+    current.profileCredentialBindingRevision === next.profileCredentialBindingRevision &&
+    current.gatewayOrigin === next.gatewayOrigin &&
+    current.protocolFamily === next.protocolFamily &&
+    current.sourceSetSha256 === next.sourceSetSha256 &&
+    JSON.stringify(current.identity) === JSON.stringify(next.identity);
+}
+
+class ProfileWorkspaceMigrationJournalStore {
+  constructor({
+    filePath,
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+  } = {}) {
+    if (!fileSystem || typeof fileSystem.openSync !== 'function' ||
+        !['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' &&
+          (typeof windowsAcl?.protect !== 'function' || typeof windowsAcl?.verify !== 'function'))) {
+      throw new TypeError('migration journal storage dependencies are invalid');
+    }
+    this.filePath = normalizedJournalPath(filePath);
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+  }
+
+  read() {
+    try {
+      this.fileSystem.lstatSync(this.filePath);
+    } catch (error) {
+      if (error?.code === 'ENOENT') return null;
+      throw error;
+    }
+    if (this.platform === 'win32' && !this.windowsAcl.verify(this.filePath)) {
+      throw new Error('invalid private file');
+    }
+    let data;
+    try {
+      ({ data } = readPrivateFileBounded(this.filePath, {
+        maxBytes: MAX_MIGRATION_JOURNAL_BYTES,
+        minBytes: 2,
+        platform: this.platform,
+        fileSystem: this.fileSystem,
+      }));
+    } catch (error) {
+      if (error?.code === 'ENOENT') {
+        throw new Error('migration journal disappeared after it was observed', { cause: error });
+      }
+      throw error;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(data.toString('utf8'));
+    } catch {
+      throw new Error('migration journal is invalid');
+    } finally {
+      data.fill(0);
+    }
+    return validateMigrationJournal(parsed);
+  }
+
+  prepare(document) {
+    const { normalized, data } = serializedJournal(document);
+    if (normalized.state !== 'prepared') {
+      data.fill(0);
+      throw new TypeError('migration journal must be prepared before storage');
+    }
+    const directory = path.dirname(this.filePath);
+    let descriptor = null;
+    let created = false;
+    try {
+      this.fileSystem.mkdirSync(directory, { recursive: true, mode: 0o700 });
+      descriptor = this.fileSystem.openSync(this.filePath, 'wx', 0o600);
+      created = true;
+      this.fileSystem.writeFileSync(descriptor, data);
+      this.fileSystem.fsyncSync?.(descriptor);
+      this.fileSystem.closeSync(descriptor);
+      descriptor = null;
+      if (this.platform === 'win32' &&
+          (!this.windowsAcl.protect(this.filePath) || !this.windowsAcl.verify(this.filePath))) {
+        throw new Error('migration journal Windows ACL is invalid');
+      }
+      return {
+        prepared: true,
+        durabilityUnconfirmed: !fsyncDirectory(directory, this.fileSystem, this.platform),
+      };
+    } catch (error) {
+      if (descriptor !== null) {
+        try { this.fileSystem.closeSync(descriptor); } catch {}
+      }
+      if (created) {
+        try { this.fileSystem.unlinkSync(this.filePath); } catch {}
+        fsyncDirectory(directory, this.fileSystem, this.platform);
+      }
+      if (error?.code === 'EEXIST') {
+        throw new Error('migration journal already exists');
+      }
+      throw new Error('migration journal prepare failed', { cause: error });
+    } finally {
+      data.fill(0);
+    }
+  }
+
+  commit(document) {
+    const current = this.read();
+    if (!current || current.state !== 'prepared') {
+      throw new Error('migration journal is not prepared');
+    }
+    const { normalized, data } = serializedJournal(document);
+    if (normalized.state !== 'committed') {
+      data.fill(0);
+      throw new TypeError('migration journal commit document is invalid');
+    }
+    if (!sameBinding(current, normalized)) {
+      data.fill(0);
+      throw new Error('migration journal binding does not match');
+    }
+
+    const directory = path.dirname(this.filePath);
+    const temporary = path.join(
+      directory,
+      `.${path.basename(this.filePath)}.${process.pid}.${Date.now()}.${temporarySequence++}.tmp`,
+    );
+    let descriptor = null;
+    let renamed = false;
+    try {
+      descriptor = this.fileSystem.openSync(temporary, 'wx', 0o600);
+      this.fileSystem.writeFileSync(descriptor, data);
+      this.fileSystem.fsyncSync?.(descriptor);
+      this.fileSystem.closeSync(descriptor);
+      descriptor = null;
+      if (this.platform === 'win32' &&
+          (!this.windowsAcl.protect(temporary) || !this.windowsAcl.verify(temporary))) {
+        throw new Error('migration journal temporary Windows ACL is invalid');
+      }
+      this.fileSystem.renameSync(temporary, this.filePath);
+      renamed = true;
+      if (this.platform === 'win32' && !this.windowsAcl.verify(this.filePath)) {
+        throw new Error('migration journal committed Windows ACL is invalid');
+      }
+      const durable = fsyncDirectory(directory, this.fileSystem, this.platform);
+      if (!durable) {
+        const observed = this.read();
+        if (!observed || observed.state !== 'committed' || !sameBinding(normalized, observed) ||
+            observed.destinationSetSha256 !== normalized.destinationSetSha256) {
+          throw new Error('migration journal commit state is unconfirmed');
+        }
+      }
+      return { committed: true, durabilityUnconfirmed: !durable };
+    } catch (error) {
+      if (descriptor !== null) {
+        try { this.fileSystem.closeSync(descriptor); } catch {}
+      }
+      if (!renamed) {
+        try { this.fileSystem.unlinkSync(temporary); } catch {}
+      }
+      throw new Error('migration journal commit failed', { cause: error });
+    } finally {
+      data.fill(0);
+    }
+  }
+
+  clearCommitted() {
+    const current = this.read();
+    if (current === null) return false;
+    if (current.state !== 'committed') {
+      throw new Error('prepared migration journal cannot be cleared');
+    }
+    const directory = path.dirname(this.filePath);
+    try {
+      this.fileSystem.unlinkSync(this.filePath);
+    } catch (error) {
+      throw new Error('migration journal clear failed', { cause: error });
+    }
+    if (!fsyncDirectory(directory, this.fileSystem, this.platform)) {
+      throw new Error('migration journal clear was not durable');
+    }
+    return true;
+  }
+}
+
+module.exports = {
+  MAX_MIGRATION_JOURNAL_BYTES,
+  ProfileWorkspaceMigrationJournalStore,
+};

--- a/desktop/lib/school-profile-schema.js
+++ b/desktop/lib/school-profile-schema.js
@@ -82,7 +82,7 @@ function boundedTimestamp(value, name) {
   return value;
 }
 
-function opaqueKey(value, name) {
+function opaqueKey(value, name = 'opaqueKey') {
   if (typeof value !== 'string' || !SAFE_OPAQUE_KEY.test(value)) {
     throw new TypeError(`${name} must be a bounded opaque key`);
   }
@@ -566,6 +566,8 @@ module.exports = {
   createSchoolProfileView,
   createWorkspaceView,
   normalizeGatewayOrigin,
+  validateOpaqueKey: opaqueKey,
+  validateProfileId,
   validateProtocolFamily,
   validateCampusAccountDocument,
   validateSchoolProfileDocument,

--- a/desktop/test/profile-workspace-migration-store.test.js
+++ b/desktop/test/profile-workspace-migration-store.test.js
@@ -1,0 +1,232 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  DESTINATION_RECEIPT_IDS,
+  LEGACY_SOURCE_IDS,
+  commitMigrationJournal,
+  createPreparedMigrationJournal,
+} = require('../lib/profile-workspace-migration-journal');
+const {
+  ProfileWorkspaceMigrationJournalStore,
+} = require('../lib/profile-workspace-migration-store');
+
+function fixture(t) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-workspace-migration-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return {
+    directory,
+    file: path.join(directory, 'global', 'profile-account-workspace-migration.json'),
+  };
+}
+
+function receipt(seed) {
+  return {
+    present: true,
+    bytes: seed,
+    sha256: seed.toString(16).padStart(64, '0'),
+  };
+}
+
+function prepared(seed = 1) {
+  let entropy = seed;
+  return createPreparedMigrationJournal({
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    profileCredentialBindingRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
+    sourceReceipts: Object.fromEntries(
+      LEGACY_SOURCE_IDS.map((id, index) => [id, receipt(index + 1)]),
+    ),
+    randomBytes: () => Buffer.alloc(16, entropy++),
+    now: () => 1_700_000_000_000,
+  });
+}
+
+function committed(document) {
+  return commitMigrationJournal(document, {
+    destinationReceipts: Object.fromEntries(
+      DESTINATION_RECEIPT_IDS.map((id, index) => [id, receipt(index + 101)]),
+    ),
+    now: () => 1_700_000_000_100,
+  });
+}
+
+test('owner-only journal store persists one prepared to committed transition', (t) => {
+  const { file } = fixture(t);
+  const store = new ProfileWorkspaceMigrationJournalStore({ filePath: file });
+  const first = prepared();
+
+  assert.equal(store.read(), null);
+  assert.deepEqual(store.prepare(first), { prepared: true, durabilityUnconfirmed: false });
+  assert.deepEqual(store.read(), first);
+  if (process.platform !== 'win32') assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+  assert.throws(() => store.prepare(prepared(20)), /already exists/u);
+
+  const next = committed(first);
+  assert.deepEqual(store.commit(next), { committed: true, durabilityUnconfirmed: false });
+  assert.deepEqual(store.read(), next);
+  assert.equal(store.clearCommitted(), true);
+  assert.equal(store.read(), null);
+  assert.equal(store.clearCommitted(), false);
+});
+
+test('prepared journal cannot be cleared or replaced by another migration identity', (t) => {
+  const { file } = fixture(t);
+  const store = new ProfileWorkspaceMigrationJournalStore({ filePath: file });
+  const first = prepared();
+  store.prepare(first);
+
+  assert.throws(() => store.clearCommitted(), /prepared/u);
+  assert.throws(() => store.commit(committed(prepared(30))), /binding/u);
+  assert.deepEqual(store.read(), first);
+});
+
+test('journal reads reject symbolic links, hard links and broad POSIX permissions', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const { directory, file } = fixture(t);
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const unrelated = path.join(directory, 'unrelated.json');
+  fs.writeFileSync(unrelated, JSON.stringify(prepared()), { mode: 0o600 });
+
+  fs.symlinkSync(unrelated, file);
+  assert.throws(() => new ProfileWorkspaceMigrationJournalStore({ filePath: file }).read(),
+    /private file/u);
+  fs.unlinkSync(file);
+
+  fs.linkSync(unrelated, file);
+  assert.throws(() => new ProfileWorkspaceMigrationJournalStore({ filePath: file }).read(),
+    /private file/u);
+  fs.unlinkSync(file);
+
+  fs.copyFileSync(unrelated, file);
+  fs.chmodSync(file, 0o644);
+  assert.throws(() => new ProfileWorkspaceMigrationJournalStore({ filePath: file }).read(),
+    /private file/u);
+});
+
+test('failure before atomic rename preserves the prepared journal', (t) => {
+  const { file } = fixture(t);
+  const first = prepared();
+  const base = new ProfileWorkspaceMigrationJournalStore({ filePath: file });
+  base.prepare(first);
+  const injected = Object.create(fs);
+  injected.renameSync = () => { throw new Error('simulated rename failure'); };
+  const store = new ProfileWorkspaceMigrationJournalStore({ filePath: file, fileSystem: injected });
+
+  assert.throws(() => store.commit(committed(first)), /commit/u);
+  assert.deepEqual(base.read(), first);
+});
+
+test('a journal disappearing after observed presence fails closed', (t) => {
+  const { file } = fixture(t);
+  const base = new ProfileWorkspaceMigrationJournalStore({ filePath: file });
+  base.prepare(prepared());
+  const injected = Object.create(fs);
+  let journalStats = 0;
+  injected.lstatSync = (value, ...args) => {
+    if (value === file && ++journalStats === 2) {
+      fs.unlinkSync(file);
+      const error = new Error('simulated disappearance');
+      error.code = 'ENOENT';
+      throw error;
+    }
+    return fs.lstatSync(value, ...args);
+  };
+  const store = new ProfileWorkspaceMigrationJournalStore({ filePath: file, fileSystem: injected });
+  assert.throws(() => store.read(), /disappeared after it was observed/u);
+});
+
+test('a committed journal disappearing during clear is not benign absence', (t) => {
+  const { file } = fixture(t);
+  const first = prepared();
+  const base = new ProfileWorkspaceMigrationJournalStore({ filePath: file });
+  base.prepare(first);
+  base.commit(committed(first));
+  const injected = Object.create(fs);
+  injected.unlinkSync = (value) => {
+    if (value === file) {
+      const error = new Error('simulated clear race');
+      error.code = 'ENOENT';
+      throw error;
+    }
+    return fs.unlinkSync(value);
+  };
+  const store = new ProfileWorkspaceMigrationJournalStore({ filePath: file, fileSystem: injected });
+  assert.throws(() => store.clearCommitted(), /clear failed/u);
+  assert.equal(fs.existsSync(file), true);
+});
+
+test('a readable committed document resolves a post-rename directory fsync failure', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const { file } = fixture(t);
+  const first = prepared();
+  const base = new ProfileWorkspaceMigrationJournalStore({ filePath: file });
+  base.prepare(first);
+  const injected = Object.create(fs);
+  let directoryFsyncs = 0;
+  injected.fsyncSync = (descriptor) => {
+    const stat = fs.fstatSync(descriptor);
+    if (stat.isDirectory() && ++directoryFsyncs === 1) {
+      throw new Error('simulated directory fsync failure');
+    }
+    return fs.fsyncSync(descriptor);
+  };
+  const store = new ProfileWorkspaceMigrationJournalStore({ filePath: file, fileSystem: injected });
+  const next = committed(first);
+
+  assert.deepEqual(store.commit(next), { committed: true, durabilityUnconfirmed: true });
+  assert.deepEqual(base.read(), next);
+});
+
+test('store path must be a normalized absolute non-root path', () => {
+  assert.throws(() => new ProfileWorkspaceMigrationJournalStore({ filePath: 'relative.json' }),
+    /absolute/u);
+  assert.throws(() => new ProfileWorkspaceMigrationJournalStore({ filePath: path.parse('/').root }),
+    /absolute/u);
+});
+
+test('simulated Windows storage protects and verifies every committed journal', (t) => {
+  const { file } = fixture(t);
+  const protectedPaths = [];
+  const verifiedPaths = [];
+  const windowsAcl = {
+    protect(value) { protectedPaths.push(value); return true; },
+    verify(value) {
+      verifiedPaths.push(value);
+      return fs.existsSync(value);
+    },
+  };
+  const store = new ProfileWorkspaceMigrationJournalStore({
+    filePath: file,
+    platform: 'win32',
+    windowsAcl,
+  });
+  const first = prepared();
+  assert.equal(store.read(), null);
+  assert.equal(verifiedPaths.length, 0);
+  store.prepare(first);
+  store.commit(committed(first));
+  assert.equal(store.read().state, 'committed');
+  assert.equal(protectedPaths.includes(file), true);
+  assert.equal(protectedPaths.some((value) => value.endsWith('.tmp')), true);
+  assert.equal(verifiedPaths.filter((value) => value === file).length >= 3, true);
+});
+
+test('simulated Windows ACL failure removes a newly prepared journal', (t) => {
+  const { file } = fixture(t);
+  const store = new ProfileWorkspaceMigrationJournalStore({
+    filePath: file,
+    platform: 'win32',
+    windowsAcl: { protect: () => false, verify: () => false },
+  });
+  assert.throws(() => store.prepare(prepared()), /prepare failed/u);
+  assert.equal(fs.existsSync(file), false);
+});

--- a/desktop/test/profile-workspace-storage.test.js
+++ b/desktop/test/profile-workspace-storage.test.js
@@ -1,0 +1,201 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  LEGACY_HKUST_BROWSER_PARTITION,
+  createProfileAccountWorkspaceLayout,
+} = require('../lib/profile-workspace-layout');
+const {
+  DESTINATION_RECEIPT_IDS,
+  LEGACY_SOURCE_IDS,
+  commitMigrationJournal,
+  createPreparedMigrationJournal,
+  validateMigrationJournal,
+} = require('../lib/profile-workspace-migration-journal');
+
+const PROFILE_KEY = `profile-${'11'.repeat(16)}`;
+const ACCOUNT_KEY = `account-${'22'.repeat(16)}`;
+const WORKSPACE_KEY = `workspace-${'33'.repeat(16)}`;
+
+function receipt(seed) {
+  return Object.freeze({
+    present: true,
+    bytes: seed,
+    sha256: seed.toString(16).padStart(64, '0'),
+  });
+}
+
+function sourceReceipts() {
+  return Object.fromEntries(LEGACY_SOURCE_IDS.map((id, index) => [id, receipt(index + 1)]));
+}
+
+function deepKeys(value, result = []) {
+  if (!value || typeof value !== 'object') return result;
+  for (const [key, entry] of Object.entries(value)) {
+    result.push(key.toLowerCase());
+    deepKeys(entry, result);
+  }
+  return result;
+}
+
+test('profile/account/workspace paths use only opaque keys beneath one absolute userData root', () => {
+  const userData = path.resolve('/tmp/campus-connect-user-data');
+  const layout = createProfileAccountWorkspaceLayout({
+    userData,
+    profileKey: PROFILE_KEY,
+    accountKey: ACCOUNT_KEY,
+    workspaceKey: WORKSPACE_KEY,
+  });
+
+  assert.equal(layout.global.root, path.join(userData, 'global'));
+  assert.equal(
+    layout.account.root,
+    path.join(userData, 'profiles', PROFILE_KEY, 'accounts', ACCOUNT_KEY),
+  );
+  assert.equal(layout.workspace.root, path.join(layout.account.root, 'workspace'));
+  assert.equal(layout.account.vpnCredential, path.join(layout.account.root, 'vpn-credential.bin'));
+  assert.equal(layout.workspace.routingRules, path.join(layout.workspace.root, 'routing-rules.json'));
+  assert.equal(layout.workspace.engineLog, path.join(layout.workspace.root, 'engine.log'));
+  assert.match(layout.browserPartition, /^persist:campus-workspace-[a-f0-9]{32}$/u);
+  assert.equal(Object.isFrozen(layout.workspace), true);
+  for (const sensitive of ['hkustgz', 'remote.hkust-gz.edu.cn', 'student001']) {
+    assert.equal(JSON.stringify(layout).includes(sensitive), false);
+  }
+});
+
+test('only the migrated HKUST primary workspace adopts the legacy Browser partition alias', () => {
+  const input = {
+    userData: path.resolve('/tmp/campus-connect-user-data'),
+    profileKey: PROFILE_KEY,
+    accountKey: ACCOUNT_KEY,
+    workspaceKey: WORKSPACE_KEY,
+  };
+  assert.notEqual(createProfileAccountWorkspaceLayout(input).browserPartition,
+    LEGACY_HKUST_BROWSER_PARTITION);
+  assert.equal(createProfileAccountWorkspaceLayout({
+    ...input,
+    adoptLegacyHkustBrowserPartition: true,
+  }).browserPartition, LEGACY_HKUST_BROWSER_PARTITION);
+});
+
+test('layout rejects relative roots, traversal keys and key reuse', () => {
+  const valid = {
+    userData: path.resolve('/tmp/campus-connect-user-data'),
+    profileKey: PROFILE_KEY,
+    accountKey: ACCOUNT_KEY,
+    workspaceKey: WORKSPACE_KEY,
+  };
+  assert.throws(() => createProfileAccountWorkspaceLayout({ ...valid, userData: 'relative' }),
+    /userData/u);
+  assert.throws(() => createProfileAccountWorkspaceLayout({ ...valid, profileKey: '../profile' }),
+    /profileKey/u);
+  assert.throws(() => createProfileAccountWorkspaceLayout({ ...valid, accountKey: PROFILE_KEY }),
+    /distinct/u);
+});
+
+test('prepared migration journal generates and erases all persistent key entropy in one operation', () => {
+  const entropy = [1, 2, 3, 4].map((value) => Buffer.alloc(16, value));
+  let index = 0;
+  const document = createPreparedMigrationJournal({
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    profileCredentialBindingRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
+    sourceReceipts: sourceReceipts(),
+    randomBytes: () => entropy[index++],
+    now: () => 1_700_000_000_000,
+  });
+
+  assert.equal(document.state, 'prepared');
+  assert.match(document.migrationId, /^migration-[a-f0-9]{32}$/u);
+  assert.match(document.identity.profileKey, /^profile-[a-f0-9]{32}$/u);
+  assert.match(document.identity.accountKey, /^account-[a-f0-9]{32}$/u);
+  assert.match(document.identity.workspaceKey, /^workspace-[a-f0-9]{32}$/u);
+  assert.equal(document.legacyBrowserPartition, LEGACY_HKUST_BROWSER_PARTITION);
+  for (const buffer of entropy) assert.deepEqual(buffer, Buffer.alloc(16));
+  const keys = deepKeys(document);
+  for (const forbidden of ['username', 'password', 'cookie', 'token', 'csrf', 'twfid']) {
+    assert.equal(keys.includes(forbidden), false);
+  }
+});
+
+test('journal schema is exact, receipt-bound and has one monotonic commit transition', () => {
+  let entropyValue = 10;
+  const prepared = createPreparedMigrationJournal({
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    profileCredentialBindingRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
+    sourceReceipts: sourceReceipts(),
+    randomBytes: () => Buffer.alloc(16, entropyValue++),
+    now: () => 1_700_000_000_000,
+  });
+  const destinationReceipts = Object.fromEntries(
+    DESTINATION_RECEIPT_IDS.map((id, index) => [id, receipt(index + 101)]),
+  );
+  const committed = commitMigrationJournal(prepared, {
+    destinationReceipts,
+    now: () => 1_700_000_000_100,
+  });
+
+  assert.equal(committed.state, 'committed');
+  assert.equal(committed.committedAt, 1_700_000_000_100);
+  assert.deepEqual(validateMigrationJournal(JSON.parse(JSON.stringify(committed))), committed);
+  assert.throws(() => commitMigrationJournal(committed, {
+    destinationReceipts,
+    now: () => 1_700_000_000_200,
+  }), /prepared/u);
+  assert.throws(() => validateMigrationJournal({ ...prepared, username: 'student001' }),
+    /schema/u);
+  assert.throws(() => validateMigrationJournal({
+    ...prepared,
+    sourceReceipts: { ...prepared.sourceReceipts, settings: receipt(999) },
+  }), /source receipt/u);
+});
+
+test('journal generation fails closed on weak entropy, missing receipts and unsafe bindings', () => {
+  const base = {
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    profileCredentialBindingRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
+    sourceReceipts: sourceReceipts(),
+    now: () => 1_700_000_000_000,
+  };
+  assert.throws(() => createPreparedMigrationJournal({
+    ...base,
+    randomBytes: () => Buffer.alloc(15),
+  }), /entropy/u);
+  assert.throws(() => createPreparedMigrationJournal({
+    ...base,
+    sourceReceipts: {},
+    randomBytes: () => Buffer.alloc(16, 1),
+  }), /source receipt/u);
+  assert.throws(() => createPreparedMigrationJournal({
+    ...base,
+    gatewayOrigin: 'http://remote.hkust-gz.edu.cn',
+    randomBytes: () => Buffer.alloc(16, 1),
+  }), /GatewayOrigin/u);
+  assert.throws(() => createPreparedMigrationJournal({
+    ...base,
+    profileId: 'another-school',
+    randomBytes: () => Buffer.alloc(16, 1),
+  }), /HKUST profile/u);
+});
+
+test('P3 foundation is packaged but does not activate migration in production Main', () => {
+  const main = fs.readFileSync(path.join(__dirname, '..', 'main.js'), 'utf8');
+  for (const moduleName of [
+    'profile-workspace-layout',
+    'profile-workspace-migration-journal',
+    'profile-workspace-migration-store',
+  ]) {
+    assert.equal(main.includes(moduleName), false);
+  }
+});

--- a/docs/adr/0007-p3-storage-foundation.md
+++ b/docs/adr/0007-p3-storage-foundation.md
@@ -1,0 +1,58 @@
+# ADR-0007: P3 profile/account/workspace storage foundation
+
+- Status: Accepted as a non-activating P3 foundation
+- Production migration: not enabled by this ADR
+- Parent contracts: [`ADR-0004`](0004-profile-account-workspace-scope.md),
+  [`ADR-0006`](0006-production-provider-composition.md)
+
+## Context
+
+The 1.x application still owns one flat `userData` namespace. P1 defined persistent Account/Workspace schemas and
+P2 added a process-lifetime account handle, but no code safely derives the future on-disk hierarchy or records an
+all-old/all-new migration boundary.
+
+P3 eventually migrates credentials, Browser state, certificate grants, routing and local resources. Activating
+that migration before its key, path and journal contracts are independently testable would put existing user
+state at risk.
+
+## Decision
+
+This batch adds three inert building blocks:
+
+1. `profile-workspace-layout.js` derives every future path from installation-local opaque profile/account keys.
+   Profile IDs, Gateway hosts, usernames and labels are never path components. A non-migrated workspace receives
+   a deterministic partition digest; only the explicit migrated HKUST primary path may adopt
+   `persist:hkustgz-campus-browser`.
+2. `profile-workspace-migration-journal.js` owns generation of `profileKey`, `accountKey`, `workspaceKey` and the
+   migration ID. Entropy buffers are exact-length and erased immediately. The exact schema stores only bounded
+   SHA-256 receipts and identity/revision bindings—never file contents, username, password, Cookie or token.
+3. `profile-workspace-migration-store.js` persists one owner-only journal with a monotonic
+   `prepared -> committed -> cleared` lifecycle. It rejects symlinks, hard links, broad POSIX permissions,
+   replacement identities and non-atomic commit failures.
+
+The existing production `main.js` does not import these modules. No directory is created and no existing user
+file, Browser partition or credential is read, copied, moved or deleted in this batch.
+
+## Security and recovery properties
+
+- All persistent keys are opaque and distinct; raw user or deployment values cannot select a path.
+- Source/destination receipt sets have exact logical IDs and a canonical aggregate digest.
+- Prepared journals cannot be overwritten or cleared.
+- A commit must retain the same migration/Profile/origin/family/key/source binding.
+- Commit writes use an owner-only same-directory temporary file, file fsync, atomic rename and directory fsync.
+- If directory fsync fails after rename, a matching readable committed document is reported as
+  `durabilityUnconfirmed`; later activation must treat this as a recovery state, not silent success.
+- Journal reads use the existing bounded no-follow single-link private-file boundary.
+
+## Deferred activation work
+
+The next P3 batches must still implement and test:
+
+- legacy source/destination receipt collection through opened descriptors;
+- journaled directory creation and bound VPN credential-envelope re-encryption;
+- all-old/all-new recovery and exact retirement of flat authorization stores;
+- settings split, workspace store adapters and legacy rollback-blob state;
+- Browser partition adoption and production Main wiring;
+- fault injection at every write/fsync/rename/unlink boundary.
+
+Until those gates pass, the flat 1.x storage path remains the only production authority.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -616,6 +616,11 @@ Implementation contract: [`ADR-0006`](../adr/0006-production-provider-compositio
 
 ### 2.0-P3 — Profile/account/workspace storage and journaled HKUST migration
 
+Non-activating storage foundation: [`ADR-0007`](../adr/0007-p3-storage-foundation.md).
+
+- land and verify opaque-key path derivation, exact receipt-bound journal schema and owner-only journal storage
+  before production Main imports any P3 module;
+
 - split app-global and profile settings;
 - create `profiles/<profileKey>/accounts/<accountKey>/workspace/` from the start;
 - generate/commit the installation-local opaque profile/account/workspace keys only inside the P3 journal;


### PR DESCRIPTION
## 依赖关系

这是 stacked Draft PR，暂时以 PR #11 的 P2 分支为 base。PR #11 合并后，本 PR 将重基并改为 main；不会把未审核的 P2 重复合并。

## 目标

先建立 P3 可独立验证的持久路径与 migration journal 基础，不激活真实用户数据迁移。

## 主要变化

- 新增 Profile/Account/Workspace 路径布局：只有安装本地 opaque profile/account keys 能成为路径组件。
- Browser partition 默认从 workspaceKey 稳定摘要派生；只有 HKUST primary 迁移路径可显式收养旧 partition。
- journal 在单一 prepare 操作内生成 migration/profile/account/workspace keys，并立即擦除熵 Buffer。
- exact-schema journal 只保存 Profile/origin/family/revision 绑定和 SHA-256 receipts，不保存旧文件内容或认证秘密。
- owner-only journal store 只允许 prepared -> committed -> cleared。
- commit 使用同目录临时文件、文件 fsync、原子 rename 和目录 fsync。
- POSIX 拒绝 symlink、hard link 和宽权限；Windows 要求 current-user-only DACL protect + verify。
- 已证明存在后消失的 journal fail closed，不会降级成 benign absence。
- 新增 ADR-0007 与架构约束。

## 明确不做

- desktop/main.js 不导入任何 P3 模块。
- 不创建真实 profiles/accounts/workspace 目录。
- 不读取、复制、移动、重加密或删除现有用户文件。
- 不切换 Browser partition、VPN credential、路由、证书、网站密码或日志的生产权威。

## 本地验证

- Desktop: 626 passed, 0 failed, 1 Windows-only skip
- P3 focused tests: 17 passed, 0 failed
- Architecture: PASS, 218 files / 286 edges / 0 cycles
- All JavaScript syntax checks: PASS
- Staged secret gate: PASS
- git diff --check: PASS

大型与三平台验证交给 GitHub Actions。