### PR TITLE
2.0 P3b: bind legacy receipts and VPN credential envelopes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -141,6 +141,12 @@ fsync。Windows 文件还必须在提交前后通过 current-user-only DACL 保�
 P3 完整激活前，flat 1.x `userData` 仍是唯一生产权威；基础 layout/journal 模块不得由
 `desktop/main.js` 导入。详细合同见 [`ADR-0007`](docs/adr/0007-p3-storage-foundation.md)。
 
+旧 flat 状态的迁移收据必须由同一个 no-follow descriptor 完成 `fstat -> bounded hash -> fstat`，
+同时比较 inode、size、mtime、ctime；收据只含 `present / bytes / sha256`。VPN username 与 password
+必须作为一个加密 envelope 提交，并绑定 profile/account credential revision、Gateway origin、
+ProtocolFamily 和 credential version。解密结果由 Main-only zeroizing owner 管理，不进入 Renderer、
+日志或 migration journal。详细合同见 [`ADR-0008`](docs/adr/0008-p3-receipts-and-vpn-envelope.md)。
+
 ## 5. Connection state machine
 
 ### 5.1 唯一权威状态

--- a/desktop/lib/legacy-flat-source-receipts.js
+++ b/desktop/lib/legacy-flat-source-receipts.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const {
+  createLegacyFlatSourcePaths,
+} = require('./profile-workspace-layout');
+const { LEGACY_SOURCE_IDS } = require('./profile-workspace-migration-journal');
+const { verifyWindowsFileOwnerOnly } = require('./windows-private-file');
+
+const READ_CHUNK_BYTES = 64 * 1024;
+const LEGACY_SOURCE_MAX_BYTES = Object.freeze({
+  settings: 512 * 1024,
+  settingsBackup: 512 * 1024,
+  vpnCredential: 64 * 1024,
+  routingRules: 512 * 1024,
+  externalPac: 1024 * 1024,
+  browserPac: 1024 * 1024,
+  siteCredentials: 2 * 1024 * 1024,
+  certificateTrust: 2 * 1024 * 1024,
+  engineLog: 16 * 1024 * 1024,
+});
+
+function absentReceipt() {
+  return Object.freeze({ present: false, bytes: 0, sha256: null });
+}
+
+function invalidSource(message, cause = null) {
+  return cause == null ? new Error(message) : new Error(message, { cause });
+}
+
+function sameFileVersion(left, right) {
+  return left.dev === right.dev && left.ino === right.ino && left.size === right.size &&
+    left.mtimeMs === right.mtimeMs && left.ctimeMs === right.ctimeMs;
+}
+
+function collectOne(file, maxBytes, { fileSystem, platform, windowsAcl }) {
+  let before;
+  try {
+    before = fileSystem.lstatSync(file);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return absentReceipt();
+    throw invalidSource('legacy source could not be inspected', error);
+  }
+  if (!before.isFile() || before.isSymbolicLink() || before.size < 0 || before.size > maxBytes ||
+      (platform !== 'win32' && (before.nlink !== 1 || (before.mode & 0o077) !== 0))) {
+    throw invalidSource('legacy source is not a bounded owner-only regular file');
+  }
+  if (platform === 'win32' && !windowsAcl.verify(file)) {
+    throw invalidSource('legacy source Windows ACL is not current-user-only');
+  }
+
+  const constants = fileSystem.constants || fs.constants;
+  let descriptor = null;
+  let buffer = null;
+  try {
+    try {
+      descriptor = fileSystem.openSync(file, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+    } catch (error) {
+      throw invalidSource('legacy source could not be opened after observed presence', error);
+    }
+    const opened = fileSystem.fstatSync(descriptor);
+    if (!opened.isFile() || !sameFileVersion(opened, before) || opened.size > maxBytes ||
+        (platform !== 'win32' && opened.nlink !== 1)) {
+      throw invalidSource('legacy source changed while opening');
+    }
+
+    const hash = crypto.createHash('sha256');
+    buffer = Buffer.alloc(Math.min(READ_CHUNK_BYTES, Math.max(1, opened.size)));
+    let offset = 0;
+    while (offset < opened.size) {
+      const requested = Math.min(buffer.length, opened.size - offset);
+      const count = fileSystem.readSync(descriptor, buffer, 0, requested, offset);
+      if (!count) throw invalidSource('legacy source read was incomplete');
+      hash.update(buffer.subarray(0, count));
+      buffer.fill(0, 0, count);
+      offset += count;
+    }
+    const after = fileSystem.fstatSync(descriptor);
+    if (!after.isFile() || !sameFileVersion(after, opened) ||
+        (platform !== 'win32' && after.nlink !== 1)) {
+      throw invalidSource('legacy source changed while reading');
+    }
+    return Object.freeze({
+      present: true,
+      bytes: opened.size,
+      sha256: hash.digest('hex'),
+    });
+  } finally {
+    buffer?.fill(0);
+    if (descriptor !== null) {
+      try { fileSystem.closeSync(descriptor); } catch {}
+    }
+  }
+}
+
+function collectLegacyFlatSourceReceipts({
+  userData,
+  fileSystem = fs,
+  platform = process.platform,
+  windowsAcl = { verify: verifyWindowsFileOwnerOnly },
+} = {}) {
+  if (!fileSystem || typeof fileSystem.lstatSync !== 'function' ||
+      !['darwin', 'linux', 'win32'].includes(platform) ||
+      (platform === 'win32' && typeof windowsAcl?.verify !== 'function')) {
+    throw new TypeError('legacy receipt dependencies are invalid');
+  }
+  const sources = createLegacyFlatSourcePaths(userData);
+  const keys = Object.keys(sources);
+  if (keys.length !== LEGACY_SOURCE_IDS.length ||
+      LEGACY_SOURCE_IDS.some((id) => !Object.hasOwn(sources, id))) {
+    throw new Error('legacy source layout does not match the journal schema');
+  }
+  return Object.freeze(Object.fromEntries(LEGACY_SOURCE_IDS.map((id) => [
+    id,
+    collectOne(sources[id], LEGACY_SOURCE_MAX_BYTES[id], {
+      fileSystem,
+      platform,
+      windowsAcl,
+    }),
+  ])));
+}
+
+module.exports = {
+  LEGACY_SOURCE_MAX_BYTES,
+  collectLegacyFlatSourceReceipts,
+};

--- a/desktop/lib/legacy-flat-source-receipts.js
+++ b/desktop/lib/legacy-flat-source-receipts.js
@@ -18,7 +18,13 @@ const LEGACY_SOURCE_MAX_BYTES = Object.freeze({
   browserPac: 1024 * 1024,
   siteCredentials: 2 * 1024 * 1024,
   certificateTrust: 2 * 1024 * 1024,
+  engineOwner: 64 * 1024,
+  credentialTransaction: 2 * 1024 * 1024,
+  proxyCredential: 64 * 1024,
+  proxyHelperCredential: 1024,
   engineLog: 16 * 1024 * 1024,
+  engineLogRotated: 16 * 1024 * 1024,
+  engineLogRetention: 64,
 });
 
 function absentReceipt() {

--- a/desktop/lib/profile-workspace-layout.js
+++ b/desktop/lib/profile-workspace-layout.js
@@ -44,7 +44,13 @@ function createLegacyFlatSourcePaths(userData) {
     browserPac: path.join(root, 'campus-browser-routing.pac'),
     siteCredentials: path.join(root, 'campus-credentials.json'),
     certificateTrust: path.join(root, 'campus-certificate-trust.json'),
+    engineOwner: path.join(root, 'engine-owner.json'),
+    credentialTransaction: path.join(root, 'credential-settings-transaction.json'),
+    proxyCredential: path.join(root, 'proxy-credential.bin'),
+    proxyHelperCredential: path.join(root, 'proxy-helper-credential.txt'),
     engineLog: path.join(root, 'engine.log'),
+    engineLogRotated: path.join(root, 'engine.log.1'),
+    engineLogRetention: path.join(root, 'engine.log.retention'),
   });
 }
 
