### PR TITLE
2.0 P3d: materialize destination and retire legacy files

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -153,6 +153,11 @@ ProtocolFamily 和 credential version。解密结果由 Main-only zeroizing owne
 destination 时删除 legacy。生产接线前的非激活合同见
 [`ADR-0009`](docs/adr/0009-p3-migration-coordinator.md)。
 
+destination materializer 必须在第一次写入前预检全部 exact-schema target；已存在且 digest 相同可幂等
+复用，任何冲突、link、宽权限或未知文件都不得覆盖。legacy retirement 只能在 committed journal
+下重新验证收据后逐文件 unlink/fsync，禁止递归删除，并把旧 `settings.json` 权威放在最后退休。
+具体非激活适配器合同见 [`ADR-0010`](docs/adr/0010-p3-destination-and-retirement.md)。
+
 ## 5. Connection state machine
 
 ### 5.1 唯一权威状态

--- a/desktop/lib/legacy-flat-source-receipts.js
+++ b/desktop/lib/legacy-flat-source-receipts.js
@@ -4,6 +4,7 @@ const crypto = require('node:crypto');
 const fs = require('node:fs');
 const {
   createLegacyFlatSourcePaths,
+  validateUserDataRoot,
 } = require('./profile-workspace-layout');
 const { LEGACY_SOURCE_IDS } = require('./profile-workspace-migration-journal');
 const { verifyWindowsFileOwnerOnly } = require('./windows-private-file');
@@ -40,20 +41,34 @@ function sameFileVersion(left, right) {
     left.mtimeMs === right.mtimeMs && left.ctimeMs === right.ctimeMs;
 }
 
