### PR TITLE
2.0 P3f: retire legacy credential rollback transactionally

### DIFF
--- a/desktop/lib/hkust-migration-destination-plan.js
+++ b/desktop/lib/hkust-migration-destination-plan.js
@@ -245,6 +245,7 @@ function createHkustMigrationDestinationPlan(options = {}) {
     vpnCredential: encryptedCredential,
     legacyCredentialRollbackBlob: copyOrNull(source.legacyCredential),
     legacyCredentialRollbackState: jsonBuffer(rollbackState),
+    legacyCredentialRollbackRetirement: null,
     credentialTransaction: null,
     deletionTombstone: null,
     workspaceSettings: jsonBuffer({

--- a/desktop/lib/legacy-credential-rollback-store.js
+++ b/desktop/lib/legacy-credential-rollback-store.js
@@ -1,0 +1,466 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { atomicWritePrivateFile } = require('./credential-store');
+const {
+  retireLegacyCredentialRollbackState,
+  validateLegacyCredentialRollbackState,
+} = require('./legacy-credential-rollback-state');
+const { readPrivateFileBounded } = require('./private-file');
+const {
+  normalizeGatewayOrigin,
+  validateOpaqueKey,
+  validateProfileId,
+  validateProtocolFamily,
+} = require('./school-profile-schema');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+const RETIREMENT_INTENT_VERSION = 1;
+const MAX_ROLLBACK_BLOB_BYTES = 64 * 1024;
+const MAX_ROLLBACK_DOCUMENT_BYTES = 64 * 1024;
+const DIGEST = /^[a-f0-9]{64}$/u;
+
+function plainObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+  return value;
+}
+
+function exactKeys(value, keys, name) {
+  const source = plainObject(value, name);
+  const actual = Object.keys(source).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${name} has an invalid schema`);
+  }
+  return source;
+}
+
+function positive(value, name) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function validateBinding(value) {
+  const source = exactKeys(value, [
+    'migrationId', 'profileId', 'profileCredentialBindingRevision', 'accountKey',
+    'accountCredentialRevision', 'gatewayOrigin', 'protocolFamily',
+  ], 'legacy rollback binding');
+  return Object.freeze({
+    migrationId: validateOpaqueKey(source.migrationId, 'migrationId'),
+    profileId: validateProfileId(source.profileId),
+    profileCredentialBindingRevision: positive(
+      source.profileCredentialBindingRevision,
+      'profileCredentialBindingRevision',
+    ),
+    accountKey: validateOpaqueKey(source.accountKey, 'accountKey'),
+    accountCredentialRevision: positive(
+      source.accountCredentialRevision,
+      'accountCredentialRevision',
+    ),
+    gatewayOrigin: normalizeGatewayOrigin(source.gatewayOrigin).origin,
+    protocolFamily: validateProtocolFamily(source.protocolFamily),
+  });
+}
+
+function bindingFromState(state) {
+  return {
+    migrationId: state.migrationId,
+    profileId: state.profileId,
+    profileCredentialBindingRevision: state.profileCredentialBindingRevision,
+    accountKey: state.accountKey,
+    accountCredentialRevision: state.accountCredentialRevision,
+    gatewayOrigin: state.gatewayOrigin,
+    protocolFamily: state.protocolFamily,
+  };
+}
+
+function sameDocument(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function stateDigest(state) {
+  return crypto.createHash('sha256').update(JSON.stringify(state), 'utf8').digest('hex');
+}
+
+function assertBinding(state, expected) {
+  if (!sameDocument(validateBinding(bindingFromState(state)), expected)) {
+    throw new Error('legacy rollback binding does not match the active account');
+  }
+}
+
+function validateRetirementIntent(value, expectedBinding) {
+  const source = exactKeys(value, [
+    'schemaVersion', 'type', 'activeStateSha256', 'retiredState', 'createdAt',
+  ], 'legacy credential retirement intent');
+  if (source.schemaVersion !== RETIREMENT_INTENT_VERSION ||
+      source.type !== 'legacy_credential_retirement' ||
+      (source.activeStateSha256 !== null &&
+        (typeof source.activeStateSha256 !== 'string' || !DIGEST.test(source.activeStateSha256)))) {
+    throw new TypeError('legacy credential retirement intent is unsupported');
+  }
+  const retiredState = validateLegacyCredentialRollbackState(source.retiredState);
+  if (retiredState.state !== 'retired') {
+    throw new TypeError('legacy credential retirement intent requires retired state');
+  }
+  assertBinding(retiredState, expectedBinding);
+  return Object.freeze({
+    schemaVersion: RETIREMENT_INTENT_VERSION,
+    type: 'legacy_credential_retirement',
+    activeStateSha256: source.activeStateSha256,
+    retiredState,
+    createdAt: positive(source.createdAt, 'createdAt'),
+  });
+}
+
+function fsyncDirectory(directory, fileSystem, platform) {
+  let descriptor = null;
+  try {
+    descriptor = fileSystem.openSync(directory, 'r');
+    fileSystem.fsyncSync?.(descriptor);
+    return true;
+  } catch {
+    return platform === 'win32';
+  } finally {
+    if (descriptor !== null) {
+      try { fileSystem.closeSync(descriptor); } catch {}
+    }
+  }
+}
+
+function storageOptions(platform, windowsAcl) {
+  return platform === 'win32' ? {
+    protectTemporary: (temporary) => windowsAcl.protect(temporary) === true,
+    verifyCommitted: (committed) => windowsAcl.verify(committed) === true,
+    removeCommittedOnFailure: true,
+  } : {};
+}
+
+class LegacyCredentialRollbackStore {
+  constructor({
+    layout,
+    expectedBinding,
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+  } = {}) {
+    if (!layout?.account || typeof layout.root !== 'string' ||
+        typeof layout.account.root !== 'string' ||
+        typeof layout.account.legacyCredentialRollbackBlob !== 'string' ||
+        typeof layout.account.legacyCredentialRollbackState !== 'string' ||
+        typeof layout.account.legacyCredentialRollbackRetirement !== 'string' ||
+        !fileSystem || typeof fileSystem.openSync !== 'function' ||
+        !['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' &&
+          (typeof windowsAcl?.protect !== 'function' || typeof windowsAcl?.verify !== 'function'))) {
+      throw new TypeError('legacy credential rollback store dependencies are invalid');
+    }
+    const files = [
+      layout.account.legacyCredentialRollbackBlob,
+      layout.account.legacyCredentialRollbackState,
+      layout.account.legacyCredentialRollbackRetirement,
+    ];
+    if (!path.isAbsolute(layout.root) || path.resolve(layout.root) !== layout.root ||
+        !path.isAbsolute(layout.account.root) || path.resolve(layout.account.root) !== layout.account.root ||
+        path.relative(layout.root, layout.account.root).startsWith('..') ||
+        files.some((file) => path.dirname(file) !== layout.account.root ||
+          !path.isAbsolute(file) || path.resolve(file) !== file) ||
+        new Set(files).size !== files.length) {
+      throw new TypeError('legacy credential rollback paths are invalid');
+    }
+    this.root = layout.root;
+    this.accountRoot = layout.account.root;
+    this.blobPath = layout.account.legacyCredentialRollbackBlob;
+    this.statePath = layout.account.legacyCredentialRollbackState;
+    this.intentPath = layout.account.legacyCredentialRollbackRetirement;
+    this.expectedBinding = validateBinding(expectedBinding);
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+  }
+
+  inspect() {
+    this.#verifyDirectoryChain();
+    const state = this.#readState();
+    const intent = this.#readIntent();
+    const blobPresent = this.#pathPresent(this.blobPath);
+    if (intent) {
+      this.#validateIntentAgainstState(intent, state);
+      if (blobPresent) this.#verifyBlob(state || intent.retiredState);
+      return Object.freeze({ status: 'retirement_pending' });
+    }
+    if (!state) {
+      if (blobPresent) throw new Error('legacy rollback blob exists without bound state');
+      return Object.freeze({ status: 'none' });
+    }
+    assertBinding(state, this.expectedBinding);
+    if (state.state === 'active') {
+      if (!blobPresent) throw new Error('active rollback blob is missing');
+      this.#verifyBlob(state);
+      return Object.freeze({ status: 'active' });
+    }
+    if (blobPresent) {
+      this.#verifyBlob(state);
+      return Object.freeze({ status: 'retirement_pending' });
+    }
+    return Object.freeze({ status: 'retired' });
+  }
+
+  readActiveRollbackBlob() {
+    this.#verifyDirectoryChain();
+    if (this.#readIntent()) {
+      throw new Error('legacy rollback retirement is pending');
+    }
+    const state = this.#readState();
+    if (!state || state.state !== 'active') {
+      throw new Error('active legacy rollback credential is unavailable');
+    }
+    assertBinding(state, this.expectedBinding);
+    return this.#readAndVerifyBlob(state);
+  }
+
+  retire({ reason, now = Date.now } = {}) {
+    const current = this.reconcile();
+    if (current.status !== 'active') return current;
+    const activeState = this.#readState();
+    const retiredState = retireLegacyCredentialRollbackState(activeState, { reason, now });
+    const intent = validateRetirementIntent({
+      schemaVersion: RETIREMENT_INTENT_VERSION,
+      type: 'legacy_credential_retirement',
+      activeStateSha256: stateDigest(activeState),
+      retiredState,
+      createdAt: retiredState.retiredAt,
+    }, this.expectedBinding);
+    this.#writeDocument(this.intentPath, intent, 'retirement intent');
+    return this.#resumeIntent(intent);
+  }
+
+  reconcile() {
+    this.#verifyDirectoryChain();
+    const intent = this.#readIntent();
+    if (intent) return this.#resumeIntent(intent);
+    const state = this.#readState();
+    const blobPresent = this.#pathPresent(this.blobPath);
+    if (!state) {
+      if (blobPresent) throw new Error('legacy rollback blob exists without bound state');
+      return Object.freeze({ status: 'none', changed: false });
+    }
+    assertBinding(state, this.expectedBinding);
+    if (state.state === 'active') {
+      if (!blobPresent) throw new Error('active rollback blob is missing');
+      this.#verifyBlob(state);
+      return Object.freeze({ status: 'active', changed: false });
+    }
+    if (!blobPresent) return Object.freeze({ status: 'retired', changed: false });
+    this.#verifyBlob(state);
+    const recoveryIntent = validateRetirementIntent({
+      schemaVersion: RETIREMENT_INTENT_VERSION,
+      type: 'legacy_credential_retirement',
+      activeStateSha256: null,
+      retiredState: state,
+      createdAt: state.retiredAt,
+    }, this.expectedBinding);
+    this.#writeDocument(this.intentPath, recoveryIntent, 'retirement intent');
+    return this.#resumeIntent(recoveryIntent);
+  }
+
+  retireBeforeMutation({ reason, mutation, now = Date.now } = {}) {
+    if (typeof mutation !== 'function') {
+      throw new TypeError('credential mutation must be a function');
+    }
+    this.retire({ reason, now });
+    const result = mutation();
+    if (result && typeof result.then === 'function') {
+      throw new TypeError('credential mutation must be synchronous');
+    }
+    return result;
+  }
+
+  #resumeIntent(intent) {
+    const state = this.#readState();
+    this.#validateIntentAgainstState(intent, state);
+    if (this.#pathPresent(this.blobPath)) {
+      this.#verifyBlob(state || intent.retiredState);
+      try {
+        this.fileSystem.unlinkSync(this.blobPath);
+      } catch (error) {
+        throw new Error('legacy rollback blob removal failed', { cause: error });
+      }
+      if (!fsyncDirectory(this.accountRoot, this.fileSystem, this.platform)) {
+        throw new Error('legacy rollback blob removal failed: directory fsync');
+      }
+    }
+    const committedState = this.#readState();
+    if (!committedState || !sameDocument(committedState, intent.retiredState)) {
+      try {
+        this.#writeDocument(this.statePath, intent.retiredState, 'state');
+      } catch (error) {
+        throw new Error('legacy rollback state commit failed', { cause: error });
+      }
+    }
+    const verifiedState = this.#readState();
+    if (!verifiedState || !sameDocument(verifiedState, intent.retiredState)) {
+      throw new Error('legacy rollback state commit failed verification');
+    }
+    try {
+      this.fileSystem.unlinkSync(this.intentPath);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        throw new Error('legacy rollback retirement intent clear failed', { cause: error });
+      }
+    }
+    if (!fsyncDirectory(this.accountRoot, this.fileSystem, this.platform)) {
+      throw new Error('legacy rollback retirement intent clear failed: directory fsync');
+    }
+    return Object.freeze({ status: 'retired', changed: true });
+  }
+
+  #validateIntentAgainstState(intent, state) {
+    if (!state) throw new Error('legacy rollback retirement intent has no bound state');
+    assertBinding(state, this.expectedBinding);
+    if (state.state === 'active') {
+      if (!intent.activeStateSha256 || stateDigest(state) !== intent.activeStateSha256) {
+        throw new Error('legacy rollback retirement intent binding is stale');
+      }
+      return;
+    }
+    if (!sameDocument(state, intent.retiredState)) {
+      throw new Error('legacy rollback retired state conflicts with retirement intent');
+    }
+  }
+
+  #verifyDirectoryChain() {
+    const relative = path.relative(this.root, this.accountRoot);
+    let current = this.root;
+    for (const component of ['', ...relative.split(path.sep).filter(Boolean)]) {
+      if (component) current = path.join(current, component);
+      let stat;
+      try {
+        stat = this.fileSystem.lstatSync(current);
+      } catch (error) {
+        throw new Error('legacy rollback account directory is unavailable', { cause: error });
+      }
+      if (!stat.isDirectory() || stat.isSymbolicLink() ||
+          (this.platform !== 'win32' && (stat.mode & 0o077) !== 0)) {
+        throw new Error('legacy rollback account directory is not owner-only and link-free');
+      }
+    }
+  }
+
+  #pathPresent(file) {
+    try {
+      this.fileSystem.lstatSync(file);
+      return true;
+    } catch (error) {
+      if (error?.code === 'ENOENT') return false;
+      throw error;
+    }
+  }
+
+  #readDocument(file, label, validator) {
+    if (!this.#pathPresent(file)) return null;
+    if (this.platform === 'win32' && !this.windowsAcl.verify(file)) {
+      throw new Error(`invalid private file: ${label}`);
+    }
+    let data = null;
+    try {
+      data = readPrivateFileBounded(file, {
+        maxBytes: MAX_ROLLBACK_DOCUMENT_BYTES,
+        minBytes: 2,
+        platform: this.platform,
+        fileSystem: this.fileSystem,
+      }).data;
+      return validator(JSON.parse(data.toString('utf8')));
+    } catch (error) {
+      if (error?.privateFileInvalid === true) throw new Error(`invalid private file: ${label}`, {
+        cause: error,
+      });
+      throw error;
+    } finally {
+      data?.fill(0);
+    }
+  }
+
+  #readState() {
+    const state = this.#readDocument(
+      this.statePath,
+      'legacy rollback state',
+      validateLegacyCredentialRollbackState,
+    );
+    if (state) assertBinding(state, this.expectedBinding);
+    return state;
+  }
+
+  #readIntent() {
+    return this.#readDocument(
+      this.intentPath,
+      'legacy rollback retirement intent',
+      (value) => validateRetirementIntent(value, this.expectedBinding),
+    );
+  }
+
+  #readAndVerifyBlob(state) {
+    if (this.platform === 'win32' && !this.windowsAcl.verify(this.blobPath)) {
+      throw new Error('invalid private file: legacy rollback blob');
+    }
+    let data;
+    try {
+      data = readPrivateFileBounded(this.blobPath, {
+        maxBytes: MAX_ROLLBACK_BLOB_BYTES,
+        platform: this.platform,
+        fileSystem: this.fileSystem,
+      }).data;
+    } catch (error) {
+      if (error?.code === 'ENOENT') throw new Error('active rollback blob is missing', {
+        cause: error,
+      });
+      if (error?.privateFileInvalid === true) throw new Error(
+        'invalid private file: legacy rollback blob',
+        { cause: error },
+      );
+      throw error;
+    }
+    const digest = crypto.createHash('sha256').update(data).digest('hex');
+    if (state.sourceBytes !== data.length || state.sourceSha256 !== digest) {
+      data.fill(0);
+      throw new Error('legacy rollback blob does not match its bound receipt');
+    }
+    return data;
+  }
+
+  #verifyBlob(state) {
+    const data = this.#readAndVerifyBlob(state);
+    data.fill(0);
+  }
+
+  #writeDocument(file, value, label) {
+    const bytes = Buffer.from(`${JSON.stringify(value)}\n`, 'utf8');
+    if (bytes.length > MAX_ROLLBACK_DOCUMENT_BYTES || !atomicWritePrivateFile(
+      file,
+      bytes,
+      this.fileSystem,
+      storageOptions(this.platform, this.windowsAcl),
+    )) {
+      bytes.fill(0);
+      throw new Error(`legacy rollback ${label} write failed`);
+    }
+    bytes.fill(0);
+  }
+}
+
+module.exports = {
+  LegacyCredentialRollbackStore,
+  RETIREMENT_INTENT_VERSION,
+};

--- a/desktop/lib/profile-workspace-destination-files.js
+++ b/desktop/lib/profile-workspace-destination-files.js
@@ -32,6 +32,7 @@ function destinationPathMap(layout) {
     vpnCredential: layout.account.vpnCredential,
     legacyCredentialRollbackBlob: layout.account.legacyCredentialRollbackBlob,
     legacyCredentialRollbackState: layout.account.legacyCredentialRollbackState,
+    legacyCredentialRollbackRetirement: layout.account.legacyCredentialRollbackRetirement,
     credentialTransaction: layout.account.credentialTransaction,
     deletionTombstone: layout.account.deletionTombstone,
     workspaceSettings: layout.workspace.settings,

--- a/desktop/lib/profile-workspace-layout.js
+++ b/desktop/lib/profile-workspace-layout.js
@@ -102,6 +102,10 @@ function createProfileAccountWorkspaceLayout({
       vpnCredential: path.join(accountRoot, 'vpn-credential.bin'),
       legacyCredentialRollbackBlob: path.join(accountRoot, 'legacy-vpn-credential-rollback.bin'),
       legacyCredentialRollbackState: path.join(accountRoot, 'legacy-vpn-credential-rollback.json'),
+      legacyCredentialRollbackRetirement: path.join(
+        accountRoot,
+        'legacy-vpn-credential-rollback-retirement.json',
+      ),
       credentialTransaction: path.join(accountRoot, 'credential-transaction.json'),
       deletionTombstone: path.join(accountRoot, 'deletion-tombstone.json'),
     },

--- a/desktop/lib/profile-workspace-migration-journal.js
+++ b/desktop/lib/profile-workspace-migration-journal.js
@@ -45,6 +45,7 @@ const DESTINATION_RECEIPT_IDS = Object.freeze([
   'vpnCredential',
   'legacyCredentialRollbackBlob',
   'legacyCredentialRollbackState',
+  'legacyCredentialRollbackRetirement',
   'credentialTransaction',
   'deletionTombstone',
   'workspaceSettings',

--- a/desktop/test/legacy-credential-rollback-store.test.js
+++ b/desktop/test/legacy-credential-rollback-store.test.js
@@ -1,0 +1,242 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  LegacyCredentialRollbackStore,
+} = require('../lib/legacy-credential-rollback-store');
+const {
+  createLegacyCredentialRollbackState,
+  retireLegacyCredentialRollbackState,
+  validateLegacyCredentialRollbackState,
+} = require('../lib/legacy-credential-rollback-state');
+const { createProfileAccountWorkspaceLayout } = require('../lib/profile-workspace-layout');
+
+function migrationJournal() {
+  return {
+    migrationId: `migration-${'11'.repeat(16)}`,
+    profileId: 'hkustgz',
+    profileCredentialBindingRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
+    identity: { accountKey: `account-${'22'.repeat(16)}` },
+    accountCredentialRevision: 1,
+  };
+}
+
+function fixture(t, { active = true } = {}) {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-rollback-store-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const layout = createProfileAccountWorkspaceLayout({
+    userData,
+    profileKey: `profile-${'33'.repeat(16)}`,
+    accountKey: migrationJournal().identity.accountKey,
+    workspaceKey: `workspace-${'44'.repeat(16)}`,
+  });
+  fs.mkdirSync(layout.account.root, { recursive: true, mode: 0o700 });
+  const blob = Buffer.from('legacy-encrypted-password');
+  const sourceReceipt = active ? {
+    present: true,
+    bytes: blob.length,
+    sha256: require('node:crypto').createHash('sha256').update(blob).digest('hex'),
+  } : { present: false, bytes: 0, sha256: null };
+  const state = createLegacyCredentialRollbackState({
+    journal: migrationJournal(),
+    sourceReceipt,
+    now: () => 1_700_000_000_000,
+  });
+  if (active) fs.writeFileSync(layout.account.legacyCredentialRollbackBlob, blob, { mode: 0o600 });
+  fs.writeFileSync(
+    layout.account.legacyCredentialRollbackState,
+    JSON.stringify(state),
+    { mode: 0o600 },
+  );
+  const expectedBinding = {
+    migrationId: state.migrationId,
+    profileId: state.profileId,
+    profileCredentialBindingRevision: state.profileCredentialBindingRevision,
+    accountKey: state.accountKey,
+    accountCredentialRevision: state.accountCredentialRevision,
+    gatewayOrigin: state.gatewayOrigin,
+    protocolFamily: state.protocolFamily,
+  };
+  return { userData, layout, blob, state, expectedBinding };
+}
+
+function store(value, options = {}) {
+  return new LegacyCredentialRollbackStore({
+    layout: value.layout,
+    expectedBinding: value.expectedBinding,
+    ...options,
+  });
+}
+
+function persistedState(value) {
+  return validateLegacyCredentialRollbackState(JSON.parse(
+    fs.readFileSync(value.layout.account.legacyCredentialRollbackState, 'utf8'),
+  ));
+}
+
+test('active rollback blob is readable only through explicit bound API', (t) => {
+  const value = fixture(t);
+  const rollback = store(value);
+  assert.deepEqual(rollback.inspect(), { status: 'active' });
+  const blob = rollback.readActiveRollbackBlob();
+  assert.deepEqual(blob, value.blob);
+  blob.fill(0);
+  assert.deepEqual(rollback.inspect(), { status: 'active' });
+});
+
+test('retirement deletes blob before committing retired state and clears intent', (t) => {
+  const value = fixture(t);
+  const rollback = store(value);
+  assert.deepEqual(rollback.retire({
+    reason: 'credential_replaced',
+    now: () => 1_700_000_000_100,
+  }), { status: 'retired', changed: true });
+  assert.equal(fs.existsSync(value.layout.account.legacyCredentialRollbackBlob), false);
+  assert.equal(fs.existsSync(value.layout.account.legacyCredentialRollbackRetirement), false);
+  assert.equal(persistedState(value).retirementReason, 'credential_replaced');
+  assert.deepEqual(rollback.retire({
+    reason: 'credential_cleared',
+    now: () => 1_700_000_000_200,
+  }), { status: 'retired', changed: false });
+});
+
+test('credential mutation cannot run until rollback retirement is proven', (t) => {
+  const value = fixture(t);
+  let mutated = false;
+  const injected = Object.create(fs);
+  injected.unlinkSync = (file) => {
+    if (file === value.layout.account.legacyCredentialRollbackBlob) {
+      throw new Error('simulated busy blob');
+    }
+    return fs.unlinkSync(file);
+  };
+  assert.throws(() => store(value, { fileSystem: injected }).retireBeforeMutation({
+    reason: 'credential_cleared',
+    mutation: () => { mutated = true; },
+  }), /blob removal failed/u);
+  assert.equal(mutated, false);
+  assert.equal(store(value).reconcile().status, 'retired');
+});
+
+test('crash after blob deletion resumes state commit from retirement intent', (t) => {
+  const value = fixture(t);
+  const injected = Object.create(fs);
+  injected.renameSync = (from, to) => {
+    if (to === value.layout.account.legacyCredentialRollbackState) {
+      throw new Error('simulated state commit crash');
+    }
+    return fs.renameSync(from, to);
+  };
+  assert.throws(() => store(value, { fileSystem: injected }).retire({
+    reason: 'credential_replaced',
+    now: () => 1_700_000_000_100,
+  }), /state commit failed/u);
+  assert.equal(fs.existsSync(value.layout.account.legacyCredentialRollbackBlob), false);
+  assert.equal(fs.existsSync(value.layout.account.legacyCredentialRollbackRetirement), true);
+  assert.equal(persistedState(value).state, 'active');
+  assert.deepEqual(store(value).reconcile(), { status: 'retired', changed: true });
+});
+
+test('crash while clearing intent resumes without resurrecting blob', (t) => {
+  const value = fixture(t);
+  const injected = Object.create(fs);
+  injected.unlinkSync = (file) => {
+    if (file === value.layout.account.legacyCredentialRollbackRetirement) {
+      throw new Error('simulated intent clear crash');
+    }
+    return fs.unlinkSync(file);
+  };
+  assert.throws(() => store(value, { fileSystem: injected }).retire({
+    reason: 'credential_replaced',
+    now: () => 1_700_000_000_100,
+  }), /intent clear failed/u);
+  assert.equal(persistedState(value).state, 'retired');
+  assert.equal(fs.existsSync(value.layout.account.legacyCredentialRollbackBlob), false);
+  assert.equal(fs.existsSync(value.layout.account.legacyCredentialRollbackRetirement), true);
+  assert.deepEqual(store(value).reconcile(), { status: 'retired', changed: true });
+});
+
+test('active state with missing blob and no intent blocks instead of inventing retirement', (t) => {
+  const value = fixture(t);
+  fs.unlinkSync(value.layout.account.legacyCredentialRollbackBlob);
+  assert.throws(() => store(value).reconcile(), /active rollback blob is missing/u);
+  assert.equal(persistedState(value).state, 'active');
+});
+
+test('retired state with resurrected blob is reconciled by deleting dedicated blob', (t) => {
+  const value = fixture(t);
+  const retired = retireLegacyCredentialRollbackState(value.state, {
+    reason: 'credential_cleared',
+    now: () => 1_700_000_000_100,
+  });
+  fs.writeFileSync(value.layout.account.legacyCredentialRollbackState, JSON.stringify(retired), {
+    mode: 0o600,
+  });
+  assert.deepEqual(store(value).reconcile(), { status: 'retired', changed: true });
+  assert.equal(fs.existsSync(value.layout.account.legacyCredentialRollbackBlob), false);
+});
+
+test('binding mismatch, link substitution and unknown retirement intent fail closed', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const value = fixture(t);
+  assert.throws(() => new LegacyCredentialRollbackStore({
+    layout: value.layout,
+    expectedBinding: {
+      ...value.expectedBinding,
+      accountKey: `account-${'55'.repeat(16)}`,
+    },
+  }).inspect(), /binding/u);
+
+  const target = path.join(value.userData, 'unrelated');
+  fs.writeFileSync(target, 'unrelated', { mode: 0o600 });
+  fs.unlinkSync(value.layout.account.legacyCredentialRollbackBlob);
+  fs.symlinkSync(target, value.layout.account.legacyCredentialRollbackBlob);
+  assert.throws(() => store(value).inspect(), /private file/u);
+  assert.equal(fs.readFileSync(target, 'utf8'), 'unrelated');
+});
+
+test('malformed retirement intent is never treated as authority', (t) => {
+  const value = fixture(t);
+  fs.writeFileSync(
+    value.layout.account.legacyCredentialRollbackRetirement,
+    JSON.stringify({ schemaVersion: 1, type: 'unknown' }),
+    { mode: 0o600 },
+  );
+  assert.throws(() => store(value).reconcile(), /schema|unsupported/u);
+  assert.equal(fs.existsSync(value.layout.account.legacyCredentialRollbackBlob), true);
+  assert.equal(persistedState(value).state, 'active');
+});
+
+test('mutation exceptions do not undo a proven credential retirement', (t) => {
+  const value = fixture(t);
+  assert.throws(() => store(value).retireBeforeMutation({
+    reason: 'account_removed',
+    mutation() { throw new Error('simulated account mutation failure'); },
+  }), /account mutation failure/u);
+  assert.equal(fs.existsSync(value.layout.account.legacyCredentialRollbackBlob), false);
+  assert.equal(persistedState(value).state, 'retired');
+});
+
+test('simulated Windows retirement protects and verifies state and intent DACLs', (t) => {
+  const value = fixture(t);
+  const protectedPaths = [];
+  const verifiedPaths = [];
+  const windowsAcl = {
+    protect(file) { protectedPaths.push(file); return true; },
+    verify(file) { verifiedPaths.push(file); return fs.existsSync(file); },
+  };
+  const rollback = store(value, { platform: 'win32', windowsAcl });
+  assert.equal(rollback.retire({
+    reason: 'credential_replaced',
+    now: () => 1_700_000_000_100,
+  }).status, 'retired');
+  assert.equal(protectedPaths.some((file) => file.endsWith('.tmp')), true);
+  assert.equal(verifiedPaths.includes(value.layout.account.legacyCredentialRollbackState), true);
+});

--- a/desktop/test/profile-workspace-destination-files.test.js
+++ b/desktop/test/profile-workspace-destination-files.test.js
@@ -17,6 +17,7 @@ const ABSENT_IDS = new Set([
   'globalProxyHelperCredential',
   'globalEngineOwner',
   'globalActiveContextSwitch',
+  'legacyCredentialRollbackRetirement',
   'credentialTransaction',
   'deletionTombstone',
 ]);

--- a/desktop/test/profile-workspace-storage.test.js
+++ b/desktop/test/profile-workspace-storage.test.js
@@ -67,6 +67,10 @@ test('profile/account/workspace paths use only opaque keys beneath one absolute 
     layout.account.legacyCredentialRollbackState,
     path.join(layout.account.root, 'legacy-vpn-credential-rollback.json'),
   );
+  assert.equal(
+    layout.account.legacyCredentialRollbackRetirement,
+    path.join(layout.account.root, 'legacy-vpn-credential-rollback-retirement.json'),
+  );
   assert.equal(layout.workspace.routingRules, path.join(layout.workspace.root, 'routing-rules.json'));
   assert.equal(layout.workspace.engineLog, path.join(layout.workspace.root, 'engine.log'));
   assert.match(layout.browserPartition, /^persist:campus-workspace-[a-f0-9]{32}$/u);
@@ -218,6 +222,7 @@ test('P3 foundation is packaged but does not activate migration in production Ma
     'legacy-flat-source-retirement',
     'hkust-migration-destination-plan',
     'legacy-credential-rollback-state',
+    'legacy-credential-rollback-store',
     'legacy-flat-source-receipts',
     'vpn-credential-envelope',
     'vpn-credential-envelope-store',

--- a/docs/adr/0012-p3-rollback-retirement.md
+++ b/docs/adr/0012-p3-rollback-retirement.md
@@ -1,0 +1,63 @@
+# ADR-0012: P3 legacy credential rollback retirement
+
+- Status: Accepted as a non-activating P3f contract
+- Production migration: not enabled by this ADR
+- Parent contract: [`ADR-0011`](0011-p3-hkust-destination-plan.md)
+
+## Context
+
+P3e retains one independently bound copy of the old encrypted VPN credential for a one-release rollback path.
+Deleting that file with a single unlink is not enough: a crash may leave active metadata without ciphertext,
+retired metadata with resurrected ciphertext, or a credential mutation that reports success while reusable old
+ciphertext remains.
+
+## Decision
+
+`LegacyCredentialRollbackStore` is the only persistent owner of the account-scoped rollback blob, state and
+retirement intent. It validates the exact migration/Profile/account credential revisions, Gateway origin and
+ProtocolFamily before reading or changing any of them. The rollback blob is exposed only by the explicit
+`readActiveRollbackBlob()` adapter; ordinary connection and auto-connect code do not import the store.
+
+Retirement is one monotonic transaction:
+
+```text
+persist owner-only retirement intent
+  -> verify and unlink receipt-bound rollback ciphertext
+  -> fsync account directory
+  -> atomically commit retired metadata
+  -> verify the committed state
+  -> unlink retirement intent
+  -> fsync account directory
+```
+
+Password replacement, credential clear/logout, account removal and Profile reset must call
+`retireBeforeMutation()` before their own mutation can run. A later mutation failure does not reactivate the old
+credential.
+
+## Recovery and failure policy
+
+- intent + active state + present or missing matching blob resumes retirement;
+- intent + matching retired state clears the completed intent;
+- retired state + a matching resurrected dedicated blob creates an intent and removes it;
+- active state + missing blob without an intent is ambiguous and blocks;
+- missing state + present blob, binding mismatch, altered receipt, malformed intent, symlink, shared POSIX inode
+  or non-owner-only Windows ACL blocks;
+- no recovery path invents a successful retirement or copies ciphertext back into place.
+
+All JSON documents use bounded private-file reads and atomic owner-only writes. POSIX paths require a link-free,
+owner-only directory chain and single-link files. Windows temporary and committed files require current-user-only
+DACL protection and verification.
+
+## Verification
+
+Tests cover normal and repeated retirement, explicit rollback reads, blob unlink failure, crash after blob
+deletion, state commit failure, intent-clear failure, active/missing ambiguity, retired/blob resurrection,
+binding mismatch, symlink substitution, malformed intent, mutation failure after retirement and simulated Windows
+ACL protection.
+
+## Non-activation boundary
+
+Production `desktop/main.js` does not import this store or any other P3 migration module. P3f changes no installed
+credential, settings, Browser partition, connection behavior or release package. Production activation remains a
+separate gate that must wire all credential-mutating operations through this retirement contract and run packaged
+migration/recovery tests before a test App replaces the installed version.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -628,6 +628,9 @@ Non-activating storage foundation: [`ADR-0007`](../adr/0007-p3-storage-foundatio
   flat files non-recursively with the old settings authority last;
 - build exact HKUST global/profile/account/workspace documents, re-encrypt the matched username/password pair,
   and bind the one-release legacy ciphertext to active/retired rollback metadata;
+- retire the bound rollback ciphertext through a durable intent -> blob unlink -> retired-state commit -> intent
+  clear transaction, reconcile every crash boundary, and block active-without-blob ambiguity rather than
+  inventing a successful retirement;
 
 - split app-global and profile settings;
 - create `profiles/<profileKey>/accounts/<accountKey>/workspace/` from the start;


### PR DESCRIPTION
## What changed

- add a profile/account/origin/family-bound rollback store
- persist a retirement intent before removing reusable legacy ciphertext
- reconcile crashes around unlink, retired-state commit, and intent cleanup
- block credential mutation until retirement is proven
- extend the destination receipt schema with the absent initial retirement intent
- document the P3f contract in ADR-0012

## Safety boundary

- ordinary auto-connect cannot read the rollback blob
- malformed intent, binding drift, receipt drift, links, unsafe permissions, and ambiguous active-without-blob state fail closed
- production Main remains unchanged; this PR is the non-activating storage/recovery contract

## Verification

- Desktop: 686 passed, 0 failed, 1 Windows-only skip
- Rust: 274 passed, 0 failed, 2 explicit performance gates ignored
- architecture: 236 files, 344 edges, 0 cycles
- Clippy: 0 warnings
- npm audit: 0 vulnerabilities
- staged secret gate, JS syntax, shell syntax: PASS