### PR TITLE
2.0 P3g: bind active workspace runtime authority

### DIFF
--- a/desktop/lib/hkust-migration-destination-plan.js
+++ b/desktop/lib/hkust-migration-destination-plan.js
@@ -11,6 +11,13 @@ const {
   createLegacyCredentialRollbackState,
 } = require('./legacy-credential-rollback-state');
 const {
+  validateGlobalSettingsDocument,
+  validateGlobalUpdateStateDocument,
+  validateProfileSettingsDocument,
+  validateProfileStateDocument,
+  validateWorkspaceSettingsDocument,
+} = require('./profile-workspace-documents');
+const {
   validateCampusAccountDocument,
   validateWorkspaceScopeDocument,
 } = require('./school-profile-schema');
@@ -209,7 +216,7 @@ function createHkustMigrationDestinationPlan(options = {}) {
   });
 
   const files = {
-    globalSettings: jsonBuffer({
+    globalSettings: jsonBuffer(validateGlobalSettingsDocument({
       schemaVersion: 1,
       activeProfileKey: journal.identity.profileKey,
       activeAccountKey: journal.identity.accountKey,
@@ -220,19 +227,22 @@ function createHkustMigrationDestinationPlan(options = {}) {
       closeAction: settings.closeAction,
       language: settings.language,
       startAtLogin: settings.startAtLogin,
-    }),
+    })),
     globalProxyCredential: copyOrNull(payloads.proxyCredential),
     globalProxyHelperCredential: null,
     globalEngineOwner: null,
-    globalUpdateState: jsonBuffer({ schemaVersion: 1, checkedAt: settings.updateCheckedAt }),
+    globalUpdateState: jsonBuffer(validateGlobalUpdateStateDocument({
+      schemaVersion: 1,
+      checkedAt: settings.updateCheckedAt,
+    })),
     globalActiveContextSwitch: null,
-    profileSettings: jsonBuffer({
+    profileSettings: jsonBuffer(validateProfileSettingsDocument({
       schemaVersion: 1,
       profileId: journal.profileId,
       profileRevision: journal.profileRevision,
       primaryAccountKey: journal.identity.accountKey,
-    }),
-    profileState: jsonBuffer({
+    })),
+    profileState: jsonBuffer(validateProfileStateDocument({
       schemaVersion: 1,
       migrationId: journal.migrationId,
       profileId: journal.profileId,
@@ -240,7 +250,7 @@ function createHkustMigrationDestinationPlan(options = {}) {
       profileCredentialBindingRevision: journal.profileCredentialBindingRevision,
       gatewayOrigin: journal.gatewayOrigin,
       protocolFamily: journal.protocolFamily,
-    }),
+    })),
     account: jsonBuffer(accountDocument),
     vpnCredential: encryptedCredential,
     legacyCredentialRollbackBlob: copyOrNull(source.legacyCredential),
@@ -248,13 +258,13 @@ function createHkustMigrationDestinationPlan(options = {}) {
     legacyCredentialRollbackRetirement: null,
     credentialTransaction: null,
     deletionTombstone: null,
-    workspaceSettings: jsonBuffer({
+    workspaceSettings: jsonBuffer(validateWorkspaceSettingsDocument({
       schemaVersion: 1,
       autoReconnect: settings.autoReconnect,
       maxAttempts: settings.maxAttempts,
       autoConnect: settings.autoConnect,
       routeDomains: settings.routeDomains,
-    }),
+    })),
     workspaceState: jsonBuffer(workspace),
     siteCredentials: copyOrNull(payloads.siteCredentials),
     certificateTrust: copyOrNull(payloads.certificateTrust),

--- a/desktop/lib/profile-workspace-documents.js
+++ b/desktop/lib/profile-workspace-documents.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const { normalizeRouteDomains } = require('./pac');
+const {
+  normalizeGatewayOrigin,
+  validateOpaqueKey,
+  validateProfileId,
+  validateProtocolFamily,
+} = require('./school-profile-schema');
+const { isValidPort, PROXY_SECURITY_VERSION } = require('./settings-store');
+
+const PROFILE_WORKSPACE_DOCUMENT_VERSION = 1;
+
+function plainObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+  return value;
+}
+
+function exactKeys(value, keys, name) {
+  const source = plainObject(value, name);
+  const actual = Object.keys(source).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${name} has an invalid schema`);
+  }
+  return source;
+}
+
+function positive(value, name) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function boolean(value, name) {
+  if (typeof value !== 'boolean') throw new TypeError(`${name} must be boolean`);
+  return value;
+}
+
+function documentVersion(value, name) {
+  if (value !== PROFILE_WORKSPACE_DOCUMENT_VERSION) {
+    throw new TypeError(`${name} schema version is unsupported`);
+  }
+  return PROFILE_WORKSPACE_DOCUMENT_VERSION;
+}
+
+function validateGlobalSettingsDocument(value) {
+  const source = exactKeys(value, [
+    'schemaVersion', 'activeProfileKey', 'activeAccountKey', 'port', 'strictProxyAuth',
+    'proxySecurityVersion', 'proxyAuthMigrationPending', 'closeAction', 'language',
+    'startAtLogin',
+  ], 'global settings');
+  if (!isValidPort(source.port) || source.proxySecurityVersion !== PROXY_SECURITY_VERSION ||
+      !['ask', 'minimize', 'quit'].includes(source.closeAction) ||
+      !['auto', 'zh', 'en'].includes(source.language)) {
+    throw new TypeError('global settings contain an unsupported value');
+  }
+  const strictProxyAuth = boolean(source.strictProxyAuth, 'strictProxyAuth');
+  const proxyAuthMigrationPending = boolean(
+    source.proxyAuthMigrationPending,
+    'proxyAuthMigrationPending',
+  );
+  if (strictProxyAuth && proxyAuthMigrationPending) {
+    throw new TypeError('strict proxy authentication cannot have a pending compatibility decision');
+  }
+  return Object.freeze({
+    schemaVersion: documentVersion(source.schemaVersion, 'global settings'),
+    activeProfileKey: validateOpaqueKey(source.activeProfileKey, 'activeProfileKey'),
+    activeAccountKey: validateOpaqueKey(source.activeAccountKey, 'activeAccountKey'),
+    port: source.port,
+    strictProxyAuth,
+    proxySecurityVersion: PROXY_SECURITY_VERSION,
+    proxyAuthMigrationPending,
+    closeAction: source.closeAction,
+    language: source.language,
+    startAtLogin: boolean(source.startAtLogin, 'startAtLogin'),
+  });
+}
+
+function validateGlobalUpdateStateDocument(value) {
+  const source = exactKeys(value, ['schemaVersion', 'checkedAt'], 'global update state');
+  if (!Number.isSafeInteger(source.checkedAt) || source.checkedAt < 0) {
+    throw new TypeError('global update timestamp is invalid');
+  }
+  return Object.freeze({
+    schemaVersion: documentVersion(source.schemaVersion, 'global update state'),
+    checkedAt: source.checkedAt,
+  });
+}
+
+function validateProfileSettingsDocument(value) {
+  const source = exactKeys(value, [
+    'schemaVersion', 'profileId', 'profileRevision', 'primaryAccountKey',
+  ], 'profile settings');
+  return Object.freeze({
+    schemaVersion: documentVersion(source.schemaVersion, 'profile settings'),
+    profileId: validateProfileId(source.profileId),
+    profileRevision: positive(source.profileRevision, 'profileRevision'),
+    primaryAccountKey: validateOpaqueKey(source.primaryAccountKey, 'primaryAccountKey'),
+  });
+}
+
+function validateProfileStateDocument(value) {
+  const source = exactKeys(value, [
+    'schemaVersion', 'migrationId', 'profileId', 'profileRevision',
+    'profileCredentialBindingRevision', 'gatewayOrigin', 'protocolFamily',
+  ], 'profile state');
+  return Object.freeze({
+    schemaVersion: documentVersion(source.schemaVersion, 'profile state'),
+    migrationId: validateOpaqueKey(source.migrationId, 'migrationId'),
+    profileId: validateProfileId(source.profileId),
+    profileRevision: positive(source.profileRevision, 'profileRevision'),
+    profileCredentialBindingRevision: positive(
+      source.profileCredentialBindingRevision,
+      'profileCredentialBindingRevision',
+    ),
+    gatewayOrigin: normalizeGatewayOrigin(source.gatewayOrigin).origin,
+    protocolFamily: validateProtocolFamily(source.protocolFamily),
+  });
+}
+
+function validateWorkspaceSettingsDocument(value) {
+  const source = exactKeys(value, [
+    'schemaVersion', 'autoReconnect', 'maxAttempts', 'autoConnect', 'routeDomains',
+  ], 'workspace settings');
+  if (!Number.isSafeInteger(source.maxAttempts) || source.maxAttempts < 0 ||
+      source.maxAttempts > 10 || !Array.isArray(source.routeDomains) ||
+      source.routeDomains.length < 1 || source.routeDomains.length > 64) {
+    throw new TypeError('workspace settings contain an unsupported value');
+  }
+  const routeDomains = normalizeRouteDomains(source.routeDomains);
+  if (routeDomains.length !== source.routeDomains.length ||
+      routeDomains.some((domain, index) => domain !== source.routeDomains[index])) {
+    throw new TypeError('workspace route domains are not canonical');
+  }
+  return Object.freeze({
+    schemaVersion: documentVersion(source.schemaVersion, 'workspace settings'),
+    autoReconnect: boolean(source.autoReconnect, 'autoReconnect'),
+    maxAttempts: source.maxAttempts,
+    autoConnect: boolean(source.autoConnect, 'autoConnect'),
+    routeDomains: Object.freeze(routeDomains),
+  });
+}
+
+module.exports = {
+  PROFILE_WORKSPACE_DOCUMENT_VERSION,
+  validateGlobalSettingsDocument,
+  validateGlobalUpdateStateDocument,
+  validateProfileSettingsDocument,
+  validateProfileStateDocument,
+  validateWorkspaceSettingsDocument,
+};

--- a/desktop/lib/profile-workspace-layout.js
+++ b/desktop/lib/profile-workspace-layout.js
@@ -54,33 +54,13 @@ function createLegacyFlatSourcePaths(userData) {
   });
 }
 
-function createProfileAccountWorkspaceLayout({
-  userData,
-  profileKey,
-  accountKey,
-  workspaceKey,
-  adoptLegacyHkustBrowserPartition = false,
-} = {}) {
-  const root = normalizedUserData(userData);
-  const keys = {
-    profileKey: validateOpaqueKey(profileKey, 'profileKey'),
-    accountKey: validateOpaqueKey(accountKey, 'accountKey'),
-    workspaceKey: validateOpaqueKey(workspaceKey, 'workspaceKey'),
-  };
-  if (new Set(Object.values(keys)).size !== 3) {
-    throw new TypeError('profile, account and workspace keys must be distinct');
-  }
-  if (typeof adoptLegacyHkustBrowserPartition !== 'boolean') {
-    throw new TypeError('legacy Browser partition adoption must be explicit');
-  }
-
+function createProfileAccountRoots(root, keys) {
   const globalRoot = path.join(root, 'global');
   const profileRoot = path.join(root, 'profiles', keys.profileKey);
   const accountRoot = path.join(profileRoot, 'accounts', keys.accountKey);
-  const workspaceRoot = path.join(accountRoot, 'workspace');
-  return deepFreeze({
+  return {
     root,
-    identity: keys,
+    identity: { profileKey: keys.profileKey, accountKey: keys.accountKey },
     global: {
       root: globalRoot,
       settings: path.join(globalRoot, 'settings.json'),
@@ -109,6 +89,47 @@ function createProfileAccountWorkspaceLayout({
       credentialTransaction: path.join(accountRoot, 'credential-transaction.json'),
       deletionTombstone: path.join(accountRoot, 'deletion-tombstone.json'),
     },
+  };
+}
+
+function createProfileAccountBootstrapLayout({ userData, profileKey, accountKey } = {}) {
+  const root = normalizedUserData(userData);
+  const keys = {
+    profileKey: validateOpaqueKey(profileKey, 'profileKey'),
+    accountKey: validateOpaqueKey(accountKey, 'accountKey'),
+  };
+  if (keys.profileKey === keys.accountKey) {
+    throw new TypeError('profile and account keys must be distinct');
+  }
+  return deepFreeze(createProfileAccountRoots(root, keys));
+}
+
+function createProfileAccountWorkspaceLayout({
+  userData,
+  profileKey,
+  accountKey,
+  workspaceKey,
+  adoptLegacyHkustBrowserPartition = false,
+} = {}) {
+  const root = normalizedUserData(userData);
+  const keys = {
+    profileKey: validateOpaqueKey(profileKey, 'profileKey'),
+    accountKey: validateOpaqueKey(accountKey, 'accountKey'),
+    workspaceKey: validateOpaqueKey(workspaceKey, 'workspaceKey'),
+  };
+  if (new Set(Object.values(keys)).size !== 3) {
+    throw new TypeError('profile, account and workspace keys must be distinct');
+  }
+  if (typeof adoptLegacyHkustBrowserPartition !== 'boolean') {
+    throw new TypeError('legacy Browser partition adoption must be explicit');
+  }
+
+  const base = createProfileAccountRoots(root, keys);
+  const accountRoot = base.account.root;
+  const workspaceRoot = path.join(accountRoot, 'workspace');
+  return deepFreeze({
+    ...base,
+    identity: keys,
     workspace: {
       root: workspaceRoot,
       settings: path.join(workspaceRoot, 'workspace-settings.json'),
@@ -135,6 +156,7 @@ function createProfileAccountWorkspaceLayout({
 module.exports = {
   LEGACY_HKUST_BROWSER_PARTITION,
   createLegacyFlatSourcePaths,
+  createProfileAccountBootstrapLayout,
   createProfileAccountWorkspaceLayout,
   validateUserDataRoot: normalizedUserData,
 };

--- a/desktop/lib/profile-workspace-runtime-authority.js
+++ b/desktop/lib/profile-workspace-runtime-authority.js
@@ -1,0 +1,222 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { collectPrivateFileReceipt } = require('./legacy-flat-source-receipts');
+const { readPrivateFileBounded } = require('./private-file');
+const {
+  createProfileAccountBootstrapLayout,
+  createProfileAccountWorkspaceLayout,
+  validateUserDataRoot,
+} = require('./profile-workspace-layout');
+const {
+  validateGlobalSettingsDocument,
+  validateGlobalUpdateStateDocument,
+  validateProfileSettingsDocument,
+  validateProfileStateDocument,
+  validateWorkspaceSettingsDocument,
+} = require('./profile-workspace-documents');
+const {
+  validateCampusAccountDocument,
+  validateSchoolProfileDocument,
+  validateWorkspaceScopeDocument,
+} = require('./school-profile-schema');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+const MAX_RUNTIME_DOCUMENT_BYTES = 512 * 1024;
+const MAX_RUNTIME_CREDENTIAL_BYTES = 64 * 1024;
+
+function equal(left, right, name) {
+  if (left !== right) throw new Error(`active workspace ${name} binding does not match`);
+}
+
+function directoryChain(root, directory, { fileSystem, platform }) {
+  const relative = path.relative(root, directory);
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error('active workspace directory escapes userData');
+  }
+  let current = root;
+  for (const component of ['', ...relative.split(path.sep).filter(Boolean)]) {
+    if (component) current = path.join(current, component);
+    let stat;
+    try {
+      stat = fileSystem.lstatSync(current);
+    } catch (error) {
+      throw new Error('active workspace directory is unavailable', { cause: error });
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink() ||
+        (platform !== 'win32' && (stat.mode & 0o077) !== 0)) {
+      throw new Error('active workspace directory is not owner-only and link-free');
+    }
+  }
+}
+
+function readDocument(file, validator, deps) {
+  directoryChain(deps.root, path.dirname(file), deps);
+  if (deps.platform === 'win32' && !deps.windowsAcl.verify(file)) {
+    throw new Error('active workspace private file ACL is invalid');
+  }
+  let data;
+  try {
+    ({ data } = readPrivateFileBounded(file, {
+      maxBytes: MAX_RUNTIME_DOCUMENT_BYTES,
+      minBytes: 2,
+      platform: deps.platform,
+      fileSystem: deps.fileSystem,
+    }));
+  } catch (error) {
+    throw new Error('active workspace private document could not be read', { cause: error });
+  }
+  try {
+    return validator(JSON.parse(data.toString('utf8')));
+  } catch (error) {
+    throw new Error('active workspace document is invalid', { cause: error });
+  } finally {
+    data.fill(0);
+  }
+}
+
+function credentialReceipt(file, deps) {
+  directoryChain(deps.root, path.dirname(file), deps);
+  const receipt = collectPrivateFileReceipt({
+    file,
+    maxBytes: MAX_RUNTIME_CREDENTIAL_BYTES,
+    fileSystem: deps.fileSystem,
+    platform: deps.platform,
+    windowsAcl: deps.windowsAcl,
+    label: 'active workspace VPN credential',
+  });
+  if (receipt.present && receipt.bytes < 1) {
+    throw new Error('active workspace VPN credential is empty');
+  }
+  return receipt;
+}
+
+function bindingFrom(profile, profileState, account) {
+  return Object.freeze({
+    profileId: profile.profileId,
+    profileCredentialBindingRevision: profileState.profileCredentialBindingRevision,
+    accountKey: account.accountKey,
+    accountCredentialRevision: account.accountCredentialRevision,
+    gatewayOrigin: profile.gateway.origin.origin,
+    protocolFamily: profile.gateway.protocolFamily,
+  });
+}
+
+function loadActiveProfileWorkspaceAuthority({
+  userData,
+  profile: rawProfile,
+  fileSystem = fs,
+  platform = process.platform,
+  windowsAcl = {
+    protect: protectWindowsFileOwnerOnly,
+    verify: verifyWindowsFileOwnerOnly,
+  },
+} = {}) {
+  if (!fileSystem || typeof fileSystem.openSync !== 'function' ||
+      !['darwin', 'linux', 'win32'].includes(platform) ||
+      (platform === 'win32' && typeof windowsAcl?.verify !== 'function')) {
+    throw new TypeError('active workspace authority dependencies are invalid');
+  }
+  const root = validateUserDataRoot(userData);
+  const profile = validateSchoolProfileDocument(rawProfile);
+  const deps = { root, fileSystem, platform, windowsAcl };
+  const globalSettings = readDocument(
+    path.join(root, 'global', 'settings.json'),
+    validateGlobalSettingsDocument,
+    deps,
+  );
+  const bootstrap = createProfileAccountBootstrapLayout({
+    userData: root,
+    profileKey: globalSettings.activeProfileKey,
+    accountKey: globalSettings.activeAccountKey,
+  });
+  const globalUpdateState = readDocument(
+    bootstrap.global.updateState,
+    validateGlobalUpdateStateDocument,
+    deps,
+  );
+  const profileSettings = readDocument(
+    bootstrap.profile.settings,
+    validateProfileSettingsDocument,
+    deps,
+  );
+  const profileState = readDocument(
+    bootstrap.profile.state,
+    validateProfileStateDocument,
+    deps,
+  );
+  const account = readDocument(
+    bootstrap.account.document,
+    validateCampusAccountDocument,
+    deps,
+  );
+
+  equal(profileSettings.profileId, profile.profileId, 'Profile ID');
+  equal(profileSettings.profileRevision, profile.profileRevision, 'Profile revision');
+  equal(profileSettings.primaryAccountKey, globalSettings.activeAccountKey, 'primary account');
+  equal(profileState.profileId, profile.profileId, 'Profile state ID');
+  equal(profileState.profileRevision, profile.profileRevision, 'Profile state revision');
+  equal(
+    profileState.profileCredentialBindingRevision,
+    profile.profileCredentialBindingRevision,
+    'Profile credential revision',
+  );
+  equal(profileState.gatewayOrigin, profile.gateway.origin.origin, 'Gateway origin');
+  equal(profileState.protocolFamily, profile.gateway.protocolFamily, 'ProtocolFamily');
+  equal(account.accountKey, globalSettings.activeAccountKey, 'account key');
+  equal(account.profileId, profile.profileId, 'account Profile ID');
+  equal(account.profileRevision, profile.profileRevision, 'account Profile revision');
+  equal(account.gatewayOrigin.origin, profile.gateway.origin.origin, 'account Gateway origin');
+  equal(account.protocolFamily, profile.gateway.protocolFamily, 'account ProtocolFamily');
+  if (account.role !== 'primary' || account.state !== 'enabled') {
+    throw new Error('active workspace account is not an enabled primary account');
+  }
+
+  const layout = createProfileAccountWorkspaceLayout({
+    userData: root,
+    profileKey: globalSettings.activeProfileKey,
+    accountKey: globalSettings.activeAccountKey,
+    workspaceKey: account.workspaceKey,
+    adoptLegacyHkustBrowserPartition: true,
+  });
+  const workspaceSettings = readDocument(
+    layout.workspace.settings,
+    validateWorkspaceSettingsDocument,
+    deps,
+  );
+  const workspaceState = readDocument(
+    layout.workspace.state,
+    (value) => validateWorkspaceScopeDocument(value, { account }),
+    deps,
+  );
+  const observedCredential = credentialReceipt(layout.account.vpnCredential, deps);
+  equal(
+    observedCredential.present,
+    account.activeCredentialVersion !== null,
+    'credential presence',
+  );
+
+  return Object.freeze({
+    profile,
+    layout,
+    globalSettings,
+    globalUpdateState,
+    profileSettings,
+    profileState,
+    account,
+    workspaceSettings,
+    workspaceState,
+    credentialBinding: bindingFrom(profile, profileState, account),
+    hasCredential: observedCredential.present,
+  });
+}
+
+module.exports = {
+  MAX_RUNTIME_CREDENTIAL_BYTES,
+  MAX_RUNTIME_DOCUMENT_BYTES,
+  loadActiveProfileWorkspaceAuthority,
+};

--- a/desktop/lib/windows-private-file.js
+++ b/desktop/lib/windows-private-file.js
@@ -5,10 +5,11 @@ const { execFileSync } = require('node:child_process');
 
 const PRIVATE_FILE_ENV = 'HKUSTGZ_PRIVATE_FILE';
 const POWERSHELL_ARGS = Object.freeze(['-NoLogo', '-NoProfile', '-NonInteractive', '-Command']);
-// Windows hosted runners and freshly booted user sessions can take more than
-// five seconds to cold-start Windows PowerShell. Keep the ACL operation
-// bounded, but do not reject a secure sidecar merely because startup is slow.
-const POWERSHELL_ACL_TIMEOUT_MS = 15_000;
+// Windows hosted runners and freshly booted user sessions can occasionally
+// take more than fifteen seconds to cold-start Windows PowerShell. Keep the ACL
+// operation bounded, but do not reject a secure sidecar merely because startup
+// is slow.
+const POWERSHELL_ACL_TIMEOUT_MS = 30_000;
 const COMMON_PREFIX = String.raw`
 $ErrorActionPreference = 'Stop'
 $privatePath = [Environment]::GetEnvironmentVariable('${PRIVATE_FILE_ENV}')

--- a/desktop/test/profile-workspace-documents.test.js
+++ b/desktop/test/profile-workspace-documents.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  validateGlobalSettingsDocument,
+  validateGlobalUpdateStateDocument,
+  validateProfileSettingsDocument,
+  validateProfileStateDocument,
+  validateWorkspaceSettingsDocument,
+} = require('../lib/profile-workspace-documents');
+
+const PROFILE_KEY = `profile-${'11'.repeat(16)}`;
+const ACCOUNT_KEY = `account-${'22'.repeat(16)}`;
+
+test('runtime storage documents are exact canonical and immutable', () => {
+  const global = validateGlobalSettingsDocument({
+    schemaVersion: 1,
+    activeProfileKey: PROFILE_KEY,
+    activeAccountKey: ACCOUNT_KEY,
+    port: 6180,
+    strictProxyAuth: true,
+    proxySecurityVersion: 3,
+    proxyAuthMigrationPending: false,
+    closeAction: 'minimize',
+    language: 'en',
+    startAtLogin: true,
+  });
+  const update = validateGlobalUpdateStateDocument({ schemaVersion: 1, checkedAt: 0 });
+  const profile = validateProfileSettingsDocument({
+    schemaVersion: 1,
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    primaryAccountKey: ACCOUNT_KEY,
+  });
+  const state = validateProfileStateDocument({
+    schemaVersion: 1,
+    migrationId: `migration-${'33'.repeat(16)}`,
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    profileCredentialBindingRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
+  });
+  const workspace = validateWorkspaceSettingsDocument({
+    schemaVersion: 1,
+    autoReconnect: true,
+    maxAttempts: 3,
+    autoConnect: false,
+    routeDomains: ['hkust-gz.edu.cn', 'hkust.edu.hk'],
+  });
+  for (const document of [global, update, profile, state, workspace]) {
+    assert.equal(Object.isFrozen(document), true);
+  }
+  assert.equal(Object.isFrozen(workspace.routeDomains), true);
+  assert.equal(state.gatewayOrigin, 'https://remote.hkust-gz.edu.cn');
+});
+
+test('runtime storage documents reject drift instead of normalizing it silently', () => {
+  const global = {
+    schemaVersion: 1,
+    activeProfileKey: PROFILE_KEY,
+    activeAccountKey: ACCOUNT_KEY,
+    port: 6180,
+    strictProxyAuth: false,
+    proxySecurityVersion: 3,
+    proxyAuthMigrationPending: true,
+    closeAction: 'ask',
+    language: 'auto',
+    startAtLogin: false,
+  };
+  assert.throws(() => validateGlobalSettingsDocument({ ...global, extra: true }), /schema/u);
+  assert.throws(() => validateGlobalSettingsDocument({
+    ...global,
+    strictProxyAuth: true,
+  }), /pending/u);
+  assert.throws(() => validateGlobalUpdateStateDocument({
+    schemaVersion: 1,
+    checkedAt: -1,
+  }), /timestamp/u);
+  assert.throws(() => validateWorkspaceSettingsDocument({
+    schemaVersion: 1,
+    autoReconnect: true,
+    maxAttempts: 3,
+    autoConnect: true,
+    routeDomains: ['*.HKUST-GZ.EDU.CN'],
+  }), /canonical/u);
+});

--- a/desktop/test/profile-workspace-runtime-authority.test.js
+++ b/desktop/test/profile-workspace-runtime-authority.test.js
@@ -1,0 +1,216 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  createProfileAccountBootstrapLayout,
+  createProfileAccountWorkspaceLayout,
+} = require('../lib/profile-workspace-layout');
+const {
+  loadActiveProfileWorkspaceAuthority,
+} = require('../lib/profile-workspace-runtime-authority');
+
+const PROFILE_KEY = `profile-${'11'.repeat(16)}`;
+const ACCOUNT_KEY = `account-${'22'.repeat(16)}`;
+const WORKSPACE_KEY = `workspace-${'33'.repeat(16)}`;
+const MIGRATION_ID = `migration-${'44'.repeat(16)}`;
+
+function profile() {
+  return JSON.parse(fs.readFileSync(
+    path.join(__dirname, '..', 'assets', 'profiles', 'hkustgz', 'school-profile.json'),
+    'utf8',
+  ));
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+}
+
+function fixture(t, { withCredential = true } = {}) {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-runtime-authority-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const bootstrap = createProfileAccountBootstrapLayout({
+    userData,
+    profileKey: PROFILE_KEY,
+    accountKey: ACCOUNT_KEY,
+  });
+  const layout = createProfileAccountWorkspaceLayout({
+    userData,
+    profileKey: PROFILE_KEY,
+    accountKey: ACCOUNT_KEY,
+    workspaceKey: WORKSPACE_KEY,
+    adoptLegacyHkustBrowserPartition: true,
+  });
+  writeJson(bootstrap.global.settings, {
+    schemaVersion: 1,
+    activeProfileKey: PROFILE_KEY,
+    activeAccountKey: ACCOUNT_KEY,
+    port: 6180,
+    strictProxyAuth: true,
+    proxySecurityVersion: 3,
+    proxyAuthMigrationPending: false,
+    closeAction: 'minimize',
+    language: 'zh',
+    startAtLogin: false,
+  });
+  writeJson(bootstrap.global.updateState, { schemaVersion: 1, checkedAt: 1_700_000_000_000 });
+  writeJson(bootstrap.profile.settings, {
+    schemaVersion: 1,
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    primaryAccountKey: ACCOUNT_KEY,
+  });
+  writeJson(bootstrap.profile.state, {
+    schemaVersion: 1,
+    migrationId: MIGRATION_ID,
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    profileCredentialBindingRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
+  });
+  writeJson(bootstrap.account.document, {
+    schemaVersion: 1,
+    accountKey: ACCOUNT_KEY,
+    accountRevision: 1,
+    accountCredentialRevision: 1,
+    role: 'primary',
+    state: 'enabled',
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
+    workspaceKey: WORKSPACE_KEY,
+    activeCredentialVersion: withCredential ? 1 : null,
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+  });
+  writeJson(layout.workspace.settings, {
+    schemaVersion: 1,
+    autoReconnect: true,
+    maxAttempts: 3,
+    autoConnect: false,
+    routeDomains: ['hkust-gz.edu.cn', 'hkust.edu.hk'],
+  });
+  writeJson(layout.workspace.state, {
+    schemaVersion: 1,
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    accountKey: ACCOUNT_KEY,
+    accountRevision: 1,
+    workspaceKey: WORKSPACE_KEY,
+    activeContextEpoch: 1,
+  });
+  if (withCredential) {
+    fs.writeFileSync(layout.account.vpnCredential, Buffer.from('synthetic-encrypted-envelope'), {
+      mode: 0o600,
+    });
+  }
+  return { userData, bootstrap, layout };
+}
+
+test('authority loads one exact active Profile Account Workspace without decrypting credentials', (t) => {
+  const value = fixture(t);
+  const authority = loadActiveProfileWorkspaceAuthority({
+    userData: value.userData,
+    profile: profile(),
+  });
+  assert.equal(authority.globalSettings.port, 6180);
+  assert.equal(authority.workspaceSettings.autoConnect, false);
+  assert.equal(authority.account.accountKey, ACCOUNT_KEY);
+  assert.equal(authority.workspaceState.workspaceKey, WORKSPACE_KEY);
+  assert.equal(authority.hasCredential, true);
+  assert.equal(authority.layout.browserPartition, 'persist:hkustgz-campus-browser');
+  assert.deepEqual(authority.credentialBinding, {
+    profileId: 'hkustgz',
+    profileCredentialBindingRevision: 1,
+    accountKey: ACCOUNT_KEY,
+    accountCredentialRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
+  });
+  const keys = [];
+  JSON.parse(JSON.stringify(authority), (key, value) => {
+    if (key) keys.push(key.toLowerCase());
+    return value;
+  });
+  assert.equal(keys.includes('username'), false);
+  assert.equal(keys.includes('password'), false);
+});
+
+test('authority rejects cross-account and reviewed Profile binding drift', (t) => {
+  const value = fixture(t);
+  const global = JSON.parse(fs.readFileSync(value.bootstrap.global.settings, 'utf8'));
+  writeJson(value.bootstrap.global.settings, {
+    ...global,
+    activeAccountKey: `account-${'55'.repeat(16)}`,
+  });
+  assert.throws(() => loadActiveProfileWorkspaceAuthority({
+    userData: value.userData,
+    profile: profile(),
+  }), /could not be read|unavailable/u);
+
+  writeJson(value.bootstrap.global.settings, global);
+  const profileState = JSON.parse(fs.readFileSync(value.bootstrap.profile.state, 'utf8'));
+  writeJson(value.bootstrap.profile.state, {
+    ...profileState,
+    gatewayOrigin: 'https://other.example.edu',
+  });
+  assert.throws(() => loadActiveProfileWorkspaceAuthority({
+    userData: value.userData,
+    profile: profile(),
+  }), /Gateway origin binding/u);
+});
+
+test('authority accepts an explicitly credential-free account without probing secure storage', (t) => {
+  const value = fixture(t, { withCredential: false });
+  const authority = loadActiveProfileWorkspaceAuthority({
+    userData: value.userData,
+    profile: profile(),
+  });
+  assert.equal(authority.hasCredential, false);
+  assert.equal(authority.account.activeCredentialVersion, null);
+});
+
+test('authority rejects credential presence drift and unsafe private paths', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const missing = fixture(t, { withCredential: false });
+  fs.writeFileSync(missing.layout.account.vpnCredential, 'unexpected', { mode: 0o600 });
+  assert.throws(() => loadActiveProfileWorkspaceAuthority({
+    userData: missing.userData,
+    profile: profile(),
+  }), /credential presence binding/u);
+
+  const linked = fixture(t);
+  const target = path.join(linked.userData, 'unrelated.json');
+  fs.writeFileSync(target, fs.readFileSync(linked.layout.workspace.settings), { mode: 0o600 });
+  fs.unlinkSync(linked.layout.workspace.settings);
+  fs.symlinkSync(target, linked.layout.workspace.settings);
+  assert.throws(() => loadActiveProfileWorkspaceAuthority({
+    userData: linked.userData,
+    profile: profile(),
+  }), /private document/u);
+  assert.equal(fs.existsSync(target), true);
+});
+
+test('simulated Windows authority verifies every persistent document and credential ACL', (t) => {
+  const value = fixture(t);
+  const verified = [];
+  const authority = loadActiveProfileWorkspaceAuthority({
+    userData: value.userData,
+    profile: profile(),
+    platform: 'win32',
+    windowsAcl: {
+      verify(file) { verified.push(file); return fs.existsSync(file); },
+    },
+  });
+  assert.equal(authority.hasCredential, true);
+  assert.equal(verified.includes(value.layout.account.vpnCredential), true);
+  assert.equal(verified.includes(value.layout.workspace.state), true);
+  assert.equal(verified.length >= 7, true);
+});

--- a/desktop/test/profile-workspace-storage.test.js
+++ b/desktop/test/profile-workspace-storage.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const test = require('node:test');
 const {
   LEGACY_HKUST_BROWSER_PARTITION,
+  createProfileAccountBootstrapLayout,
   createProfileAccountWorkspaceLayout,
 } = require('../lib/profile-workspace-layout');
 const {
@@ -93,6 +94,24 @@ test('only the migrated HKUST primary workspace adopts the legacy Browser partit
     ...input,
     adoptLegacyHkustBrowserPartition: true,
   }).browserPartition, LEGACY_HKUST_BROWSER_PARTITION);