-function collectOne(file, maxBytes, { fileSystem, platform, windowsAcl }) {
+function collectPrivateFileReceipt({
+  file,
+  maxBytes,
+  fileSystem = fs,
+  platform = process.platform,
+  windowsAcl = { verify: verifyWindowsFileOwnerOnly },
+  label = 'private file',
+} = {}) {
+  if (typeof file !== 'string' || !Number.isSafeInteger(maxBytes) || maxBytes < 1 ||
+      !fileSystem || typeof fileSystem.lstatSync !== 'function' ||
+      !['darwin', 'linux', 'win32'].includes(platform) ||
+      (platform === 'win32' && typeof windowsAcl?.verify !== 'function') ||
+      typeof label !== 'string' || !label) {
+    throw new TypeError('private receipt dependencies are invalid');
+  }
   let before;
   try {
     before = fileSystem.lstatSync(file);
   } catch (error) {
     if (error?.code === 'ENOENT') return absentReceipt();
-    throw invalidSource('legacy source could not be inspected', error);
+    throw invalidSource(`${label} could not be inspected`, error);
   }
   if (!before.isFile() || before.isSymbolicLink() || before.size < 0 || before.size > maxBytes ||
       (platform !== 'win32' && (before.nlink !== 1 || (before.mode & 0o077) !== 0))) {
-    throw invalidSource('legacy source is not a bounded owner-only regular file');
+    throw invalidSource(`${label} is not a bounded owner-only regular file`);
   }
   if (platform === 'win32' && !windowsAcl.verify(file)) {
-    throw invalidSource('legacy source Windows ACL is not current-user-only');
+    throw invalidSource(`${label} Windows ACL is not current-user-only`);
   }
 
   const constants = fileSystem.constants || fs.constants;
@@ -63,12 +78,12 @@ function collectOne(file, maxBytes, { fileSystem, platform, windowsAcl }) {
     try {
       descriptor = fileSystem.openSync(file, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
     } catch (error) {
-      throw invalidSource('legacy source could not be opened after observed presence', error);
+      throw invalidSource(`${label} could not be opened after observed presence`, error);
     }
     const opened = fileSystem.fstatSync(descriptor);
     if (!opened.isFile() || !sameFileVersion(opened, before) || opened.size > maxBytes ||
         (platform !== 'win32' && opened.nlink !== 1)) {
-      throw invalidSource('legacy source changed while opening');
+      throw invalidSource(`${label} changed while opening`);
     }
 
     const hash = crypto.createHash('sha256');
@@ -77,7 +92,7 @@ function collectOne(file, maxBytes, { fileSystem, platform, windowsAcl }) {
     while (offset < opened.size) {
       const requested = Math.min(buffer.length, opened.size - offset);
       const count = fileSystem.readSync(descriptor, buffer, 0, requested, offset);
-      if (!count) throw invalidSource('legacy source read was incomplete');
+      if (!count) throw invalidSource(`${label} read was incomplete`);
       hash.update(buffer.subarray(0, count));
       buffer.fill(0, 0, count);
       offset += count;
@@ -85,7 +100,7 @@ function collectOne(file, maxBytes, { fileSystem, platform, windowsAcl }) {
     const after = fileSystem.fstatSync(descriptor);
     if (!after.isFile() || !sameFileVersion(after, opened) ||
         (platform !== 'win32' && after.nlink !== 1)) {
-      throw invalidSource('legacy source changed while reading');
+      throw invalidSource(`${label} changed while reading`);
     }
     return Object.freeze({
       present: true,
@@ -111,7 +126,17 @@ function collectLegacyFlatSourceReceipts({
       (platform === 'win32' && typeof windowsAcl?.verify !== 'function')) {
     throw new TypeError('legacy receipt dependencies are invalid');
   }
-  const sources = createLegacyFlatSourcePaths(userData);
+  const root = validateUserDataRoot(userData);
+  let rootStat;
+  try {
+    rootStat = fileSystem.lstatSync(root);
+  } catch (error) {
+    throw new Error('legacy source root is unavailable', { cause: error });
+  }
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new Error('legacy source root is not a trusted directory');
+  }
+  const sources = createLegacyFlatSourcePaths(root);
   const keys = Object.keys(sources);
   if (keys.length !== LEGACY_SOURCE_IDS.length ||
       LEGACY_SOURCE_IDS.some((id) => !Object.hasOwn(sources, id))) {
@@ -119,15 +144,19 @@ function collectLegacyFlatSourceReceipts({
   }
   return Object.freeze(Object.fromEntries(LEGACY_SOURCE_IDS.map((id) => [
     id,
-    collectOne(sources[id], LEGACY_SOURCE_MAX_BYTES[id], {
+    collectPrivateFileReceipt({
+      file: sources[id],
+      maxBytes: LEGACY_SOURCE_MAX_BYTES[id],
       fileSystem,
       platform,
       windowsAcl,
+      label: 'legacy source',
     }),
   ])));
 }
 
 module.exports = {
   LEGACY_SOURCE_MAX_BYTES,
+  collectPrivateFileReceipt,
   collectLegacyFlatSourceReceipts,
 };

--- a/desktop/lib/legacy-flat-source-retirement.js
+++ b/desktop/lib/legacy-flat-source-retirement.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  LEGACY_SOURCE_MAX_BYTES,
+  collectLegacyFlatSourceReceipts,
+  collectPrivateFileReceipt,
+} = require('./legacy-flat-source-receipts');
+const {
+  LEGACY_SOURCE_IDS,
+  legacySourceReceiptDigest,
+} = require('./profile-workspace-migration-journal');
+const { createLegacyFlatSourcePaths } = require('./profile-workspace-layout');
+const { verifyWindowsFileOwnerOnly } = require('./windows-private-file');
+
+function sameReceipt(left, right) {
+  return left.present === right.present && left.bytes === right.bytes && left.sha256 === right.sha256;
+}
+
+function fsyncDirectory(directory, fileSystem, platform) {
+  let descriptor = null;
+  try {
+    descriptor = fileSystem.openSync(directory, 'r');
+    fileSystem.fsyncSync?.(descriptor);
+    return true;
+  } catch {
+    return platform === 'win32';
+  } finally {
+    if (descriptor !== null) {
+      try { fileSystem.closeSync(descriptor); } catch {}
+    }
+  }
+}
+
+function retireLegacyFlatSources({
+  userData,
+  expectedReceipts,
+  fileSystem = fs,
+  platform = process.platform,
+  windowsAcl = { verify: verifyWindowsFileOwnerOnly },
+} = {}) {
+  if (!fileSystem || typeof fileSystem.unlinkSync !== 'function' ||
+      !['darwin', 'linux', 'win32'].includes(platform) ||
+      (platform === 'win32' && typeof windowsAcl?.verify !== 'function')) {
+    throw new TypeError('legacy retirement dependencies are invalid');
+  }
+  // Validates exact receipt IDs and shapes before any deletion.
+  legacySourceReceiptDigest(expectedReceipts);
+  const paths = createLegacyFlatSourcePaths(userData);
+  const current = collectLegacyFlatSourceReceipts({ userData, fileSystem, platform, windowsAcl });
+  for (const id of LEGACY_SOURCE_IDS) {
+    if (!expectedReceipts[id].present && current[id].present) {
+      throw new Error(`unexpected legacy source appeared: ${id}`);
+    }
+    if (expectedReceipts[id].present && current[id].present &&
+        !sameReceipt(expectedReceipts[id], current[id])) {
+      throw new Error(`legacy source receipt changed: ${id}`);
+    }
+  }
+
+  // Keep the flat settings authority until every other matched source has
+  // retired. A committed journal makes partial retirement safely resumable.
+  const order = [...LEGACY_SOURCE_IDS.filter((id) => id !== 'settings'), 'settings'];
+  for (const id of order) {
+    if (!expectedReceipts[id].present) continue;
+    const observed = collectPrivateFileReceipt({
+      file: paths[id],
+      maxBytes: LEGACY_SOURCE_MAX_BYTES[id],
+      fileSystem,
+      platform,
+      windowsAcl,
+      label: 'legacy source',
+    });
+    if (!observed.present) continue;
+    if (!sameReceipt(observed, expectedReceipts[id])) {
+      throw new Error(`legacy source receipt changed: ${id}`);
+    }
+    try {
+      fileSystem.unlinkSync(paths[id]);
+    } catch (error) {
+      throw new Error(`legacy source retirement failed: ${id}`, { cause: error });
+    }
+    if (!fsyncDirectory(path.dirname(paths[id]), fileSystem, platform)) {
+      throw new Error(`legacy source retirement was not durable: ${id}`);
+    }
+  }
+
+  const after = collectLegacyFlatSourceReceipts({ userData, fileSystem, platform, windowsAcl });
+  if (LEGACY_SOURCE_IDS.some((id) => after[id].present)) {
+    throw new Error('legacy source retirement is incomplete');
+  }
+  return true;
+}
+
+module.exports = { retireLegacyFlatSources };

--- a/desktop/lib/profile-workspace-destination-files.js
+++ b/desktop/lib/profile-workspace-destination-files.js
@@ -1,0 +1,261 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { atomicWritePrivateFile } = require('./credential-store');
+const {
+  collectPrivateFileReceipt,
+} = require('./legacy-flat-source-receipts');
+const { DESTINATION_RECEIPT_IDS } = require('./profile-workspace-migration-journal');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+const MAX_DESTINATION_FILE_BYTES = 16 * 1024 * 1024;
+
+function destinationPathMap(layout) {
+  if (!layout?.global || !layout?.profile || !layout?.account || !layout?.workspace) {
+    throw new TypeError('profile workspace layout is invalid');
+  }
+  const values = {
+    globalSettings: layout.global.settings,
+    globalProxyCredential: layout.global.proxyCredential,
+    globalProxyHelperCredential: layout.global.proxyHelperCredential,
+    globalEngineOwner: layout.global.engineOwner,
+    globalUpdateState: layout.global.updateState,
+    globalActiveContextSwitch: layout.global.activeContextSwitch,
+    profileSettings: layout.profile.settings,
+    profileState: layout.profile.state,
+    account: layout.account.document,
+    vpnCredential: layout.account.vpnCredential,
+    credentialTransaction: layout.account.credentialTransaction,
+    deletionTombstone: layout.account.deletionTombstone,
+    workspaceState: layout.workspace.state,
+    siteCredentials: layout.workspace.siteCredentials,
+    certificateTrust: layout.workspace.certificateTrust,
+    routingRules: layout.workspace.routingRules,
+    externalPac: layout.workspace.externalPac,
+    browserPac: layout.workspace.browserPac,
+    localResources: layout.workspace.localResources,
+    favorites: layout.workspace.favorites,
+    recentResources: layout.workspace.recentResources,
+    externalIntegrations: layout.workspace.externalIntegrations,
+    engineLog: layout.workspace.engineLog,
+    engineLogRotated: layout.workspace.engineLogRotated,
+    engineLogRetention: layout.workspace.engineLogRetention,
+  };
+  if (DESTINATION_RECEIPT_IDS.some((id) => typeof values[id] !== 'string') ||
+      Object.keys(values).length !== DESTINATION_RECEIPT_IDS.length ||
+      new Set(Object.values(values)).size !== DESTINATION_RECEIPT_IDS.length) {
+    throw new TypeError('destination path map does not match the journal schema');
+  }
+  const root = layout.root;
+  if (typeof root !== 'string' || !path.isAbsolute(root) || path.resolve(root) !== root ||
+      Object.values(values).some((file) => {
+        if (!path.isAbsolute(file) || path.resolve(file) !== file) return true;
+        const relative = path.relative(root, file);
+        return !relative || relative === '..' || relative.startsWith(`..${path.sep}`) ||
+          path.isAbsolute(relative);
+      })) {
+    throw new TypeError('destination path escapes the profile workspace root');
+  }
+  return Object.freeze(Object.fromEntries(DESTINATION_RECEIPT_IDS.map((id) => [id, values[id]])));
+}
+
+function exactFilePlan(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError('destination file plan must be a plain object');
+  }
+  const keys = Object.keys(value).sort();
+  const expected = [...DESTINATION_RECEIPT_IDS].sort();
+  if (keys.length !== expected.length || keys.some((key, index) => key !== expected[index])) {
+    throw new TypeError('destination file plan does not match the journal schema');
+  }
+  for (const id of DESTINATION_RECEIPT_IDS) {
+    if (value[id] !== null && (!Buffer.isBuffer(value[id]) || value[id].length < 1 ||
+        value[id].length > MAX_DESTINATION_FILE_BYTES)) {
+      throw new TypeError(`destination file ${id} is invalid`);
+    }
+  }
+  return value;
+}
+
+function receiptFor(file, { fileSystem, platform, windowsAcl }) {
+  return collectPrivateFileReceipt({
+    file,
+    maxBytes: MAX_DESTINATION_FILE_BYTES,
+    fileSystem,
+    platform,
+    windowsAcl,
+    label: 'destination file',
+  });
+}
+
+function expectedReceipt(data) {
+  if (data === null) return Object.freeze({ present: false, bytes: 0, sha256: null });
+  return Object.freeze({
+    present: true,
+    bytes: data.length,
+    sha256: crypto.createHash('sha256').update(data).digest('hex'),
+  });
+}
+
+function sameReceipt(left, right) {
+  return left.present === right.present && left.bytes === right.bytes && left.sha256 === right.sha256;
+}
+
+function fsyncDirectory(directory, fileSystem, platform) {
+  let descriptor = null;
+  try {
+    descriptor = fileSystem.openSync(directory, 'r');
+    fileSystem.fsyncSync?.(descriptor);
+    return true;
+  } catch {
+    return platform === 'win32';
+  } finally {
+    if (descriptor !== null) {
+      try { fileSystem.closeSync(descriptor); } catch {}
+    }
+  }
+}
+
+function verifyDirectoryChain(root, directory, deps, { create = false } = {}) {
+  const relative = path.relative(root, directory);
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error('destination directory escapes the workspace root');
+  }
+  let rootStat;
+  try {
+    rootStat = deps.fileSystem.lstatSync(root);
+  } catch (error) {
+    throw new Error('destination root is unavailable', { cause: error });
+  }
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new Error('destination root is not a trusted directory');
+  }
+  let current = root;
+  for (const component of relative.split(path.sep).filter(Boolean)) {
+    current = path.join(current, component);
+    let stat;
+    try {
+      stat = deps.fileSystem.lstatSync(current);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+      if (!create) return false;
+      try {
+        deps.fileSystem.mkdirSync(current, { mode: 0o700 });
+        stat = deps.fileSystem.lstatSync(current);
+      } catch (mkdirError) {
+        throw new Error('destination directory creation failed', { cause: mkdirError });
+      }
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink() ||
+        (deps.platform !== 'win32' && (stat.mode & 0o077) !== 0)) {
+      throw new Error('destination directory is not owner-only and link-free');
+    }
+  }
+  return true;
+}
+
+function storageOptions(platform, windowsAcl) {
+  return platform === 'win32' ? {
+    protectTemporary: (temporary) => windowsAcl.protect(temporary) === true,
+    verifyCommitted: (committed) => windowsAcl.verify(committed) === true,
+    removeCommittedOnFailure: true,
+  } : {};
+}
+
+function dependencies({ fileSystem = fs, platform = process.platform, windowsAcl = {
+  protect: protectWindowsFileOwnerOnly,
+  verify: verifyWindowsFileOwnerOnly,
+} } = {}) {
+  if (!fileSystem || typeof fileSystem.openSync !== 'function' ||
+      !['darwin', 'linux', 'win32'].includes(platform) ||
+      (platform === 'win32' &&
+        (typeof windowsAcl?.protect !== 'function' || typeof windowsAcl?.verify !== 'function'))) {
+    throw new TypeError('destination file dependencies are invalid');
+  }
+  return { fileSystem, platform, windowsAcl };
+}
+
+function verifyDestinationFiles({ layout, fileSystem, platform, windowsAcl } = {}) {
+  const deps = dependencies({ fileSystem, platform, windowsAcl });
+  const paths = destinationPathMap(layout);
+  return Object.freeze(Object.fromEntries(DESTINATION_RECEIPT_IDS.map((id) => [
+    id,
+    verifyDirectoryChain(layout.root, path.dirname(paths[id]), deps)
+      ? receiptFor(paths[id], deps)
+      : Object.freeze({ present: false, bytes: 0, sha256: null }),
+  ])));
+}
+
+function materializeDestinationFiles({ layout, files, fileSystem, platform, windowsAcl } = {}) {
+  const deps = dependencies({ fileSystem, platform, windowsAcl });
+  const plan = exactFilePlan(files);
+  const paths = destinationPathMap(layout);
+  const expected = Object.fromEntries(DESTINATION_RECEIPT_IDS.map((id) => [
+    id,
+    expectedReceipt(plan[id]),
+  ]));
+
+  for (const directory of new Set(Object.values(paths).map(path.dirname))) {
+    verifyDirectoryChain(layout.root, directory, deps);
+  }
+
+  // Preflight every target before the first write. Existing matching files are
+  // valid idempotent recovery; any other entry blocks the whole attempt.
+  const before = {};
+  for (const id of DESTINATION_RECEIPT_IDS) {
+    before[id] = receiptFor(paths[id], deps);
+    if (before[id].present && !sameReceipt(before[id], expected[id])) {
+      throw new Error(`destination file conflict: ${id}`);
+    }
+  }
+
+  for (const directory of new Set(Object.values(paths).map(path.dirname))) {
+    verifyDirectoryChain(layout.root, directory, deps, { create: true });
+  }
+
+  const touchedDirectories = new Set();
+  for (const id of DESTINATION_RECEIPT_IDS) {
+    if (plan[id] === null || before[id].present) continue;
+    const file = paths[id];
+    if (!atomicWritePrivateFile(
+      file,
+      plan[id],
+      deps.fileSystem,
+      storageOptions(deps.platform, deps.windowsAcl),
+    )) {
+      const observed = receiptFor(file, deps);
+      const error = new Error(`destination file write failed: ${id}`);
+      error.commitApplied = sameReceipt(observed, expected[id]);
+      throw error;
+    }
+    touchedDirectories.add(path.dirname(file));
+  }
+
+  for (const directory of new Set(Object.values(paths).map(path.dirname))) {
+    if (!fsyncDirectory(directory, deps.fileSystem, deps.platform)) {
+      const error = new Error('destination directory fsync failed');
+      error.commitApplied = touchedDirectories.has(directory);
+      throw error;
+    }
+  }
+  const observed = verifyDestinationFiles({ layout, ...deps });
+  for (const id of DESTINATION_RECEIPT_IDS) {
+    if (!sameReceipt(observed[id], expected[id])) {
+      throw new Error(`destination verification failed: ${id}`);
+    }
+  }
+  return observed;
+}
+
+module.exports = {
+  MAX_DESTINATION_FILE_BYTES,
+  destinationPathMap,
+  materializeDestinationFiles,
+  verifyDestinationFiles,
+};

--- a/desktop/lib/profile-workspace-migration-coordinator.js
+++ b/desktop/lib/profile-workspace-migration-coordinator.js
@@ -145,7 +145,8 @@ class ProfileWorkspaceMigrationCoordinator {
     });
 
     if (journal.state === 'prepared') {
-      if (!bool(synchronous(this.legacyAuthorityExists(), 'legacy authority inspection'),
+      const context = Object.freeze({ journal, layout });
+      if (!bool(synchronous(this.legacyAuthorityExists(context), 'legacy authority inspection'),
         'legacy authority inspection')) {
         return result(false, 'blocked', 'none', 'LEGACY_AUTHORITY_MISSING');
       }
@@ -157,7 +158,7 @@ class ProfileWorkspaceMigrationCoordinator {
         return result(false, 'blocked', 'legacy', 'LEGACY_SOURCE_CHANGED');
       }
       const destinationReceipts = synchronous(
-        this.buildDestination(Object.freeze({ journal, layout })),
+        this.buildDestination(context),
         'destination build',
       );
       const committed = commitMigrationJournal(journal, {
@@ -186,25 +187,26 @@ class ProfileWorkspaceMigrationCoordinator {
       }
     }
 
-    if (!bool(synchronous(this.destinationAuthorityExists(), 'destination authority inspection'),
+    const context = Object.freeze({ journal, layout });
+    if (!bool(synchronous(this.destinationAuthorityExists(context), 'destination authority inspection'),
       'destination authority inspection')) {
       return result(false, 'blocked', 'destination', 'DESTINATION_MISSING');
     }
     const observedDestination = synchronous(
-      this.verifyDestination(Object.freeze({ journal, layout })),
+      this.verifyDestination(context),
       'destination verification',
     );
     if (destinationReceiptDigest(observedDestination) !== journal.destinationSetSha256) {
       return result(false, 'blocked', 'destination', 'DESTINATION_CHANGED');
     }
     if (synchronous(
-      this.retireLegacy(Object.freeze({ journal, layout })),
+      this.retireLegacy(context),
       'legacy retirement',
-    ) !== true || bool(synchronous(this.legacyAuthorityExists(), 'legacy authority inspection'),
+    ) !== true || bool(synchronous(this.legacyAuthorityExists(context), 'legacy authority inspection'),
       'legacy authority inspection')) {
       return result(false, 'blocked', 'destination', 'LEGACY_RETIREMENT_UNCONFIRMED');
     }
-    if (!bool(synchronous(this.destinationAuthorityExists(), 'destination authority inspection'),
+    if (!bool(synchronous(this.destinationAuthorityExists(context), 'destination authority inspection'),
       'destination authority inspection')) {
       return result(false, 'blocked', 'none', 'DESTINATION_MISSING');
     }

--- a/desktop/lib/profile-workspace-migration-journal.js
+++ b/desktop/lib/profile-workspace-migration-journal.js
@@ -27,6 +27,11 @@ const LEGACY_SOURCE_IDS = Object.freeze([
   'engineLogRotated',
   'engineLogRetention',
 ]);
+const REQUIRED_ABSENT_LEGACY_SOURCE_IDS = Object.freeze([
+  'engineOwner',
+  'credentialTransaction',
+  'proxyHelperCredential',
+]);
 const DESTINATION_RECEIPT_IDS = Object.freeze([
   'globalSettings',
   'globalProxyCredential',
@@ -182,6 +187,9 @@ function validateMigrationJournal(value) {
     LEGACY_SOURCE_IDS,
     'source receipt set',
   );
+  if (REQUIRED_ABSENT_LEGACY_SOURCE_IDS.some((id) => sourceReceipts[id].present)) {
+    throw new TypeError('legacy migration precondition source must be absent');
+  }
   const expectedSourceDigest = receiptSetDigest(sourceReceipts, LEGACY_SOURCE_IDS);
   if (source.sourceSetSha256 !== expectedSourceDigest) {
     throw new TypeError('source receipt set digest does not match');
@@ -313,6 +321,7 @@ function commitMigrationJournal(document, { destinationReceipts, now = Date.now 
 module.exports = {
   DESTINATION_RECEIPT_IDS,
   LEGACY_SOURCE_IDS,
+  REQUIRED_ABSENT_LEGACY_SOURCE_IDS,
   MIGRATION_JOURNAL_VERSION,
   commitMigrationJournal,
   createPreparedMigrationJournal,

--- a/desktop/test/legacy-flat-source-receipts.test.js
+++ b/desktop/test/legacy-flat-source-receipts.test.js
@@ -92,6 +92,19 @@ test('receipt collection rejects links, broad permissions and oversized sources'
   assert.throws(() => collectLegacyFlatSourceReceipts({ userData }), /legacy source/u);
 });
 
+test('symlinked userData root is rejected before any source inspection', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const target = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-legacy-root-target-'));
+  const link = `${target}-link`;
+  fs.symlinkSync(target, link);
+  t.after(() => {
+    try { fs.unlinkSync(link); } catch {}
+    fs.rmSync(target, { recursive: true, force: true });
+  });
+  assert.throws(() => collectLegacyFlatSourceReceipts({ userData: link }), /trusted directory/u);
+});
+
 test('replacement between lstat and opened descriptor fails closed', (t) => {
   const { userData, paths } = fixture(t);
   writePrivate(paths.settings, 'settings');

--- a/desktop/test/legacy-flat-source-retirement.test.js
+++ b/desktop/test/legacy-flat-source-retirement.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { collectLegacyFlatSourceReceipts } = require('../lib/legacy-flat-source-receipts');
+const { retireLegacyFlatSources } = require('../lib/legacy-flat-source-retirement');
+const { createLegacyFlatSourcePaths } = require('../lib/profile-workspace-layout');
+
+function fixture(t) {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-legacy-retirement-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const paths = createLegacyFlatSourcePaths(userData);
+  for (const id of ['settings', 'settingsBackup', 'vpnCredential', 'routingRules',
+    'proxyCredential', 'engineLog', 'engineLogRotated', 'engineLogRetention']) {
+    fs.writeFileSync(paths[id], `synthetic-${id}`, { mode: 0o600 });
+  }
+  return { userData, paths, expected: collectLegacyFlatSourceReceipts({ userData }) };
+}
+
+test('retirement removes only receipt-matched sources and settings authority last', (t) => {
+  const { userData, paths, expected } = fixture(t);
+  const removed = [];
+  const injected = Object.create(fs);
+  injected.unlinkSync = (file) => { removed.push(file); return fs.unlinkSync(file); };
+  assert.equal(retireLegacyFlatSources({ userData, expectedReceipts: expected, fileSystem: injected }),
+    true);
+  assert.equal(removed.at(-1), paths.settings);
+  assert.equal(Object.values(paths).some((file) => fs.existsSync(file)), false);
+  assert.equal(retireLegacyFlatSources({ userData, expectedReceipts: expected }), true);
+});
+
+test('one mismatched source blocks before any retirement side effect', (t) => {
+  const { userData, paths, expected } = fixture(t);
+  fs.writeFileSync(paths.routingRules, 'changed', { mode: 0o600 });
+  assert.throws(() => retireLegacyFlatSources({ userData, expectedReceipts: expected }),
+    /receipt changed/u);
+  assert.equal(fs.existsSync(paths.settings), true);
+  assert.equal(fs.existsSync(paths.vpnCredential), true);
+});
+
+test('unexpected source appearing where receipt proved absence blocks retirement', (t) => {
+  const { userData, paths, expected } = fixture(t);
+  fs.writeFileSync(paths.siteCredentials, 'unexpected', { mode: 0o600 });
+  assert.throws(() => retireLegacyFlatSources({ userData, expectedReceipts: expected }),
+    /unexpected legacy source/u);
+  assert.equal(fs.existsSync(paths.settings), true);
+});
+
+test('partial unlink failure keeps settings authority and retry completes idempotently', (t) => {
+  const { userData, paths, expected } = fixture(t);
+  const injected = Object.create(fs);
+  let unlinks = 0;
+  injected.unlinkSync = (file) => {
+    if (++unlinks === 3) throw new Error('simulated unlink failure');
+    return fs.unlinkSync(file);
+  };
+  assert.throws(() => retireLegacyFlatSources({
+    userData,
+    expectedReceipts: expected,
+    fileSystem: injected,
+  }), /retirement failed/u);
+  assert.equal(fs.existsSync(paths.settings), true);
+  assert.equal(retireLegacyFlatSources({ userData, expectedReceipts: expected }), true);
+  assert.equal(fs.existsSync(paths.settings), false);
+});
+
+test('directory fsync failure after unlink remains retryable under committed journal', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const { userData, paths, expected } = fixture(t);
+  const injected = Object.create(fs);
+  let directoryFsyncs = 0;
+  injected.fsyncSync = (descriptor) => {
+    if (fs.fstatSync(descriptor).isDirectory() && ++directoryFsyncs === 1) {
+      throw new Error('simulated directory fsync failure');
+    }
+    return fs.fsyncSync(descriptor);
+  };
+  assert.throws(() => retireLegacyFlatSources({
+    userData,
+    expectedReceipts: expected,
+    fileSystem: injected,
+  }), /not durable/u);
+  assert.equal(fs.existsSync(paths.settings), true);
+  assert.equal(retireLegacyFlatSources({ userData, expectedReceipts: expected }), true);
+});
+
+test('simulated Windows retirement verifies every present source ACL', (t) => {
+  const { userData, expected } = fixture(t);
+  const verified = [];
+  assert.equal(retireLegacyFlatSources({
+    userData,
+    expectedReceipts: expected,
+    platform: 'win32',
+    windowsAcl: { verify(file) { verified.push(file); return true; } },
+  }), true);
+  assert.equal(verified.length, 2 * Object.values(expected).filter((entry) => entry.present).length);
+});

--- a/desktop/test/profile-workspace-destination-files.test.js
+++ b/desktop/test/profile-workspace-destination-files.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { DESTINATION_RECEIPT_IDS } = require('../lib/profile-workspace-migration-journal');
+const { createProfileAccountWorkspaceLayout } = require('../lib/profile-workspace-layout');
+const {
+  destinationPathMap,
+  materializeDestinationFiles,
+  verifyDestinationFiles,
+} = require('../lib/profile-workspace-destination-files');
+
+const ABSENT_IDS = new Set([
+  'globalProxyHelperCredential',
+  'globalEngineOwner',
+  'globalActiveContextSwitch',
+  'credentialTransaction',
+  'deletionTombstone',
+]);
+
+function fixture(t) {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-destination-files-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const layout = createProfileAccountWorkspaceLayout({
+    userData,
+    profileKey: `profile-${'11'.repeat(16)}`,
+    accountKey: `account-${'22'.repeat(16)}`,
+    workspaceKey: `workspace-${'33'.repeat(16)}`,
+    adoptLegacyHkustBrowserPartition: true,
+  });
+  const files = Object.freeze(Object.fromEntries(DESTINATION_RECEIPT_IDS.map((id) => [
+    id,
+    ABSENT_IDS.has(id) ? null : Buffer.from(`synthetic-${id}`, 'utf8'),
+  ])));
+  return { userData, layout, files };
+}
+
+test('destination path map covers every journal receipt under opaque roots', (t) => {
+  const { userData, layout } = fixture(t);
+  const paths = destinationPathMap(layout);
+  assert.deepEqual(Object.keys(paths), [...DESTINATION_RECEIPT_IDS]);
+  for (const file of Object.values(paths)) {
+    assert.equal(path.relative(userData, file).startsWith('..'), false);
+    assert.equal(file.includes('hkustgz'), false);
+    assert.equal(file.includes('remote.hkust-gz.edu.cn'), false);
+    assert.equal(file.includes('student001'), false);
+  }
+});
+
+test('destination path map rejects lexical escape even when leaf names look valid', (t) => {
+  const { layout } = fixture(t);
+  const malicious = {
+    ...layout,
+    global: { ...layout.global, settings: path.resolve('/tmp/outside-settings.json') },
+  };
+  assert.throws(() => destinationPathMap(malicious), /escapes/u);
+});
+
+test('materializer writes every present file once and verifies exact receipts idempotently', (t) => {
+  const { layout, files } = fixture(t);
+  const first = materializeDestinationFiles({ layout, files });
+  assert.deepEqual(verifyDestinationFiles({ layout }), first);
+  for (const id of DESTINATION_RECEIPT_IDS) {
+    assert.equal(first[id].present, !ABSENT_IDS.has(id));
+  }
+  const paths = destinationPathMap(layout);
+  const before = fs.statSync(paths.globalSettings);
+  assert.deepEqual(materializeDestinationFiles({ layout, files }), first);
+  const after = fs.statSync(paths.globalSettings);
+  assert.equal(after.ino, before.ino);
+  assert.equal(after.mtimeMs, before.mtimeMs);
+});
+
+test('mismatched destination blocks without overwriting any existing file', (t) => {
+  const { layout, files } = fixture(t);
+  const paths = destinationPathMap(layout);
+  fs.mkdirSync(path.dirname(paths.globalSettings), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(paths.globalSettings, 'unexpected', { mode: 0o600 });
+  assert.throws(() => materializeDestinationFiles({ layout, files }), /conflict/u);
+  assert.equal(fs.readFileSync(paths.globalSettings, 'utf8'), 'unexpected');
+  assert.equal(fs.existsSync(paths.profileState), false);
+});
+
+test('symlinked destination is rejected without touching its target', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const { userData, layout, files } = fixture(t);
+  const paths = destinationPathMap(layout);
+  const target = path.join(userData, 'unrelated');
+  fs.mkdirSync(path.dirname(paths.globalSettings), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(target, 'unrelated', { mode: 0o600 });
+  fs.symlinkSync(target, paths.globalSettings);
+  assert.throws(() => materializeDestinationFiles({ layout, files }), /destination file/u);
+  assert.equal(fs.readFileSync(target, 'utf8'), 'unrelated');
+});
+
+test('symlinked parent directory is rejected before the first destination write', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const { userData, layout, files } = fixture(t);
+  const unrelated = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-unrelated-destination-'));
+  t.after(() => fs.rmSync(unrelated, { recursive: true, force: true }));
+  fs.symlinkSync(unrelated, path.join(userData, 'global'));
+  assert.throws(() => materializeDestinationFiles({ layout, files }), /link-free/u);
+  assert.deepEqual(fs.readdirSync(unrelated), []);
+});
+
+test('atomic rename failure leaves an existing destination untouched', (t) => {
+  const { layout, files } = fixture(t);
+  const injected = Object.create(fs);
+  injected.renameSync = () => { throw new Error('simulated rename failure'); };
+  assert.throws(() => materializeDestinationFiles({ layout, files, fileSystem: injected }),
+    /write failed/u);
+  const paths = destinationPathMap(layout);
+  assert.equal(fs.existsSync(paths.globalSettings), false);
+});
+
+test('simulated Windows destination files are ACL-protected and verified', (t) => {
+  const { layout, files } = fixture(t);
+  const protectedPaths = [];
+  const verifiedPaths = [];
+  const windowsAcl = {
+    protect(file) { protectedPaths.push(file); return true; },
+    verify(file) { verifiedPaths.push(file); return fs.existsSync(file); },
+  };
+  materializeDestinationFiles({ layout, files, platform: 'win32', windowsAcl });
+  assert.equal(protectedPaths.some((file) => file.endsWith('.tmp')), true);
+  assert.equal(verifiedPaths.includes(destinationPathMap(layout).globalSettings), true);
+});

--- a/desktop/test/profile-workspace-migration-coordinator.test.js
+++ b/desktop/test/profile-workspace-migration-coordinator.test.js
@@ -8,6 +8,7 @@ const test = require('node:test');
 const {
   DESTINATION_RECEIPT_IDS,
   LEGACY_SOURCE_IDS,
+  REQUIRED_ABSENT_LEGACY_SOURCE_IDS,
   createPreparedMigrationJournal,
 } = require('../lib/profile-workspace-migration-journal');
 const {
@@ -16,6 +17,19 @@ const {
 const {
   ProfileWorkspaceMigrationJournalStore,
 } = require('../lib/profile-workspace-migration-store');
+const {
+  collectLegacyFlatSourceReceipts,
+} = require('../lib/legacy-flat-source-receipts');
+const {
+  retireLegacyFlatSources,
+} = require('../lib/legacy-flat-source-retirement');
+const {
+  destinationPathMap,
+  materializeDestinationFiles,
+  verifyDestinationFiles,
+} = require('../lib/profile-workspace-destination-files');
+const { createLegacyFlatSourcePaths } = require('../lib/profile-workspace-layout');
+const { encryptVpnCredentialEnvelope } = require('../lib/vpn-credential-envelope');
 
 function receipt(seed) {
   return Object.freeze({
@@ -27,6 +41,15 @@ function receipt(seed) {
 
 function receipts(ids, start) {
   return Object.freeze(Object.fromEntries(ids.map((id, index) => [id, receipt(start + index)])));
+}
+
+function legacyReceipts(start) {
+  return Object.freeze(Object.fromEntries(LEGACY_SOURCE_IDS.map((id, index) => [
+    id,
+    REQUIRED_ABSENT_LEGACY_SOURCE_IDS.includes(id)
+      ? Object.freeze({ present: false, bytes: 0, sha256: null })
+      : receipt(start + index),
+  ])));
 }
 
 class MemoryJournalStore {
@@ -65,7 +88,7 @@ function scenario(overrides = {}) {
   const store = overrides.store || new MemoryJournalStore();
   let legacy = overrides.legacy ?? true;
   let destination = overrides.destination ?? false;
-  let sourceReceipts = overrides.sourceReceipts || receipts(LEGACY_SOURCE_IDS, 1);
+  let sourceReceipts = overrides.sourceReceipts || legacyReceipts(1);
   let destinationReceipts = overrides.destinationReceipts || receipts(DESTINATION_RECEIPT_IDS, 101);
   let entropy = 1;
   const calls = { build: 0, verify: 0, retire: 0 };
@@ -164,7 +187,7 @@ test('prepared migration blocks if any legacy source receipt changed', () => {
     buildDestination() { throw new Error('first crash'); },
   });
   assert.throws(() => value.coordinator.run(), /first crash/u);
-  value.setSourceReceipts(receipts(LEGACY_SOURCE_IDS, 20));
+  value.setSourceReceipts(legacyReceipts(20));
   assert.deepEqual(value.coordinator.run(), {
     ok: false,
     status: 'blocked',
@@ -268,7 +291,7 @@ test('coordinator and owner-only filesystem journal store complete one real cont
   let legacy = true;
   let destination = false;
   let entropy = 1;
-  const sources = receipts(LEGACY_SOURCE_IDS, 1);
+  const sources = legacyReceipts(1);
   const destinations = receipts(DESTINATION_RECEIPT_IDS, 101);
   const coordinator = new ProfileWorkspaceMigrationCoordinator({
     userData,
@@ -297,5 +320,94 @@ test('coordinator and owner-only filesystem journal store complete one real cont
   });
   assert.equal(coordinator.run().status, 'migrated');
   assert.equal(store.read(), null);
+  assert.equal(coordinator.run().status, 'already_migrated');
+});
+
+test('all P3 storage adapters complete one synthetic all-old to all-new filesystem migration', (t) => {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-full-migration-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const legacyPaths = createLegacyFlatSourcePaths(userData);
+  for (const id of ['settings', 'settingsBackup', 'vpnCredential', 'routingRules',
+    'proxyCredential', 'engineLog', 'engineLogRotated', 'engineLogRetention']) {
+    fs.writeFileSync(legacyPaths[id], `legacy-${id}`, { mode: 0o600 });
+  }
+  const sourceReceipts = collectLegacyFlatSourceReceipts({ userData });
+  const journalStore = new ProfileWorkspaceMigrationJournalStore({
+    filePath: path.join(userData, 'global', 'profile-account-workspace-migration.json'),
+  });
+  const safeStorage = {
+    isEncryptionAvailable: () => true,
+    getSelectedStorageBackend: () => 'keychain',
+    encryptString: (value) => Buffer.from(value, 'utf8').map((byte) => byte ^ 0xa5),
+    decryptString: (value) => Buffer.from(value).map((byte) => byte ^ 0xa5).toString('utf8'),
+  };
+  let entropy = 1;
+  let destinationLayout = null;
+  const coordinator = new ProfileWorkspaceMigrationCoordinator({
+    userData,
+    journalStore,
+    legacyAuthorityExists: () => fs.existsSync(legacyPaths.settings),
+    destinationAuthorityExists: (context) => {
+      const layout = context?.layout || destinationLayout;
+      return Boolean(layout && fs.existsSync(destinationPathMap(layout).globalSettings));
+    },
+    collectSourceReceipts: () => collectLegacyFlatSourceReceipts({ userData }),
+    prepareJournal: (receiptsValue) => createPreparedMigrationJournal({
+      profileId: 'hkustgz',
+      profileRevision: 1,
+      profileCredentialBindingRevision: 1,
+      gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+      protocolFamily: 'easyconnect-password-modern-l3-v1',
+      sourceReceipts: receiptsValue,
+      randomBytes: () => Buffer.alloc(16, entropy++),
+      now: () => 1_700_000_000_000,
+    }),
+    buildDestination: ({ journal, layout }) => {
+      destinationLayout = layout;
+      const encrypted = encryptVpnCredentialEnvelope({
+        binding: {
+          profileId: journal.profileId,
+          profileCredentialBindingRevision: journal.profileCredentialBindingRevision,
+          accountKey: journal.identity.accountKey,
+          accountCredentialRevision: journal.accountCredentialRevision,
+          gatewayOrigin: journal.gatewayOrigin,
+          protocolFamily: journal.protocolFamily,
+        },
+        credentialVersion: 1,
+        username: 'synthetic-user',
+        password: 'synthetic-password',
+        updatedAt: 1_700_000_000_050,
+        safeStorage,
+        platform: 'darwin',
+      });
+      const absent = new Set([
+        'globalProxyHelperCredential', 'globalEngineOwner', 'globalActiveContextSwitch',
+        'credentialTransaction', 'deletionTombstone',
+      ]);
+      const files = Object.fromEntries(DESTINATION_RECEIPT_IDS.map((id) => [
+        id,
+        absent.has(id) ? null : Buffer.from(`destination-${id}`, 'utf8'),
+      ]));
+      files.vpnCredential = encrypted;
+      try {
+        return materializeDestinationFiles({ layout, files });
+      } finally {
+        encrypted.fill(0);
+      }
+    },
+    verifyDestination: ({ layout }) => verifyDestinationFiles({ layout }),
+    retireLegacy: () => retireLegacyFlatSources({
+      userData,
+      expectedReceipts: sourceReceipts,
+    }),
+    now: () => 1_700_000_000_100,
+  });
+
+  assert.deepEqual(coordinator.run(), {
+    ok: true, status: 'migrated', authority: 'destination',
+  });
+  assert.equal(fs.existsSync(legacyPaths.settings), false);
+  assert.equal(fs.existsSync(destinationPathMap(destinationLayout).vpnCredential), true);
+  assert.equal(journalStore.read(), null);
   assert.equal(coordinator.run().status, 'already_migrated');
 });

--- a/desktop/test/profile-workspace-migration-store.test.js
+++ b/desktop/test/profile-workspace-migration-store.test.js
@@ -8,6 +8,7 @@ const test = require('node:test');
 const {
   DESTINATION_RECEIPT_IDS,
   LEGACY_SOURCE_IDS,
+  REQUIRED_ABSENT_LEGACY_SOURCE_IDS,
   commitMigrationJournal,
   createPreparedMigrationJournal,
 } = require('../lib/profile-workspace-migration-journal');
@@ -41,7 +42,12 @@ function prepared(seed = 1) {
     gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
     protocolFamily: 'easyconnect-password-modern-l3-v1',
     sourceReceipts: Object.fromEntries(
-      LEGACY_SOURCE_IDS.map((id, index) => [id, receipt(index + 1)]),
+      LEGACY_SOURCE_IDS.map((id, index) => [
+        id,
+        REQUIRED_ABSENT_LEGACY_SOURCE_IDS.includes(id)
+          ? { present: false, bytes: 0, sha256: null }
+          : receipt(index + 1),
+      ]),
     ),
     randomBytes: () => Buffer.alloc(16, entropy++),
     now: () => 1_700_000_000_000,

--- a/desktop/test/profile-workspace-storage.test.js
+++ b/desktop/test/profile-workspace-storage.test.js
@@ -11,6 +11,7 @@ const {
 const {
   DESTINATION_RECEIPT_IDS,
   LEGACY_SOURCE_IDS,
+  REQUIRED_ABSENT_LEGACY_SOURCE_IDS,
   commitMigrationJournal,
   createPreparedMigrationJournal,
   validateMigrationJournal,
@@ -29,7 +30,12 @@ function receipt(seed) {
 }
 
 function sourceReceipts() {
-  return Object.fromEntries(LEGACY_SOURCE_IDS.map((id, index) => [id, receipt(index + 1)]));
+  return Object.fromEntries(LEGACY_SOURCE_IDS.map((id, index) => [
+    id,
+    REQUIRED_ABSENT_LEGACY_SOURCE_IDS.includes(id)
+      ? Object.freeze({ present: false, bytes: 0, sha256: null })
+      : receipt(index + 1),
+  ]));
 }
 
 function deepKeys(value, result = []) {
@@ -187,6 +193,14 @@ test('journal generation fails closed on weak entropy, missing receipts and unsa
     profileId: 'another-school',
     randomBytes: () => Buffer.alloc(16, 1),
   }), /HKUST profile/u);
+  assert.throws(() => createPreparedMigrationJournal({
+    ...base,
+    sourceReceipts: {
+      ...sourceReceipts(),
+      credentialTransaction: receipt(900),
+    },
+    randomBytes: () => Buffer.alloc(16, 1),
+  }), /precondition source must be absent/u);
 });
 
 test('P3 foundation is packaged but does not activate migration in production Main', () => {
@@ -196,6 +210,8 @@ test('P3 foundation is packaged but does not activate migration in production Ma
     'profile-workspace-migration-journal',
     'profile-workspace-migration-store',
     'profile-workspace-migration-coordinator',
+    'profile-workspace-destination-files',
+    'legacy-flat-source-retirement',
     'legacy-flat-source-receipts',
     'vpn-credential-envelope',
     'vpn-credential-envelope-store',

--- a/docs/adr/0010-p3-destination-and-retirement.md
+++ b/docs/adr/0010-p3-destination-and-retirement.md
@@ -1,0 +1,72 @@
+# ADR-0010: P3 destination materialization and legacy retirement
+
+- Status: Accepted as a non-activating P3d contract
+- Production migration: not enabled by this ADR
+- Parent contracts: [`ADR-0008`](0008-p3-receipts-and-vpn-envelope.md),
+  [`ADR-0009`](0009-p3-migration-coordinator.md)
+
+## Context
+
+P3c proves migration authority transitions but uses callbacks for destination construction and legacy retirement.
+Those callbacks are security boundaries: a generic copy loop could overwrite unrelated data, follow a link or
+delete old authority before the destination is complete.
+
+## Decision
+
+### Exact destination map
+
+`profile-workspace-destination-files.js` maps every `DESTINATION_RECEIPT_IDS` entry to one path from the validated
+opaque Profile/Account/Workspace layout. The plan has exactly the same IDs and each value is either a bounded
+Buffer or explicit `null` absence.
+
+Before the first write, the materializer inspects every target:
+
+- absent target + present plan: eligible for atomic owner-only creation;
+- present target + identical length/SHA-256: idempotent recovery;
+- explicit absent plan + absent target: valid;
+- every other state: conflict, zero writes.
+
+Writes use same-directory owner-only temporary files, file fsync, atomic rename, directory fsync and Windows
+current-user-only DACL protection/verification. Every directory is fsynced and every final file is re-read through
+the no-follow receipt boundary before receipts are returned. A pre-rename failure leaves no target; a visible
+post-rename failure is reported with `commitApplied` and remains safe for idempotent retry.
+
+### Legacy retirement
+
+`legacy-flat-source-retirement.js` accepts only the exact journal-bound legacy receipt set and derives every path
+from `userData`. It first inspects all sources, so one mismatch or unexpected new source blocks before deletion.
+Each present file is re-opened and rehashed immediately before its non-recursive unlink, followed by directory
+fsync. Missing receipt-matched files are accepted as already retired after a prior committed-journal crash.
+
+The fixed retirement order removes the old `settings.json` authority last. Partial unlink or fsync failure leaves
+the committed journal in place; retry repeats receipt checks and completes without recursive deletion. The final
+proof requires every legacy source path to be absent.
+
+### Migration preconditions
+
+The journal schema requires these legacy receipts to be absent before prepare:
+
+- `credential-settings-transaction.json` — existing username/password recovery must finish first;
+- `engine-owner.json` — stale/current Engine cleanup must finish first;
+- `proxy-helper-credential.txt` — short-lived plaintext projection must be removed first.
+
+This prevents migration from carrying an unresolved credential pair, a live Engine owner or plaintext helper.
+
+## Verification
+
+Fault tests cover target conflicts, links, rename failure, Windows ACL, source drift, unexpected sources, partial
+unlink, directory-fsync failure, settings-last order and retry. A full temporary-directory integration uses the
+real journal, source collector, destination materializer, bound encrypted VPN envelope, destination verifier,
+coordinator and retirement adapter to complete one all-old to all-new migration.
+
+## Non-activation boundary
+
+Production `desktop/main.js` imports none of the P3d modules. The integration uses synthetic temporary files and
+credentials only. Actual destination document planning, current credential decryption and application startup
+wiring remain disabled.
+
+## Next gate
+
+P3e must build exact HKUST destination documents from validated legacy settings and a decrypted legacy credential,
+preserve/copy each account-owned store without weakening its own schema, and model active/retired legacy rollback
+state. Only then can a separate activation PR execute migration before any ordinary settings/credential read.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -624,6 +624,8 @@ Non-activating storage foundation: [`ADR-0007`](../adr/0007-p3-storage-foundatio
   encrypted, exact-profile/account/origin/family-bound VPN credential envelope before orchestration is enabled;
 - prove a synchronous single-flight coordinator can resume prepared/committed journals, reject changed receipts
   and ambiguous dual authority, and survive repeated recovery before production storage adapters are connected;
+- materialize exact destination files idempotently without overwriting conflicts, then retire only receipt-matched
+  flat files non-recursively with the old settings authority last;
 
 - split app-global and profile settings;
 - create `profiles/<profileKey>/accounts/<accountKey>/workspace/` from the start;


### PR DESCRIPTION
## 依赖关系

这是 stacked Draft PR，以 P3c PR #14 为 base。前置 PR 合并后依次重基到 main。

## 目标

实现真正的文件级 destination materializer 和 receipt-bound legacy retirement adapter，但仍不接入生产 Main 或真实用户数据。

## Destination materializer

- journal destination IDs 与 opaque layout paths 一一对应。
- lexical containment 和逐级 directory no-link/owner-only 验证。
- 第一次写入前预检全部目标；一个冲突即零文件写入。
- 已存在且 length/SHA-256 相同可幂等复用；任何其他文件、link 或宽权限禁止覆盖。
- owner-only temporary + file fsync + atomic rename + directory fsync + Windows DACL。
- 最终重新打开每个文件生成 exact receipts。

## Legacy retirement

- 只接受 journal exact legacy receipt set，路径只从 userData 推导。
- 先全局预检，再在每次 unlink 前重新打开和哈希。
- 非递归逐文件删除，每次 directory fsync。
- settings.json 作为旧 authority 最后退休。
- partial unlink/fsync failure 在 committed journal 下可幂等续跑。
- final proof 要求全部 legacy paths absent。

## 强制迁移前置条件

以下旧文件必须在 journal prepare 前证明 absent：

- credential-settings-transaction.json
- engine-owner.json
- proxy-helper-credential.txt

## 验证

- Desktop: 667 passed, 0 failed, 1 Windows-only skip
- P3 focused: 54 passed, 0 failed
- P3d storage/retirement: 12 passed
- 全组件临时目录 all-old -> all-new migration: PASS
- Architecture: 230 files / 322 edges / 0 cycles
- JavaScript syntax, staged secret gate, git diff check: PASS

## 非激活边界

production main.js 不导入这些模块；所有迁移测试只使用 synthetic temporary files/credentials，不读取或修改安装用户数据。