@@ -110,6 +116,8 @@ function createProfileAccountWorkspaceLayout({
       recentResources: path.join(workspaceRoot, 'recent-resources.json'),
       externalIntegrations: path.join(workspaceRoot, 'external-integrations.json'),
       engineLog: path.join(workspaceRoot, 'engine.log'),
+      engineLogRotated: path.join(workspaceRoot, 'engine.log.1'),
+      engineLogRetention: path.join(workspaceRoot, 'engine.log.retention'),
     },
     browserPartition: adoptLegacyHkustBrowserPartition
       ? LEGACY_HKUST_BROWSER_PARTITION

--- a/desktop/lib/profile-workspace-layout.js
+++ b/desktop/lib/profile-workspace-layout.js
@@ -33,6 +33,21 @@ function browserPartition(workspaceKey) {
   return `persist:campus-workspace-${digest}`;
 }
 
+function createLegacyFlatSourcePaths(userData) {
+  const root = normalizedUserData(userData);
+  return deepFreeze({
+    settings: path.join(root, 'settings.json'),
+    settingsBackup: path.join(root, 'settings.json.bak'),
+    vpnCredential: path.join(root, 'cred.bin'),
+    routingRules: path.join(root, 'routing-rules.json'),
+    externalPac: path.join(root, 'routing.pac'),
+    browserPac: path.join(root, 'campus-browser-routing.pac'),
+    siteCredentials: path.join(root, 'campus-credentials.json'),
+    certificateTrust: path.join(root, 'campus-certificate-trust.json'),
+    engineLog: path.join(root, 'engine.log'),
+  });
+}
+
 function createProfileAccountWorkspaceLayout({
   userData,
   profileKey,
@@ -104,5 +119,6 @@ function createProfileAccountWorkspaceLayout({
 
 module.exports = {
   LEGACY_HKUST_BROWSER_PARTITION,
+  createLegacyFlatSourcePaths,
   createProfileAccountWorkspaceLayout,
 };

--- a/desktop/lib/profile-workspace-migration-journal.js
+++ b/desktop/lib/profile-workspace-migration-journal.js
@@ -19,14 +19,27 @@ const LEGACY_SOURCE_IDS = Object.freeze([
   'browserPac',
   'siteCredentials',
   'certificateTrust',
+  'engineOwner',
+  'credentialTransaction',
+  'proxyCredential',
+  'proxyHelperCredential',
   'engineLog',
+  'engineLogRotated',
+  'engineLogRetention',
 ]);
 const DESTINATION_RECEIPT_IDS = Object.freeze([
   'globalSettings',
+  'globalProxyCredential',
+  'globalProxyHelperCredential',
+  'globalEngineOwner',
+  'globalUpdateState',
+  'globalActiveContextSwitch',
   'profileSettings',
   'profileState',
   'account',
   'vpnCredential',
+  'credentialTransaction',
+  'deletionTombstone',
   'workspaceState',
   'siteCredentials',
   'certificateTrust',
@@ -38,6 +51,8 @@ const DESTINATION_RECEIPT_IDS = Object.freeze([
   'recentResources',
   'externalIntegrations',
   'engineLog',
+  'engineLogRotated',
+  'engineLogRetention',
 ]);
 const JOURNAL_STATES = Object.freeze(['prepared', 'committed']);
 const HEX_DIGEST = /^[a-f0-9]{64}$/u;

--- a/desktop/lib/profile-workspace-migration-journal.js
+++ b/desktop/lib/profile-workspace-migration-journal.js
@@ -82,7 +82,7 @@ function normalizeReceipt(value, name) {
   }
   if (!source.present) {
     if (source.bytes !== 0 || source.sha256 !== null) throw new TypeError(`${name} is invalid`);
-  } else if (source.bytes < 1 || typeof source.sha256 !== 'string' ||
+  } else if (typeof source.sha256 !== 'string' ||
       !HEX_DIGEST.test(source.sha256)) {
     throw new TypeError(`${name} is invalid`);
   }

--- a/desktop/lib/vpn-credential-envelope-store.js
+++ b/desktop/lib/vpn-credential-envelope-store.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { atomicWritePrivateFile } = require('./credential-store');
+const { readPrivateFileBounded } = require('./private-file');
+const { MAX_ENCRYPTED_ENVELOPE_BYTES } = require('./vpn-credential-envelope');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+function normalizedEnvelopePath(value) {
+  if (typeof value !== 'string' || !path.isAbsolute(value)) {
+    throw new TypeError('VPN credential envelope path must be absolute and normalized');
+  }
+  const normalized = path.resolve(value);
+  const root = path.parse(normalized).root;
+  if (normalized !== value || normalized === root || path.dirname(normalized) === root) {
+    throw new TypeError('VPN credential envelope path must be absolute and normalized');
+  }
+  return normalized;
+}
+
+function fsyncDirectory(directory, fileSystem, platform) {
+  let descriptor = null;
+  try {
+    descriptor = fileSystem.openSync(directory, 'r');
+    fileSystem.fsyncSync?.(descriptor);
+    return true;
+  } catch {
+    return platform === 'win32';
+  } finally {
+    if (descriptor !== null) {
+      try { fileSystem.closeSync(descriptor); } catch {}
+    }
+  }
+}
+
+class VpnCredentialEnvelopeStore {
+  constructor({
+    filePath,
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+  } = {}) {
+    if (!fileSystem || typeof fileSystem.openSync !== 'function' ||
+        !['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' &&
+          (typeof windowsAcl?.protect !== 'function' || typeof windowsAcl?.verify !== 'function'))) {
+      throw new TypeError('VPN credential envelope store dependencies are invalid');
+    }
+    this.filePath = normalizedEnvelopePath(filePath);
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+  }
+
+  load() {
+    try {
+      this.fileSystem.lstatSync(this.filePath);
+    } catch (error) {
+      if (error?.code === 'ENOENT') return null;
+      throw error;
+    }
+    if (this.platform === 'win32' && !this.windowsAcl.verify(this.filePath)) {
+      throw new Error('invalid private file');
+    }
+    try {
+      return readPrivateFileBounded(this.filePath, {
+        maxBytes: MAX_ENCRYPTED_ENVELOPE_BYTES,
+        platform: this.platform,
+        fileSystem: this.fileSystem,
+      }).data;
+    } catch (error) {
+      if (error?.code === 'ENOENT') {
+        throw new Error('VPN credential envelope disappeared after it was observed', { cause: error });
+      }
+      throw error;
+    }
+  }
+
+  save(encrypted) {
+    if (!Buffer.isBuffer(encrypted) || encrypted.length < 1 ||
+        encrypted.length > MAX_ENCRYPTED_ENVELOPE_BYTES) {
+      throw new TypeError('encrypted VPN credential envelope is invalid');
+    }
+    const options = this.platform === 'win32' ? {
+      protectTemporary: (temporary) => this.windowsAcl.protect(temporary) === true,
+      verifyCommitted: (committed) => this.windowsAcl.verify(committed) === true,
+      removeCommittedOnFailure: true,
+    } : {};
+    if (!atomicWritePrivateFile(this.filePath, encrypted, this.fileSystem, options)) {
+      let observed = null;
+      let commitApplied = false;
+      try {
+        observed = this.load();
+        commitApplied = Buffer.isBuffer(observed) && observed.length === encrypted.length &&
+          crypto.timingSafeEqual(observed, encrypted);
+      } catch {
+        commitApplied = false;
+      } finally {
+        observed?.fill(0);
+      }
+      const error = new Error('VPN credential envelope save failed');
+      error.commitApplied = commitApplied;
+      throw error;
+    }
+    return true;
+  }
+
+  remove() {
+    const current = this.load();
+    if (current === null) return false;
+    current.fill(0);
+    const directory = path.dirname(this.filePath);
+    try {
+      this.fileSystem.unlinkSync(this.filePath);
+    } catch (error) {
+      throw new Error('VPN credential envelope removal failed', { cause: error });
+    }
+    if (!fsyncDirectory(directory, this.fileSystem, this.platform)) {
+      throw new Error('VPN credential envelope removal was not durable');
+    }
+    return true;
+  }
+}
+
+module.exports = { VpnCredentialEnvelopeStore };

--- a/desktop/lib/vpn-credential-envelope.js
+++ b/desktop/lib/vpn-credential-envelope.js
@@ -1,0 +1,251 @@
+'use strict';
+
+const util = require('node:util');
+const {
+  normalizeGatewayOrigin,
+  validateOpaqueKey,
+  validateProfileId,
+  validateProtocolFamily,
+} = require('./school-profile-schema');
+
+const VPN_CREDENTIAL_ENVELOPE_VERSION = 1;
+const MAX_ENCRYPTED_ENVELOPE_BYTES = 64 * 1024;
+const MAX_PLAINTEXT_ENVELOPE_BYTES = 16 * 1024;
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/u;
+
+function plainObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+  return value;
+}
+
+function exactKeys(value, keys, name) {
+  const source = plainObject(value, name);
+  const actual = Object.keys(source).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${name} has an invalid schema`);
+  }
+  return source;
+}
+
+function positiveInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function normalizeBinding(value) {
+  const source = exactKeys(value, [
+    'profileId', 'profileCredentialBindingRevision', 'accountKey',
+    'accountCredentialRevision', 'gatewayOrigin', 'protocolFamily',
+  ], 'VPN credential binding');
+  return Object.freeze({
+    profileId: validateProfileId(source.profileId),
+    profileCredentialBindingRevision: positiveInteger(
+      source.profileCredentialBindingRevision,
+      'profileCredentialBindingRevision',
+    ),
+    accountKey: validateOpaqueKey(source.accountKey, 'accountKey'),
+    accountCredentialRevision: positiveInteger(
+      source.accountCredentialRevision,
+      'accountCredentialRevision',
+    ),
+    gatewayOrigin: normalizeGatewayOrigin(source.gatewayOrigin).origin,
+    protocolFamily: validateProtocolFamily(source.protocolFamily),
+  });
+}
+
+function bindingProjection(value) {
+  return {
+    profileId: value.profileId,
+    profileCredentialBindingRevision: value.profileCredentialBindingRevision,
+    accountKey: value.accountKey,
+    accountCredentialRevision: value.accountCredentialRevision,
+    gatewayOrigin: value.gatewayOrigin,
+    protocolFamily: value.protocolFamily,
+  };
+}
+
+function credentialField(value, maxLength) {
+  if (typeof value !== 'string' || !value || value.length > maxLength ||
+      CONTROL_CHARACTERS.test(value)) {
+    throw new TypeError('VPN credential field is invalid');
+  }
+  return value;
+}
+
+function protectedStorageAvailable(safeStorage, platform) {
+  if (!safeStorage || typeof safeStorage.isEncryptionAvailable !== 'function' ||
+      typeof safeStorage.encryptString !== 'function' ||
+      typeof safeStorage.decryptString !== 'function' ||
+      !['darwin', 'linux', 'win32'].includes(platform)) {
+    return false;
+  }
+  try {
+    if (!safeStorage.isEncryptionAvailable()) return false;
+    return platform !== 'linux' || (
+      typeof safeStorage.getSelectedStorageBackend === 'function' &&
+      safeStorage.getSelectedStorageBackend() !== 'basic_text'
+    );
+  } catch {
+    return false;
+  }
+}
+
+function normalizeEnvelope(value) {
+  const source = exactKeys(value, [
+    'schemaVersion', 'profileId', 'profileCredentialBindingRevision', 'accountKey',
+    'accountCredentialRevision', 'gatewayOrigin', 'protocolFamily', 'credentialVersion',
+    'username', 'password', 'updatedAt',
+  ], 'VPN credential envelope');
+  if (source.schemaVersion !== VPN_CREDENTIAL_ENVELOPE_VERSION) {
+    throw new TypeError('VPN credential envelope version is unsupported');
+  }
+  const binding = normalizeBinding(bindingProjection(source));
+  return {
+    schemaVersion: VPN_CREDENTIAL_ENVELOPE_VERSION,
+    ...binding,
+    credentialVersion: positiveInteger(source.credentialVersion, 'credentialVersion'),
+    username: credentialField(source.username, 256),
+    password: credentialField(source.password, 4096),
+    updatedAt: positiveInteger(source.updatedAt, 'updatedAt'),
+  };
+}
+
+function sameBinding(left, right) {
+  return left.profileId === right.profileId &&
+    left.profileCredentialBindingRevision === right.profileCredentialBindingRevision &&
+    left.accountKey === right.accountKey &&
+    left.accountCredentialRevision === right.accountCredentialRevision &&
+    left.gatewayOrigin === right.gatewayOrigin &&
+    left.protocolFamily === right.protocolFamily;
+}
+
+class DecryptedVpnCredential {
+  #username;
+  #password;
+  #destroyed = false;
+
+  constructor(envelope) {
+    this.binding = normalizeBinding(bindingProjection(envelope));
+    this.credentialVersion = envelope.credentialVersion;
+    this.updatedAt = envelope.updatedAt;
+    this.#username = Buffer.from(envelope.username, 'utf8');
+    this.#password = Buffer.from(envelope.password, 'utf8');
+    Object.freeze(this.binding);
+    Object.freeze(this);
+  }
+
+  withStrings(callback) {
+    if (this.#destroyed) throw new Error('VPN credential owner is destroyed');
+    if (typeof callback !== 'function') throw new TypeError('VPN credential callback is required');
+    return callback(this.#username.toString('utf8'), this.#password.toString('utf8'));
+  }
+
+  destroy() {
+    if (this.#destroyed) return false;
+    this.#destroyed = true;
+    this.#username.fill(0);
+    this.#password.fill(0);
+    return true;
+  }
+
+  toJSON() { return '[redacted vpn credential]'; }
+
+  toString() { return '[redacted vpn credential]'; }
+
+  [util.inspect.custom]() { return '[redacted vpn credential]'; }
+}
+
+function encryptVpnCredentialEnvelope(options = {}) {
+  const source = exactKeys(options, [
+    'binding', 'credentialVersion', 'username', 'password', 'updatedAt', 'safeStorage', 'platform',
+  ], 'VPN credential encryption request');
+  if (!protectedStorageAvailable(source.safeStorage, source.platform)) {
+    throw new Error('protected storage is unavailable');
+  }
+  const envelope = normalizeEnvelope({
+    schemaVersion: VPN_CREDENTIAL_ENVELOPE_VERSION,
+    ...normalizeBinding(source.binding),
+    credentialVersion: source.credentialVersion,
+    username: source.username,
+    password: source.password,
+    updatedAt: source.updatedAt,
+  });
+  let plaintext = JSON.stringify(envelope);
+  let encrypted;
+  try {
+    if (Buffer.byteLength(plaintext, 'utf8') > MAX_PLAINTEXT_ENVELOPE_BYTES) {
+      throw new TypeError('VPN credential envelope is too large');
+    }
+    encrypted = source.safeStorage.encryptString(plaintext);
+  } catch (error) {
+    throw new Error('VPN credential envelope encryption failed', { cause: error });
+  } finally {
+    plaintext = '';
+    envelope.username = '';
+    envelope.password = '';
+  }
+  if (!Buffer.isBuffer(encrypted) || encrypted.length < 1 ||
+      encrypted.length > MAX_ENCRYPTED_ENVELOPE_BYTES) {
+    encrypted?.fill?.(0);
+    throw new Error('VPN credential envelope encryption returned invalid data');
+  }
+  return encrypted;
+}
+
+function clearParsedStrings(value, seen = new Set()) {
+  if (!value || typeof value !== 'object' || seen.has(value)) return;
+  seen.add(value);
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === 'string') value[key] = '';
+    else clearParsedStrings(entry, seen);
+  }
+}
+
+function decryptVpnCredentialEnvelope(encrypted, options = {}) {
+  const source = exactKeys(options, ['expectedBinding', 'safeStorage', 'platform'],
+    'VPN credential decryption request');
+  if (!Buffer.isBuffer(encrypted) || encrypted.length < 1 ||
+      encrypted.length > MAX_ENCRYPTED_ENVELOPE_BYTES) {
+    throw new TypeError('encrypted VPN credential envelope is invalid');
+  }
+  if (!protectedStorageAvailable(source.safeStorage, source.platform)) {
+    throw new Error('protected storage is unavailable');
+  }
+  const expectedBinding = normalizeBinding(source.expectedBinding);
+  let plaintext = '';
+  let parsed = null;
+  try {
+    plaintext = source.safeStorage.decryptString(encrypted);
+    if (typeof plaintext !== 'string' || Buffer.byteLength(plaintext, 'utf8') < 2 ||
+        Buffer.byteLength(plaintext, 'utf8') > MAX_PLAINTEXT_ENVELOPE_BYTES) {
+      throw new Error('decrypted VPN credential envelope is invalid');
+    }
+    try {
+      parsed = JSON.parse(plaintext);
+    } catch (error) {
+      throw new Error('VPN credential envelope JSON is invalid', { cause: error });
+    }
+    const envelope = normalizeEnvelope(parsed);
+    if (!sameBinding(envelope, expectedBinding)) {
+      throw new Error('VPN credential envelope binding does not match');
+    }
+    return new DecryptedVpnCredential(envelope);
+  } finally {
+    plaintext = '';
+    clearParsedStrings(parsed);
+  }
+}
+
+module.exports = {
+  MAX_ENCRYPTED_ENVELOPE_BYTES,
+  VPN_CREDENTIAL_ENVELOPE_VERSION,
+  DecryptedVpnCredential,
+  decryptVpnCredentialEnvelope,
+  encryptVpnCredentialEnvelope,
+};

--- a/desktop/test/legacy-flat-source-receipts.test.js
+++ b/desktop/test/legacy-flat-source-receipts.test.js
@@ -36,7 +36,13 @@ test('legacy source paths are the exact current flat userData authorities', () =
     browserPac: path.join(userData, 'campus-browser-routing.pac'),
     siteCredentials: path.join(userData, 'campus-credentials.json'),
     certificateTrust: path.join(userData, 'campus-certificate-trust.json'),
+    engineOwner: path.join(userData, 'engine-owner.json'),
+    credentialTransaction: path.join(userData, 'credential-settings-transaction.json'),
+    proxyCredential: path.join(userData, 'proxy-credential.bin'),
+    proxyHelperCredential: path.join(userData, 'proxy-helper-credential.txt'),
     engineLog: path.join(userData, 'engine.log'),
+    engineLogRotated: path.join(userData, 'engine.log.1'),
+    engineLogRetention: path.join(userData, 'engine.log.retention'),
   });
 });
 

--- a/desktop/test/legacy-flat-source-receipts.test.js
+++ b/desktop/test/legacy-flat-source-receipts.test.js
@@ -1,0 +1,168 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { createLegacyFlatSourcePaths } = require('../lib/profile-workspace-layout');
+const {
+  collectLegacyFlatSourceReceipts,
+} = require('../lib/legacy-flat-source-receipts');
+
+function fixture(t) {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-legacy-receipts-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  return { userData, paths: createLegacyFlatSourcePaths(userData) };
+}
+
+function writePrivate(file, value) {
+  fs.writeFileSync(file, value, { mode: 0o600 });
+}
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+test('legacy source paths are the exact current flat userData authorities', () => {
+  const userData = path.resolve('/tmp/campus-connect-user-data');
+  assert.deepEqual(createLegacyFlatSourcePaths(userData), {
+    settings: path.join(userData, 'settings.json'),
+    settingsBackup: path.join(userData, 'settings.json.bak'),
+    vpnCredential: path.join(userData, 'cred.bin'),
+    routingRules: path.join(userData, 'routing-rules.json'),
+    externalPac: path.join(userData, 'routing.pac'),
+    browserPac: path.join(userData, 'campus-browser-routing.pac'),
+    siteCredentials: path.join(userData, 'campus-credentials.json'),
+    certificateTrust: path.join(userData, 'campus-certificate-trust.json'),
+    engineLog: path.join(userData, 'engine.log'),
+  });
+});
+
+test('receipt collection hashes opened descriptors without retaining file contents', (t) => {
+  const { userData, paths } = fixture(t);
+  const settings = Buffer.from('{"username":"legacy-user"}', 'utf8');
+  writePrivate(paths.settings, settings);
+  writePrivate(paths.engineLog, Buffer.alloc(0));
+
+  const receipts = collectLegacyFlatSourceReceipts({ userData });
+  assert.deepEqual(receipts.settings, {
+    present: true,
+    bytes: settings.length,
+    sha256: sha256(settings),
+  });
+  assert.deepEqual(receipts.engineLog, {
+    present: true,
+    bytes: 0,
+    sha256: sha256(Buffer.alloc(0)),
+  });
+  assert.deepEqual(receipts.vpnCredential, { present: false, bytes: 0, sha256: null });
+  assert.equal(JSON.stringify(receipts).includes('legacy-user'), false);
+  assert.equal(Object.isFrozen(receipts), true);
+});
+
+test('receipt collection rejects links, broad permissions and oversized sources', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const { userData, paths } = fixture(t);
+  const unrelated = path.join(userData, 'unrelated');
+  writePrivate(unrelated, 'data');
+
+  fs.symlinkSync(unrelated, paths.settings);
+  assert.throws(() => collectLegacyFlatSourceReceipts({ userData }), /legacy source/u);
+  fs.unlinkSync(paths.settings);
+
+  fs.linkSync(unrelated, paths.settings);
+  assert.throws(() => collectLegacyFlatSourceReceipts({ userData }), /legacy source/u);
+  fs.unlinkSync(paths.settings);
+
+  writePrivate(paths.settings, 'settings');
+  fs.chmodSync(paths.settings, 0o644);
+  assert.throws(() => collectLegacyFlatSourceReceipts({ userData }), /legacy source/u);
+  fs.chmodSync(paths.settings, 0o600);
+
+  fs.truncateSync(paths.settings, 512 * 1024 + 1);
+  assert.throws(() => collectLegacyFlatSourceReceipts({ userData }), /legacy source/u);
+});
+
+test('replacement between lstat and opened descriptor fails closed', (t) => {
+  const { userData, paths } = fixture(t);
+  writePrivate(paths.settings, 'settings');
+  const injected = Object.create(fs);
+  let changed = false;
+  injected.fstatSync = (descriptor) => {
+    const stat = fs.fstatSync(descriptor);
+    if (!changed) {
+      changed = true;
+      return {
+        ...stat,
+        ino: stat.ino + 1,
+        isFile: () => true,
+      };
+    }
+    return stat;
+  };
+  assert.throws(() => collectLegacyFlatSourceReceipts({ userData, fileSystem: injected }),
+    /changed while opening/u);
+});
+
+test('same-inode same-size modification during hashing fails closed', (t) => {
+  const { userData, paths } = fixture(t);
+  writePrivate(paths.settings, 'settings');
+  const injected = Object.create(fs);
+  let fstats = 0;
+  injected.fstatSync = (descriptor) => {
+    const stat = fs.fstatSync(descriptor);
+    if (++fstats === 2) {
+      return {
+        ...stat,
+        mtimeMs: stat.mtimeMs + 1,
+        isFile: () => true,
+      };
+    }
+    return stat;
+  };
+  assert.throws(() => collectLegacyFlatSourceReceipts({ userData, fileSystem: injected }),
+    /changed while reading/u);
+});
+
+test('short reads and disappearance after observed presence fail closed', (t) => {
+  const { userData, paths } = fixture(t);
+  writePrivate(paths.settings, 'settings');
+  const shortRead = Object.create(fs);
+  shortRead.readSync = () => 0;
+  assert.throws(() => collectLegacyFlatSourceReceipts({ userData, fileSystem: shortRead }),
+    /incomplete/u);
+
+  const disappearing = Object.create(fs);
+  disappearing.openSync = (file, ...args) => {
+    if (file === paths.settings) {
+      fs.unlinkSync(file);
+      const error = new Error('disappeared');
+      error.code = 'ENOENT';
+      throw error;
+    }
+    return fs.openSync(file, ...args);
+  };
+  assert.throws(() => collectLegacyFlatSourceReceipts({ userData, fileSystem: disappearing }),
+    /could not be opened/u);
+});
+
+test('simulated Windows collection requires current-user-only ACL verification', (t) => {
+  const { userData, paths } = fixture(t);
+  writePrivate(paths.settings, 'settings');
+  assert.throws(() => collectLegacyFlatSourceReceipts({
+    userData,
+    platform: 'win32',
+    windowsAcl: { verify: () => false },
+  }), /Windows ACL/u);
+  const verified = [];
+  const receipts = collectLegacyFlatSourceReceipts({
+    userData,
+    platform: 'win32',
+    windowsAcl: { verify(file) { verified.push(file); return true; } },
+  });
+  assert.equal(receipts.settings.present, true);
+  assert.deepEqual(verified, [paths.settings]);
+});

--- a/desktop/test/profile-workspace-storage.test.js
+++ b/desktop/test/profile-workspace-storage.test.js
@@ -195,6 +195,9 @@ test('P3 foundation is packaged but does not activate migration in production Ma
     'profile-workspace-layout',
     'profile-workspace-migration-journal',
     'profile-workspace-migration-store',
+    'legacy-flat-source-receipts',
+    'vpn-credential-envelope',
+    'vpn-credential-envelope-store',
   ]) {
     assert.equal(main.includes(moduleName), false);
   }

--- a/desktop/test/vpn-credential-envelope-store.test.js
+++ b/desktop/test/vpn-credential-envelope-store.test.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  VpnCredentialEnvelopeStore,
+} = require('../lib/vpn-credential-envelope-store');
+
+function fixture(t) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-vpn-envelope-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return { directory, file: path.join(directory, 'account', 'vpn-credential.bin') };
+}
+
+test('encrypted envelope store saves, loads and durably removes one owner-only blob', (t) => {
+  const { file } = fixture(t);
+  const store = new VpnCredentialEnvelopeStore({ filePath: file });
+  const encrypted = Buffer.from('synthetic-encrypted-envelope');
+
+  assert.equal(store.load(), null);
+  assert.equal(store.save(encrypted), true);
+  assert.deepEqual(store.load(), encrypted);
+  if (process.platform !== 'win32') assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+  assert.equal(store.remove(), true);
+  assert.equal(store.load(), null);
+  assert.equal(store.remove(), false);
+});
+
+test('failed atomic replacement preserves the previous encrypted envelope', (t) => {
+  const { file } = fixture(t);
+  const original = Buffer.from('old-encrypted-envelope');
+  const base = new VpnCredentialEnvelopeStore({ filePath: file });
+  base.save(original);
+  const injected = Object.create(fs);
+  injected.renameSync = () => { throw new Error('simulated rename failure'); };
+  const store = new VpnCredentialEnvelopeStore({ filePath: file, fileSystem: injected });
+
+  assert.throws(() => store.save(Buffer.from('new-encrypted-envelope')), /save failed/u);
+  assert.deepEqual(base.load(), original);
+});
+
+test('post-rename directory fsync failure reports that the new envelope became visible', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const { file } = fixture(t);
+  const injected = Object.create(fs);
+  let fsyncs = 0;
+  injected.fsyncSync = (descriptor) => {
+    if (++fsyncs === 2) throw new Error('simulated directory fsync failure');
+    return fs.fsyncSync(descriptor);
+  };
+  const store = new VpnCredentialEnvelopeStore({ filePath: file, fileSystem: injected });
+  const next = Buffer.from('new-encrypted-envelope');
+  assert.throws(() => store.save(next), (error) => (
+    /save failed/u.test(error.message) && error.commitApplied === true
+  ));
+  assert.deepEqual(new VpnCredentialEnvelopeStore({ filePath: file }).load(), next);
+});
+
+test('envelope store rejects links and broad POSIX permissions', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const { directory, file } = fixture(t);
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const unrelated = path.join(directory, 'unrelated.bin');
+  fs.writeFileSync(unrelated, 'encrypted', { mode: 0o600 });
+  fs.symlinkSync(unrelated, file);
+  assert.throws(() => new VpnCredentialEnvelopeStore({ filePath: file }).load(), /private file/u);
+  fs.unlinkSync(file);
+  fs.linkSync(unrelated, file);
+  assert.throws(() => new VpnCredentialEnvelopeStore({ filePath: file }).load(), /private file/u);
+  fs.unlinkSync(file);
+  fs.copyFileSync(unrelated, file);
+  fs.chmodSync(file, 0o644);
+  assert.throws(() => new VpnCredentialEnvelopeStore({ filePath: file }).load(), /private file/u);
+});
+
+test('observed encrypted envelope disappearance fails closed', (t) => {
+  const { file } = fixture(t);
+  const base = new VpnCredentialEnvelopeStore({ filePath: file });
+  base.save(Buffer.from('encrypted'));
+  const injected = Object.create(fs);
+  let stats = 0;
+  injected.lstatSync = (value, ...args) => {
+    if (value === file && ++stats === 2) {
+      fs.unlinkSync(file);
+      const error = new Error('disappeared');
+      error.code = 'ENOENT';
+      throw error;
+    }
+    return fs.lstatSync(value, ...args);
+  };
+  const store = new VpnCredentialEnvelopeStore({ filePath: file, fileSystem: injected });
+  assert.throws(() => store.load(), /disappeared/u);
+});
+
+test('simulated Windows envelope storage protects and verifies ACLs', (t) => {
+  const { file } = fixture(t);
+  const protectedPaths = [];
+  const verifiedPaths = [];
+  const windowsAcl = {
+    protect(value) { protectedPaths.push(value); return true; },
+    verify(value) { verifiedPaths.push(value); return fs.existsSync(value); },
+  };
+  const store = new VpnCredentialEnvelopeStore({
+    filePath: file,
+    platform: 'win32',
+    windowsAcl,
+  });
+  assert.equal(store.load(), null);
+  assert.equal(verifiedPaths.length, 0);
+  store.save(Buffer.from('encrypted'));
+  assert.deepEqual(store.load(), Buffer.from('encrypted'));
+  assert.equal(protectedPaths.some((value) => value.endsWith('.tmp')), true);
+  assert.equal(verifiedPaths.includes(file), true);
+});

--- a/desktop/test/vpn-credential-envelope.test.js
+++ b/desktop/test/vpn-credential-envelope.test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  decryptVpnCredentialEnvelope,
+  encryptVpnCredentialEnvelope,
+} = require('../lib/vpn-credential-envelope');
+
+function fakeSafeStorage() {
+  return {
+    isEncryptionAvailable: () => true,
+    getSelectedStorageBackend: () => 'keychain',
+    encryptString(value) {
+      return Buffer.from(value, 'utf8').map((byte) => byte ^ 0xa5);
+    },
+    decryptString(value) {
+      return Buffer.from(value).map((byte) => byte ^ 0xa5).toString('utf8');
+    },
+  };
+}
+
+function binding(overrides = {}) {
+  return {
+    profileId: 'hkustgz',
+    profileCredentialBindingRevision: 1,
+    accountKey: `account-${'22'.repeat(16)}`,
+    accountCredentialRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
+    ...overrides,
+  };
+}
+
+test('username and password commit as one encrypted profile/account-bound envelope', () => {
+  const safeStorage = fakeSafeStorage();
+  const encrypted = encryptVpnCredentialEnvelope({
+    binding: binding(),
+    credentialVersion: 1,
+    username: 'legacy-user',
+    password: 'private-password',
+    updatedAt: 1_700_000_000_000,
+    safeStorage,
+    platform: 'darwin',
+  });
+  assert.equal(Buffer.isBuffer(encrypted), true);
+  assert.equal(encrypted.includes(Buffer.from('legacy-user')), false);
+  assert.equal(encrypted.includes(Buffer.from('private-password')), false);
+
+  const decrypted = decryptVpnCredentialEnvelope(encrypted, {
+    expectedBinding: binding(),
+    safeStorage,
+    platform: 'darwin',
+  });
+  assert.equal(decrypted.credentialVersion, 1);
+  assert.equal(Object.isFrozen(decrypted), true);
+  assert.equal(decrypted.withStrings((username, password) => (
+    `${username}:${password}`
+  )), 'legacy-user:private-password');
+  assert.equal(JSON.stringify(decrypted), '"[redacted vpn credential]"');
+  assert.equal(String(decrypted).includes('legacy-user'), false);
+  assert.equal(decrypted.destroy(), true);
+  assert.equal(decrypted.destroy(), false);
+  assert.throws(() => decrypted.withStrings(() => true), /destroyed/u);
+});
+
+test('binding mismatch fails before returning a credential owner', () => {
+  const safeStorage = fakeSafeStorage();
+  const encrypted = encryptVpnCredentialEnvelope({
+    binding: binding(),
+    credentialVersion: 1,
+    username: 'legacy-user',
+    password: 'private-password',
+    updatedAt: 1_700_000_000_000,
+    safeStorage,
+    platform: 'darwin',
+  });
+  for (const expectedBinding of [
+    binding({ accountKey: `account-${'33'.repeat(16)}` }),
+    binding({ accountCredentialRevision: 2 }),
+    binding({ gatewayOrigin: 'https://other.example.edu' }),
+  ]) {
+    assert.throws(() => decryptVpnCredentialEnvelope(encrypted, {
+      expectedBinding,
+      safeStorage,
+      platform: 'darwin',
+    }), /binding/u);
+  }
+});
+
+test('envelope schema rejects controls, unknown fields and unsupported plaintext storage', () => {
+  const safeStorage = fakeSafeStorage();
+  const base = {
+    binding: binding(),
+    credentialVersion: 1,
+    username: 'legacy-user',
+    password: 'private-password',
+    updatedAt: 1_700_000_000_000,
+    safeStorage,
+    platform: 'darwin',
+  };
+  assert.throws(() => encryptVpnCredentialEnvelope({ ...base, username: 'bad\nuser' }),
+    /credential/u);
+  assert.throws(() => encryptVpnCredentialEnvelope({ ...base, password: '' }),
+    /credential/u);
+  assert.throws(() => encryptVpnCredentialEnvelope({
+    ...base,
+    platform: 'linux',
+    safeStorage: { ...safeStorage, getSelectedStorageBackend: () => 'basic_text' },
+  }), /protected storage/u);
+  assert.throws(() => encryptVpnCredentialEnvelope({
+    ...base,
+    platform: 'linux',
+    safeStorage: {
+      isEncryptionAvailable: () => true,
+      encryptString: safeStorage.encryptString,
+      decryptString: safeStorage.decryptString,
+    },
+  }), /protected storage/u);
+
+  const unknown = safeStorage.encryptString(JSON.stringify({
+    schemaVersion: 1,
+    ...binding(),
+    credentialVersion: 1,
+    username: 'legacy-user',
+    password: 'private-password',
+    updatedAt: 1_700_000_000_000,
+    otp: 'not-allowed',
+  }));
+  assert.throws(() => decryptVpnCredentialEnvelope(unknown, {
+    expectedBinding: binding(), safeStorage, platform: 'darwin',
+  }), /schema/u);
+});

--- a/docs/adr/0008-p3-receipts-and-vpn-envelope.md
+++ b/docs/adr/0008-p3-receipts-and-vpn-envelope.md
@@ -21,7 +21,9 @@ and encrypted password independently could commit a credential for the wrong acc
 ### Legacy receipt collection
 
 `legacy-flat-source-receipts.js` derives the exact existing paths from the normalized `userData` root. Callers
-cannot supply arbitrary source files. Each present source is processed through one no-follow descriptor:
+cannot supply arbitrary source files. The set includes settings/backup, VPN credential, routing/PAC, website
+vault, certificate trust, Engine owner, the existing credential transaction, proxy credential/helper projection,
+and current/rotated/retention log files. Each present source is processed through one no-follow descriptor:
 
 ```text
 lstat and policy check

--- a/docs/adr/0008-p3-receipts-and-vpn-envelope.md
+++ b/docs/adr/0008-p3-receipts-and-vpn-envelope.md
@@ -1,0 +1,79 @@
+# ADR-0008: P3 legacy receipts and bound VPN credential envelope
+
+- Status: Accepted as a non-activating P3b contract
+- Production migration: not enabled by this ADR
+- Parent contracts: [`ADR-0004`](0004-profile-account-workspace-scope.md),
+  [`ADR-0007`](0007-p3-storage-foundation.md)
+
+## Context
+
+ADR-0007 can derive the future storage layout and persist a receipt-bound migration journal, but P3 still needs
+two security-critical inputs before an orchestrator may touch existing state:
+
+1. a stable snapshot receipt for every flat 1.x authority; and
+2. one encrypted object that keeps the legacy username and password paired with their destination account.
+
+Reading by path and hashing later would leave a replacement window. Migrating the current plaintext username
+and encrypted password independently could commit a credential for the wrong account.
+
+## Decision
+
+### Legacy receipt collection
+
+`legacy-flat-source-receipts.js` derives the exact existing paths from the normalized `userData` root. Callers
+cannot supply arbitrary source files. Each present source is processed through one no-follow descriptor:
+
+```text
+lstat and policy check
+  -> Windows DACL verification when applicable
+  -> O_NOFOLLOW open
+  -> fstat identity/version comparison
+  -> bounded chunked SHA-256 with immediate buffer clearing
+  -> final fstat identity/version comparison
+```
+
+The comparison covers device/inode, size, mtime and ctime. POSIX sources must be regular, single-link and
+owner-only. Missing files produce an explicit absent receipt; a file that disappears after observed presence is
+an error. Receipt output contains only `present`, `bytes` and `sha256`, never file contents.
+
+### VPN credential envelope
+
+`vpn-credential-envelope.js` encrypts username and password together with:
+
+```text
+profileId / profileCredentialBindingRevision
+accountKey / accountCredentialRevision
+GatewayOrigin / ProtocolFamily
+credentialVersion / updatedAt
+```
+
+Unknown fields, control characters, empty values, oversized values, an unavailable protected store and Linux
+`basic_text` all fail closed. Decryption requires the exact expected binding before it returns a credential
+owner. The owner keeps username/password in Buffers, redacts JSON/string/inspect output and supports explicit
+zeroizing destruction.
+
+Electron `safeStorage` accepts/returns JavaScript strings, so immutable temporary strings cannot be overwritten.
+The implementation removes references immediately and clears parsed string fields; the persistent and
+longer-lived owner remains Buffer-backed and zeroized.
+
+### Encrypted envelope store
+
+`vpn-credential-envelope-store.js` stores only ciphertext below the account path. It uses an owner-only
+same-directory temporary file, file fsync, atomic rename and directory fsync. Windows protects the temporary
+file and verifies the committed DACL. Reads are bounded/no-follow/single-link; observed disappearance fails
+closed. Replacement failure preserves the prior ciphertext. If rename applied but directory fsync failed, the
+store compares the visible ciphertext in constant time and raises an error with `commitApplied = true` so the
+future migration coordinator can recover rather than repeat blindly.
+
+## Non-activation boundary
+
+Production `desktop/main.js` imports none of these P3b modules. This batch does not decrypt the installed legacy
+credential, write a destination envelope, collect receipts from the actual user profile or move/delete any flat
+file. It introduces no Renderer or IPC surface.
+
+## Deferred work
+
+P3c must gate all flat writers, complete the existing credential/settings recovery first, collect receipts,
+write the full destination tree, re-encrypt the legacy credential in memory, verify destination receipts and
+drive the ADR-0007 journal through all-old/all-new recovery. Legacy authorization-store retirement and rollback
+blob state remain separate required gates.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -620,6 +620,8 @@ Non-activating storage foundation: [`ADR-0007`](../adr/0007-p3-storage-foundatio
 
 - land and verify opaque-key path derivation, exact receipt-bound journal schema and owner-only journal storage
   before production Main imports any P3 module;
+- collect every legacy receipt through one stable opened descriptor and commit username/password only as one
+  encrypted, exact-profile/account/origin/family-bound VPN credential envelope before orchestration is enabled;
 
 - split app-global and profile settings;
 - create `profiles/<profileKey>/accounts/<accountKey>/workspace/` from the start;


### PR DESCRIPTION
## 依赖关系

这是 stacked Draft PR，以 P3a PR #12 分支为 base；PR #11 和 #12 合并后依次重基到 main。

## 目标

为未来 P3 migration coordinator 提供两个缺失的安全输入：稳定的 legacy flat source receipts，以及 username/password 一体提交的 profile/account-bound encrypted envelope。

## 主要变化

- 旧 flat 路径只能从 normalized userData 推导，调用方不能提供任意 source path。
- 每个 present source 通过同一 no-follow descriptor 执行 lstat/fstat、bounded SHA-256、final fstat。
- 比较 device/inode/size/mtime/ctime，拒绝 symlink、hard link、宽权限、超限、短读、原地修改和观察后消失。
- Windows source 需要 current-user-only DACL 验证。
- username/password 与 profile/account credential revision、Gateway origin、ProtocolFamily、credential version 一起加密。
- exact schema 拒绝 unknown fields、控制字符、空值、超限和 Linux basic_text。
- 解密结果由 Main-only Buffer owner 管理，JSON/string/inspect 全部脱敏并支持显式 zeroize。
- ciphertext store 使用 owner-only temporary、fsync、atomic rename、directory fsync 和 Windows DACL。
- rename 已发生但目录 fsync 失败时以 commitApplied 明确报告，不会盲目重复写入。
- 新增 ADR-0008 与架构约束。

## 明确不做

- production main.js 不导入这些模块。
- 不读取本机真实 userData、不解密现有密码、不写目标 envelope。
- 不迁移或删除 settings、credential、Cookie、routing、certificate、vault 或 log。
- 不增加 Renderer/IPC surface。

## 本地验证

- Desktop: 642 passed, 0 failed, 1 Windows-only skip
- P3b focused: 24 passed, 0 failed
- Architecture: PASS, 224 files / 298 edges / 0 cycles
- JavaScript syntax: PASS
- Staged secret gate: PASS
- git diff --check: PASS

大型 Rust 与三平台 package verification 交给 GitHub Actions。