+});
+
+test('bootstrap layout discovers Account authority before the Workspace key is known', () => {
+  const input = {
+    userData: path.resolve('/tmp/campus-connect-user-data'),
+    profileKey: PROFILE_KEY,
+    accountKey: ACCOUNT_KEY,
+  };
+  const bootstrap = createProfileAccountBootstrapLayout(input);
+  const complete = createProfileAccountWorkspaceLayout({
+    ...input,
+    workspaceKey: WORKSPACE_KEY,
+  });
+  assert.deepEqual(bootstrap.global, complete.global);
+  assert.deepEqual(bootstrap.profile, complete.profile);
+  assert.deepEqual(bootstrap.account, complete.account);
+  assert.equal(Object.hasOwn(bootstrap, 'workspace'), false);
+  assert.equal(Object.isFrozen(bootstrap.account), true);
 });
 
 test('layout rejects relative roots, traversal keys and key reuse', () => {
@@ -223,6 +242,8 @@ test('P3 foundation is packaged but does not activate migration in production Ma
     'hkust-migration-destination-plan',
     'legacy-credential-rollback-state',
     'legacy-credential-rollback-store',
+    'profile-workspace-documents',
+    'profile-workspace-runtime-authority',
     'legacy-flat-source-receipts',
     'vpn-credential-envelope',
     'vpn-credential-envelope-store',

--- a/desktop/test/windows-private-file.test.js
+++ b/desktop/test/windows-private-file.test.js
@@ -57,7 +57,7 @@ test('Windows ACL commands keep paths out of scripts and require fixed verificat
 });
 
 test('Windows ACL subprocess remains bounded but tolerates a cold PowerShell start', () => {
-  assert.equal(POWERSHELL_ACL_TIMEOUT_MS, 15_000);
+  assert.equal(POWERSHELL_ACL_TIMEOUT_MS, 30_000);
 });
 
 test('real Windows ACL is current-user-only and inheritance-protected', {

--- a/docs/adr/0013-p3-runtime-authority.md
+++ b/docs/adr/0013-p3-runtime-authority.md
@@ -1,0 +1,65 @@
+# ADR-0013: P3 active Profile/Account/Workspace runtime authority
+
+- Status: Accepted as a non-activating P3g contract
+- Production storage switch: not enabled by this ADR
+- Parent contracts: [`ADR-0011`](0011-p3-hkust-destination-plan.md),
+  [`ADR-0012`](0012-p3-rollback-retirement.md)
+
+## Context
+
+The migration planner can write split global, Profile, Account and Workspace documents, but production cannot
+switch from the legacy flat paths until it can prove that one exact destination tree belongs to the packaged
+reviewed Profile. Reading files merely because they appear below an opaque directory would permit stale or
+cross-account state to become active.
+
+The account document contains the Workspace key, so runtime discovery also needs a bounded bootstrap layout that
+can reach only global, Profile and Account authority before the final Workspace layout and Browser partition are
+derived.
+
+## Decision
+
+`profile-workspace-documents.js` is the single strict schema for:
+
+- global active keys and application settings;
+- global update state;
+- Profile settings and immutable migration/Profile/Gateway state;
+- Workspace connection and routing settings.
+
+The HKUST destination planner validates every emitted document through these same functions. Runtime never
+normalizes malformed destination documents to defaults; unknown fields, noncanonical route domains and invalid
+security combinations fail closed.
+
+`loadActiveProfileWorkspaceAuthority()` follows one ordered chain:
+
+```text
+validated reviewed SchoolProfile
+  -> owner-only global settings and active opaque keys
+  -> bootstrap Profile and Account paths
+  -> exact Profile settings/state
+  -> exact enabled primary CampusAccount
+  -> final Workspace layout from the bound workspaceKey
+  -> exact Workspace settings/state
+  -> owner-only VPN ciphertext presence receipt
+```
+
+Every layer must match the reviewed Profile ID/revision, credential-binding revision, Gateway origin,
+ProtocolFamily, Account key/revision and Workspace key/revision. Credential presence must agree with
+`activeCredentialVersion`. The loader hashes the bounded ciphertext only to prove private-file presence and never
+decrypts it, asks secure storage for access or returns a username/password.
+
+All parent directories are required to be owner-only and link-free on POSIX. Every document and credential must
+have a current-user-only DACL on Windows. The returned authority is Main-internal and contains persistent opaque
+keys; it is not a Renderer projection.
+
+## Verification
+
+Tests cover exact immutable schemas, canonical routing values, bootstrap/full-layout agreement, successful
+credential and credential-free Accounts, cross-account lookup, reviewed Profile/Gateway drift, credential
+presence drift, symlink substitution, unsafe private files and simulated Windows ACL verification. The planner's
+existing migration tests prove that writer and reader share the schema.
+
+## Non-activation boundary and next gate
+
+Production `desktop/main.js` does not import the runtime authority. P3h must add transactionally writable split
+settings and VPN credential adapters while keeping the legacy UI/connection behavior as a projection. Only P3i
+may activate startup migration and replace the installed test App after packaged restart/recovery tests pass.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -631,6 +631,9 @@ Non-activating storage foundation: [`ADR-0007`](../adr/0007-p3-storage-foundatio
 - retire the bound rollback ciphertext through a durable intent -> blob unlink -> retired-state commit -> intent
   clear transaction, reconcile every crash boundary, and block active-without-blob ambiguity rather than
   inventing a successful retirement;
+- load the destination authority from global active opaque keys through exact Profile/Account/Workspace
+  documents, verify reviewed Gateway/protocol/revision and credential-presence bindings without decrypting the
+  VPN credential, and share the same strict document validators with migration planning;
 
 - split app-global and profile settings;
 - create `profiles/<profileKey>/accounts/<accountKey>/workspace/` from the start;


### PR DESCRIPTION
## What changed

- define one exact schema for global, Profile and Workspace runtime documents
- make the HKUST migration planner validate output through the same schema
- add a bootstrap layout for discovering Account authority before the Workspace key is known
- load one active Profile/Account/Workspace tree through reviewed revision, Gateway, protocol and credential-presence bindings
- verify owner-only/link-free POSIX paths and current-user-only Windows ACLs
- inspect encrypted credential presence without decrypting it or touching secure storage

## Safety boundary

- cross-account, stale Profile, wrong Gateway/protocol, credential-presence drift and malformed documents fail closed
- persistent opaque keys remain Main-internal and are not Renderer projections
- production Main remains unchanged; P3h adds writable adapters before P3i activation

## Verification

- Desktop: 694 passed, 0 failed, 1 Windows-only skip
- architecture: 240 files, 357 edges, 0 cycles
- npm audit: 0 vulnerabilities
- staged secret gate and all JS syntax: PASS