### PR TITLE
2.0 P3h: transact split workspace settings

### DIFF
--- a/desktop/lib/hkust-migration-destination-plan.js
+++ b/desktop/lib/hkust-migration-destination-plan.js
@@ -13,6 +13,7 @@ const {
 const {
   validateGlobalSettingsDocument,
   validateGlobalUpdateStateDocument,
+  validateLocalResourcesDocument,
   validateProfileSettingsDocument,
   validateProfileStateDocument,
   validateWorkspaceSettingsDocument,
@@ -236,6 +237,7 @@ function createHkustMigrationDestinationPlan(options = {}) {
       checkedAt: settings.updateCheckedAt,
     })),
     globalActiveContextSwitch: null,
+    globalSettingsTransaction: null,
     profileSettings: jsonBuffer(validateProfileSettingsDocument({
       schemaVersion: 1,
       profileId: journal.profileId,
@@ -271,7 +273,10 @@ function createHkustMigrationDestinationPlan(options = {}) {
     routingRules: copyOrNull(payloads.routingRules),
     externalPac: copyOrNull(payloads.externalPac),
     browserPac: copyOrNull(payloads.browserPac),
-    localResources: jsonBuffer({ schemaVersion: 1, resources: settings.customResources }),
+    localResources: jsonBuffer(validateLocalResourcesDocument({
+      schemaVersion: 1,
+      resources: settings.customResources,
+    })),
     favorites: jsonBuffer({ schemaVersion: 1, entries: [] }),
     recentResources: jsonBuffer({ schemaVersion: 1, entries: [] }),
     externalIntegrations: jsonBuffer({ schemaVersion: 1, entries: [] }),

--- a/desktop/lib/profile-workspace-destination-files.js
+++ b/desktop/lib/profile-workspace-destination-files.js
@@ -26,6 +26,7 @@ function destinationPathMap(layout) {
     globalEngineOwner: layout.global.engineOwner,
     globalUpdateState: layout.global.updateState,
     globalActiveContextSwitch: layout.global.activeContextSwitch,
+    globalSettingsTransaction: layout.global.settingsTransaction,
     profileSettings: layout.profile.settings,
     profileState: layout.profile.state,
     account: layout.account.document,

--- a/desktop/lib/profile-workspace-documents.js
+++ b/desktop/lib/profile-workspace-documents.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { validateCustomResourceDocument } = require('./campus-resource-contract');
 const { normalizeRouteDomains } = require('./pac');
 const {
   normalizeGatewayOrigin,
@@ -146,10 +147,26 @@ function validateWorkspaceSettingsDocument(value) {
   });
 }
 
+function validateLocalResourcesDocument(value) {
+  const source = exactKeys(value, ['schemaVersion', 'resources'], 'local resources');
+  const resources = validateCustomResourceDocument(source.resources).map((resource) => Object.freeze({
+    id: resource.id,
+    name: resource.name,
+    description: resource.description,
+    url: resource.url,
+    route: resource.route,
+  }));
+  return Object.freeze({
+    schemaVersion: documentVersion(source.schemaVersion, 'local resources'),
+    resources: Object.freeze(resources),
+  });
+}
+
 module.exports = {
   PROFILE_WORKSPACE_DOCUMENT_VERSION,
   validateGlobalSettingsDocument,
   validateGlobalUpdateStateDocument,
+  validateLocalResourcesDocument,
   validateProfileSettingsDocument,
   validateProfileStateDocument,
   validateWorkspaceSettingsDocument,

--- a/desktop/lib/profile-workspace-layout.js
+++ b/desktop/lib/profile-workspace-layout.js
@@ -69,6 +69,7 @@ function createProfileAccountRoots(root, keys) {
       engineOwner: path.join(globalRoot, 'engine-owner.json'),
       updateState: path.join(globalRoot, 'update-state.json'),
       activeContextSwitch: path.join(globalRoot, 'active-context-switch.json'),
+      settingsTransaction: path.join(globalRoot, 'profile-workspace-settings-transaction.json'),
       migrationJournal: path.join(globalRoot, 'profile-account-workspace-migration.json'),
     },
     profile: {

--- a/desktop/lib/profile-workspace-migration-journal.js
+++ b/desktop/lib/profile-workspace-migration-journal.js
@@ -39,6 +39,7 @@ const DESTINATION_RECEIPT_IDS = Object.freeze([
   'globalEngineOwner',
   'globalUpdateState',
   'globalActiveContextSwitch',
+  'globalSettingsTransaction',
   'profileSettings',
   'profileState',
   'account',

--- a/desktop/lib/profile-workspace-runtime-authority.js
+++ b/desktop/lib/profile-workspace-runtime-authority.js
@@ -12,6 +12,7 @@ const {
 const {
   validateGlobalSettingsDocument,
   validateGlobalUpdateStateDocument,
+  validateLocalResourcesDocument,
   validateProfileSettingsDocument,
   validateProfileStateDocument,
   validateWorkspaceSettingsDocument,
@@ -193,6 +194,11 @@ function loadActiveProfileWorkspaceAuthority({
     (value) => validateWorkspaceScopeDocument(value, { account }),
     deps,
   );
+  const localResources = readDocument(
+    layout.workspace.localResources,
+    validateLocalResourcesDocument,
+    deps,
+  );
   const observedCredential = credentialReceipt(layout.account.vpnCredential, deps);
   equal(
     observedCredential.present,
@@ -210,6 +216,7 @@ function loadActiveProfileWorkspaceAuthority({
     account,
     workspaceSettings,
     workspaceState,
+    localResources,
     credentialBinding: bindingFrom(profile, profileState, account),
     hasCredential: observedCredential.present,
   });

--- a/desktop/lib/profile-workspace-settings-bundle.js
+++ b/desktop/lib/profile-workspace-settings-bundle.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const { isDeepStrictEqual } = require('node:util');
+const { parseCredentialField } = require('./settings-update');
+const { DEFAULTS, normalizeSettings } = require('./settings-store');
+const {
+  validateGlobalSettingsDocument,
+  validateGlobalUpdateStateDocument,
+  validateLocalResourcesDocument,
+  validateWorkspaceSettingsDocument,
+} = require('./profile-workspace-documents');
+
+const LEGACY_SETTINGS_KEYS = Object.freeze(Object.keys(DEFAULTS).sort());
+
+function plainObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+  return value;
+}
+
+function exactLegacySettings(value) {
+  const source = plainObject(value, 'runtime settings projection');
+  const keys = Object.keys(source).sort();
+  if (keys.length !== LEGACY_SETTINGS_KEYS.length ||
+      keys.some((key, index) => key !== LEGACY_SETTINGS_KEYS[index])) {
+    throw new TypeError('runtime settings projection has an invalid schema');
+  }
+  const normalized = normalizeSettings(source);
+  if (!isDeepStrictEqual(source, normalized)) {
+    throw new TypeError('runtime settings projection is not canonical');
+  }
+  if (source.username.length > 256) {
+    throw new TypeError('runtime account label is too long');
+  }
+  parseCredentialField(source.username, 'account');
+  return normalized;
+}
+
+function validateAuthority(value) {
+  const authority = plainObject(value, 'active workspace authority');
+  for (const key of [
+    'globalSettings', 'globalUpdateState', 'workspaceSettings', 'localResources',
+  ]) {
+    if (!authority[key]) throw new TypeError(`active workspace authority lacks ${key}`);
+  }
+  return authority;
+}
+
+function projectRuntimeSettings(authorityValue, { accountLabel = '' } = {}) {
+  const authority = validateAuthority(authorityValue);
+  const global = validateGlobalSettingsDocument(authority.globalSettings);
+  const update = validateGlobalUpdateStateDocument(authority.globalUpdateState);
+  const workspace = validateWorkspaceSettingsDocument(authority.workspaceSettings);
+  const local = validateLocalResourcesDocument(authority.localResources);
+  const username = parseCredentialField(accountLabel, 'account');
+  if (username.length > 256) throw new TypeError('runtime account label is too long');
+  return Object.freeze(normalizeSettings({
+    username,
+    port: global.port,
+    autoReconnect: workspace.autoReconnect,
+    maxAttempts: workspace.maxAttempts,
+    startAtLogin: global.startAtLogin,
+    autoConnect: workspace.autoConnect,
+    strictProxyAuth: global.strictProxyAuth,
+    proxySecurityVersion: global.proxySecurityVersion,
+    proxyAuthMigrationPending: global.proxyAuthMigrationPending,
+    closeAction: global.closeAction,
+    language: global.language,
+    updateCheckedAt: update.checkedAt,
+    routeDomains: workspace.routeDomains,
+    customResources: local.resources,
+  }));
+}
+
+function splitRuntimeSettings(authorityValue, settingsValue) {
+  const authority = validateAuthority(authorityValue);
+  const settings = exactLegacySettings(settingsValue);
+  return Object.freeze({
+    globalSettings: validateGlobalSettingsDocument({
+      ...authority.globalSettings,
+      port: settings.port,
+      strictProxyAuth: settings.strictProxyAuth,
+      proxySecurityVersion: settings.proxySecurityVersion,
+      proxyAuthMigrationPending: settings.proxyAuthMigrationPending,
+      closeAction: settings.closeAction,
+      language: settings.language,
+      startAtLogin: settings.startAtLogin,
+    }),
+    globalUpdateState: validateGlobalUpdateStateDocument({
+      schemaVersion: 1,
+      checkedAt: settings.updateCheckedAt,
+    }),
+    workspaceSettings: validateWorkspaceSettingsDocument({
+      schemaVersion: 1,
+      autoReconnect: settings.autoReconnect,
+      maxAttempts: settings.maxAttempts,
+      autoConnect: settings.autoConnect,
+      routeDomains: settings.routeDomains,
+    }),
+    localResources: validateLocalResourcesDocument({
+      schemaVersion: 1,
+      resources: settings.customResources,
+    }),
+  });
+}
+
+module.exports = {
+  LEGACY_SETTINGS_KEYS,
+  projectRuntimeSettings,
+  splitRuntimeSettings,
+};

--- a/desktop/lib/profile-workspace-settings-store.js
+++ b/desktop/lib/profile-workspace-settings-store.js
@@ -1,0 +1,432 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { atomicWritePrivateFile } = require('./credential-store');
+const { collectPrivateFileReceipt } = require('./legacy-flat-source-receipts');
+const { readPrivateFileBounded } = require('./private-file');
+const { splitRuntimeSettings } = require('./profile-workspace-settings-bundle');
+const {
+  normalizeGatewayOrigin,
+  validateOpaqueKey,
+  validateProfileId,
+  validateProtocolFamily,
+} = require('./school-profile-schema');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+const SETTINGS_TRANSACTION_VERSION = 1;
+const MAX_SETTINGS_TARGET_BYTES = 512 * 1024;
+const MAX_SETTINGS_TRANSACTION_BYTES = 3 * 1024 * 1024;
+const TARGET_IDS = Object.freeze([
+  'globalSettings',
+  'globalUpdateState',
+  'workspaceSettings',
+  'localResources',
+]);
+const DIGEST = /^[a-f0-9]{64}$/u;
+
+function plainObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+  return value;
+}
+
+function exactKeys(value, keys, name) {
+  const source = plainObject(value, name);
+  const actual = Object.keys(source).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${name} has an invalid schema`);
+  }
+  return source;
+}
+
+function positive(value, name) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function receipt(value) {
+  if (!Buffer.isBuffer(value) || value.length < 1 || value.length > MAX_SETTINGS_TARGET_BYTES) {
+    throw new TypeError('profile workspace settings target is invalid');
+  }
+  return Object.freeze({
+    present: true,
+    bytes: value.length,
+    sha256: crypto.createHash('sha256').update(value).digest('hex'),
+  });
+}
+
+function validateReceipt(value, name) {
+  const source = exactKeys(value, ['present', 'bytes', 'sha256'], name);
+  if (source.present !== true || !Number.isSafeInteger(source.bytes) || source.bytes < 1 ||
+      source.bytes > MAX_SETTINGS_TARGET_BYTES || typeof source.sha256 !== 'string' ||
+      !DIGEST.test(source.sha256)) {
+    throw new TypeError(`${name} is invalid`);
+  }
+  return Object.freeze({ present: true, bytes: source.bytes, sha256: source.sha256 });
+}
+
+function sameReceipt(left, right) {
+  return left.present === right.present && left.bytes === right.bytes && left.sha256 === right.sha256;
+}
+
+function validateBinding(value) {
+  const source = exactKeys(value, [
+    'profileId', 'profileKey', 'profileCredentialBindingRevision', 'accountKey',
+    'accountCredentialRevision', 'workspaceKey', 'activeContextEpoch', 'gatewayOrigin',
+    'protocolFamily',
+  ], 'profile workspace settings binding');
+  return Object.freeze({
+    profileId: validateProfileId(source.profileId),
+    profileKey: validateOpaqueKey(source.profileKey, 'profileKey'),
+    profileCredentialBindingRevision: positive(
+      source.profileCredentialBindingRevision,
+      'profileCredentialBindingRevision',
+    ),
+    accountKey: validateOpaqueKey(source.accountKey, 'accountKey'),
+    accountCredentialRevision: positive(
+      source.accountCredentialRevision,
+      'accountCredentialRevision',
+    ),
+    workspaceKey: validateOpaqueKey(source.workspaceKey, 'workspaceKey'),
+    activeContextEpoch: positive(source.activeContextEpoch, 'activeContextEpoch'),
+    gatewayOrigin: normalizeGatewayOrigin(source.gatewayOrigin).origin,
+    protocolFamily: validateProtocolFamily(source.protocolFamily),
+  });
+}
+
+function bindingFromAuthority(authority) {
+  return validateBinding({
+    profileId: authority.profile.profileId,
+    profileKey: authority.layout.identity.profileKey,
+    profileCredentialBindingRevision:
+      authority.profileState.profileCredentialBindingRevision,
+    accountKey: authority.account.accountKey,
+    accountCredentialRevision: authority.account.accountCredentialRevision,
+    workspaceKey: authority.workspaceState.workspaceKey,
+    activeContextEpoch: authority.workspaceState.activeContextEpoch,
+    gatewayOrigin: authority.profile.gateway.origin.origin,
+    protocolFamily: authority.profile.gateway.protocolFamily,
+  });
+}
+
+function sameDocument(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function serializedDocuments(bundle) {
+  const value = exactKeys(bundle, TARGET_IDS, 'profile workspace settings bundle');
+  return Object.freeze(Object.fromEntries(TARGET_IDS.map((id) => [
+    id,
+    Buffer.from(`${JSON.stringify(value[id])}\n`, 'utf8'),
+  ])));
+}
+
+function validateTarget(value, id) {
+  const source = exactKeys(value, ['before', 'after', 'data'], `settings target ${id}`);
+  const before = validateReceipt(source.before, `settings target ${id} before receipt`);
+  const after = validateReceipt(source.after, `settings target ${id} after receipt`);
+  if (typeof source.data !== 'string' || source.data.length < 4 ||
+      source.data.length > Math.ceil(MAX_SETTINGS_TARGET_BYTES / 3) * 4 + 4) {
+    throw new TypeError(`settings target ${id} data is invalid`);
+  }
+  const data = Buffer.from(source.data, 'base64');
+  if (data.toString('base64') !== source.data || !sameReceipt(receipt(data), after)) {
+    data.fill(0);
+    throw new TypeError(`settings target ${id} data does not match its receipt`);
+  }
+  data.fill(0);
+  return Object.freeze({ before, after, data: source.data });
+}
+
+function validateIntent(value, expectedBinding = null) {
+  const source = exactKeys(value, [
+    'schemaVersion', 'type', 'transactionId', 'binding', 'createdAt', 'targets',
+  ], 'profile workspace settings transaction');
+  if (source.schemaVersion !== SETTINGS_TRANSACTION_VERSION ||
+      source.type !== 'profile_workspace_settings_commit') {
+    throw new TypeError('profile workspace settings transaction is unsupported');
+  }
+  const binding = validateBinding(source.binding);
+  if (expectedBinding && !sameDocument(binding, expectedBinding)) {
+    throw new Error('profile workspace settings transaction binding does not match');
+  }
+  const targets = exactKeys(source.targets, TARGET_IDS, 'profile workspace settings targets');
+  return Object.freeze({
+    schemaVersion: SETTINGS_TRANSACTION_VERSION,
+    type: 'profile_workspace_settings_commit',
+    transactionId: validateOpaqueKey(source.transactionId, 'transactionId'),
+    binding,
+    createdAt: positive(source.createdAt, 'createdAt'),
+    targets: Object.freeze(Object.fromEntries(TARGET_IDS.map((id) => [
+      id,
+      validateTarget(targets[id], id),
+    ]))),
+  });
+}
+
+function fsyncDirectory(directory, fileSystem, platform) {
+  let descriptor = null;
+  try {
+    descriptor = fileSystem.openSync(directory, 'r');
+    fileSystem.fsyncSync?.(descriptor);
+    return true;
+  } catch {
+    return platform === 'win32';
+  } finally {
+    if (descriptor !== null) {
+      try { fileSystem.closeSync(descriptor); } catch {}
+    }
+  }
+}
+
+function storageOptions(platform, windowsAcl) {
+  return platform === 'win32' ? {
+    protectTemporary: (temporary) => windowsAcl.protect(temporary) === true,
+    verifyCommitted: (committed) => windowsAcl.verify(committed) === true,
+    removeCommittedOnFailure: true,
+  } : {};
+}
+
+class ProfileWorkspaceSettingsStore {
+  constructor({
+    loadAuthority,
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+    randomBytes = crypto.randomBytes,
+    now = Date.now,
+  } = {}) {
+    if (typeof loadAuthority !== 'function' || !fileSystem ||
+        typeof fileSystem.openSync !== 'function' ||
+        !['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' &&
+          (typeof windowsAcl?.protect !== 'function' || typeof windowsAcl?.verify !== 'function')) ||
+        typeof randomBytes !== 'function' || typeof now !== 'function') {
+      throw new TypeError('profile workspace settings store dependencies are invalid');
+    }
+    this.loadAuthority = loadAuthority;
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+    this.randomBytes = randomBytes;
+    this.now = now;
+    this.running = false;
+  }
+
+  save(settings) {
+    return this.#singleFlight(() => {
+      this.#reconcileOnce();
+      const authority = this.#authority();
+      const bundle = splitRuntimeSettings(authority, settings);
+      const documents = serializedDocuments(bundle);
+      try {
+        const paths = this.#paths(authority);
+        const before = Object.fromEntries(TARGET_IDS.map((id) => [
+          id,
+          this.#receipt(paths[id]),
+        ]));
+        const after = Object.fromEntries(TARGET_IDS.map((id) => [id, receipt(documents[id])]));
+        if (TARGET_IDS.every((id) => sameReceipt(before[id], after[id]))) {
+          return Object.freeze({ changed: false, authority });
+        }
+        let entropy = this.randomBytes(16);
+        if (!Buffer.isBuffer(entropy) || entropy.length !== 16) {
+          entropy?.fill?.(0);
+          throw new Error('profile workspace settings transaction entropy is invalid');
+        }
+        let transactionId;
+        try {
+          transactionId = `transaction-${entropy.toString('hex')}`;
+        } finally {
+          entropy.fill(0);
+          entropy = null;
+        }
+        const intent = validateIntent({
+          schemaVersion: SETTINGS_TRANSACTION_VERSION,
+          type: 'profile_workspace_settings_commit',
+          transactionId,
+          binding: bindingFromAuthority(authority),
+          createdAt: this.now(),
+          targets: Object.fromEntries(TARGET_IDS.map((id) => [id, {
+            before: before[id],
+            after: after[id],
+            data: documents[id].toString('base64'),
+          }])),
+        });
+        this.#writeIntent(paths.intent, intent);
+        this.#resume(intent, authority);
+        return Object.freeze({ changed: true, authority: this.#authority() });
+      } finally {
+        for (const document of Object.values(documents)) document.fill(0);
+      }
+    });
+  }
+
+  reconcile() {
+    return this.#singleFlight(() => this.#reconcileOnce());
+  }
+
+  #reconcileOnce() {
+    const initialAuthority = this.#authority();
+    const paths = this.#paths(initialAuthority);
+    const intent = this.#readIntent(paths.intent, bindingFromAuthority(initialAuthority));
+    if (!intent) return Object.freeze({ changed: false, authority: initialAuthority });
+    this.#resume(intent, initialAuthority);
+    return Object.freeze({ changed: true, authority: this.#authority() });
+  }
+
+  #resume(intent, authority) {
+    const binding = bindingFromAuthority(authority);
+    if (!sameDocument(intent.binding, binding)) {
+      throw new Error('profile workspace settings transaction binding does not match');
+    }
+    const paths = this.#paths(authority);
+    for (const id of TARGET_IDS) {
+      const target = intent.targets[id];
+      const current = this.#receipt(paths[id]);
+      if (sameReceipt(current, target.after)) continue;
+      if (!sameReceipt(current, target.before)) {
+        throw new Error(`profile workspace settings target changed outside transaction: ${id}`);
+      }
+      const data = Buffer.from(target.data, 'base64');
+      try {
+        if (!atomicWritePrivateFile(
+          paths[id],
+          data,
+          this.fileSystem,
+          storageOptions(this.platform, this.windowsAcl),
+        )) {
+          throw new Error(`profile workspace settings target write failed: ${id}`);
+        }
+      } finally {
+        data.fill(0);
+      }
+    }
+    for (const id of TARGET_IDS) {
+      if (!sameReceipt(this.#receipt(paths[id]), intent.targets[id].after)) {
+        throw new Error(`profile workspace settings target verification failed: ${id}`);
+      }
+    }
+    try {
+      this.fileSystem.unlinkSync(paths.intent);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        throw new Error('profile workspace settings transaction clear failed', { cause: error });
+      }
+    }
+    if (!fsyncDirectory(path.dirname(paths.intent), this.fileSystem, this.platform)) {
+      throw new Error('profile workspace settings transaction clear was not durable');
+    }
+  }
+
+  #singleFlight(operation) {
+    if (this.running) throw new Error('profile workspace settings transaction is already running');
+    this.running = true;
+    try {
+      const value = operation();
+      if (value && typeof value.then === 'function') {
+        throw new TypeError('profile workspace settings transaction must be synchronous');
+      }
+      return value;
+    } finally {
+      this.running = false;
+    }
+  }
+
+  #authority() {
+    const authority = this.loadAuthority();
+    if (authority && typeof authority.then === 'function') {
+      throw new TypeError('active workspace authority loader must be synchronous');
+    }
+    bindingFromAuthority(authority);
+    this.#paths(authority);
+    return authority;
+  }
+
+  #paths(authority) {
+    const layout = authority?.layout;
+    const values = {
+      globalSettings: layout?.global?.settings,
+      globalUpdateState: layout?.global?.updateState,
+      workspaceSettings: layout?.workspace?.settings,
+      localResources: layout?.workspace?.localResources,
+      intent: layout?.global?.settingsTransaction,
+    };
+    if (Object.values(values).some((file) => typeof file !== 'string' || !path.isAbsolute(file)) ||
+        new Set(Object.values(values)).size !== Object.keys(values).length) {
+      throw new TypeError('profile workspace settings paths are invalid');
+    }
+    return values;
+  }
+
+  #receipt(file) {
+    return collectPrivateFileReceipt({
+      file,
+      maxBytes: MAX_SETTINGS_TARGET_BYTES,
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+      windowsAcl: this.windowsAcl,
+      label: 'profile workspace settings target',
+    });
+  }
+
+  #readIntent(file, expectedBinding) {
+    try {
+      this.fileSystem.lstatSync(file);
+    } catch (error) {
+      if (error?.code === 'ENOENT') return null;
+      throw error;
+    }
+    if (this.platform === 'win32' && !this.windowsAcl.verify(file)) {
+      throw new Error('profile workspace settings transaction ACL is invalid');
+    }
+    let data;
+    try {
+      ({ data } = readPrivateFileBounded(file, {
+        maxBytes: MAX_SETTINGS_TRANSACTION_BYTES,
+        minBytes: 2,
+        platform: this.platform,
+        fileSystem: this.fileSystem,
+      }));
+      return validateIntent(JSON.parse(data.toString('utf8')), expectedBinding);
+    } finally {
+      data?.fill(0);
+    }
+  }
+
+  #writeIntent(file, intent) {
+    const data = Buffer.from(`${JSON.stringify(intent)}\n`, 'utf8');
+    try {
+      if (data.length > MAX_SETTINGS_TRANSACTION_BYTES || !atomicWritePrivateFile(
+        file,
+        data,
+        this.fileSystem,
+        storageOptions(this.platform, this.windowsAcl),
+      )) {
+        throw new Error('profile workspace settings transaction write failed');
+      }
+    } finally {
+      data.fill(0);
+    }
+  }
+}
+
+module.exports = {
+  MAX_SETTINGS_TRANSACTION_BYTES,
+  ProfileWorkspaceSettingsStore,
+  SETTINGS_TRANSACTION_VERSION,
+  TARGET_IDS,
+};

--- a/desktop/test/hkust-migration-destination-plan.test.js
+++ b/desktop/test/hkust-migration-destination-plan.test.js
@@ -126,6 +126,7 @@ test('planner produces every exact destination without plaintext identity leakag
   assert.equal(workspace.workspaceKey, value.journal.identity.workspaceKey);
   assert.equal(account.activeCredentialVersion, 1);
   assert.equal(parseJson(plan.files.localResources).resources.length, 1);
+  assert.equal(Object.hasOwn(parseJson(plan.files.localResources).resources[0], 'builtin'), false);
   assert.equal(parseJson(plan.files.favorites).entries.length, 0);
   assert.equal(parseJson(plan.files.recentResources).entries.length, 0);
   assert.equal(parseJson(plan.files.externalIntegrations).entries.length, 0);

--- a/desktop/test/profile-workspace-destination-files.test.js
+++ b/desktop/test/profile-workspace-destination-files.test.js
@@ -17,6 +17,7 @@ const ABSENT_IDS = new Set([
   'globalProxyHelperCredential',
   'globalEngineOwner',
   'globalActiveContextSwitch',
+  'globalSettingsTransaction',
   'legacyCredentialRollbackRetirement',
   'credentialTransaction',
   'deletionTombstone',

--- a/desktop/test/profile-workspace-runtime-authority.test.js
+++ b/desktop/test/profile-workspace-runtime-authority.test.js
@@ -105,6 +105,7 @@ function fixture(t, { withCredential = true } = {}) {
     workspaceKey: WORKSPACE_KEY,
     activeContextEpoch: 1,
   });
+  writeJson(layout.workspace.localResources, { schemaVersion: 1, resources: [] });
   if (withCredential) {
     fs.writeFileSync(layout.account.vpnCredential, Buffer.from('synthetic-encrypted-envelope'), {
       mode: 0o600,
@@ -123,6 +124,7 @@ test('authority loads one exact active Profile Account Workspace without decrypt
   assert.equal(authority.workspaceSettings.autoConnect, false);
   assert.equal(authority.account.accountKey, ACCOUNT_KEY);
   assert.equal(authority.workspaceState.workspaceKey, WORKSPACE_KEY);
+  assert.deepEqual(authority.localResources.resources, []);
   assert.equal(authority.hasCredential, true);
   assert.equal(authority.layout.browserPartition, 'persist:hkustgz-campus-browser');
   assert.deepEqual(authority.credentialBinding, {

--- a/desktop/test/profile-workspace-settings-bundle.test.js
+++ b/desktop/test/profile-workspace-settings-bundle.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  projectRuntimeSettings,
+  splitRuntimeSettings,
+} = require('../lib/profile-workspace-settings-bundle');
+
+function authority() {
+  return {
+    globalSettings: {
+      schemaVersion: 1,
+      activeProfileKey: `profile-${'11'.repeat(16)}`,
+      activeAccountKey: `account-${'22'.repeat(16)}`,
+      port: 6180,
+      strictProxyAuth: true,
+      proxySecurityVersion: 3,
+      proxyAuthMigrationPending: false,
+      closeAction: 'minimize',
+      language: 'zh',
+      startAtLogin: false,
+    },
+    globalUpdateState: { schemaVersion: 1, checkedAt: 1_700_000_000_000 },
+    workspaceSettings: {
+      schemaVersion: 1,
+      autoReconnect: true,
+      maxAttempts: 3,
+      autoConnect: false,
+      routeDomains: ['hkust-gz.edu.cn'],
+    },
+    localResources: { schemaVersion: 1, resources: [] },
+  };
+}
+
+test('runtime settings projection round-trips without persisting the account label', () => {
+  const current = projectRuntimeSettings(authority(), { accountLabel: 'synthetic-user' });
+  assert.equal(current.username, 'synthetic-user');
+  assert.equal(current.port, 6180);
+  assert.equal(current.autoConnect, false);
+  const split = splitRuntimeSettings(authority(), {
+    ...current,
+    port: 6280,
+    autoConnect: true,
+  });
+  assert.equal(split.globalSettings.port, 6280);
+  assert.equal(split.workspaceSettings.autoConnect, true);
+  assert.equal(JSON.stringify(split).includes('synthetic-user'), false);
+  assert.equal(Object.isFrozen(split.localResources.resources), true);
+  assert.deepEqual(
+    split.localResources,
+    splitRuntimeSettings({ ...authority(), ...split }, {
+      ...current,
+      port: 6280,
+      autoConnect: true,
+    }).localResources,
+  );
+});
+
+test('runtime settings reject password fields unknown fields and noncanonical values', () => {
+  const current = projectRuntimeSettings(authority());
+  assert.throws(() => splitRuntimeSettings(authority(), {
+    ...current,
+    password: 'not-persisted-here',
+  }), /schema/u);
+  assert.throws(() => splitRuntimeSettings(authority(), { ...current, port: 80 }), /canonical/u);
+  assert.throws(() => projectRuntimeSettings(authority(), { accountLabel: 'bad\nlabel' }),
+    /控制字符|control/u);
+});

--- a/desktop/test/profile-workspace-settings-store.test.js
+++ b/desktop/test/profile-workspace-settings-store.test.js
@@ -1,0 +1,266 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  createProfileAccountWorkspaceLayout,
+} = require('../lib/profile-workspace-layout');
+const {
+  loadActiveProfileWorkspaceAuthority,
+} = require('../lib/profile-workspace-runtime-authority');
+const {
+  projectRuntimeSettings,
+} = require('../lib/profile-workspace-settings-bundle');
+const {
+  ProfileWorkspaceSettingsStore,
+} = require('../lib/profile-workspace-settings-store');
+
+const PROFILE_KEY = `profile-${'11'.repeat(16)}`;
+const ACCOUNT_KEY = `account-${'22'.repeat(16)}`;
+const WORKSPACE_KEY = `workspace-${'33'.repeat(16)}`;
+
+function profile() {
+  return JSON.parse(fs.readFileSync(
+    path.join(__dirname, '..', 'assets', 'profiles', 'hkustgz', 'school-profile.json'),
+    'utf8',
+  ));
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+}
+
+function fixture(t) {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-settings-store-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const layout = createProfileAccountWorkspaceLayout({
+    userData,
+    profileKey: PROFILE_KEY,
+    accountKey: ACCOUNT_KEY,
+    workspaceKey: WORKSPACE_KEY,
+    adoptLegacyHkustBrowserPartition: true,
+  });
+  writeJson(layout.global.settings, {
+    schemaVersion: 1,
+    activeProfileKey: PROFILE_KEY,
+    activeAccountKey: ACCOUNT_KEY,
+    port: 6180,
+    strictProxyAuth: true,
+    proxySecurityVersion: 3,
+    proxyAuthMigrationPending: false,
+    closeAction: 'ask',
+    language: 'zh',
+    startAtLogin: false,
+  });
+  writeJson(layout.global.updateState, { schemaVersion: 1, checkedAt: 0 });
+  writeJson(layout.profile.settings, {
+    schemaVersion: 1,
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    primaryAccountKey: ACCOUNT_KEY,
+  });
+  writeJson(layout.profile.state, {
+    schemaVersion: 1,
+    migrationId: `migration-${'44'.repeat(16)}`,
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    profileCredentialBindingRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
+  });
+  writeJson(layout.account.document, {
+    schemaVersion: 1,
+    accountKey: ACCOUNT_KEY,
+    accountRevision: 1,
+    accountCredentialRevision: 1,
+    role: 'primary',
+    state: 'enabled',
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
+    workspaceKey: WORKSPACE_KEY,
+    activeCredentialVersion: null,
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+  });
+  writeJson(layout.workspace.settings, {
+    schemaVersion: 1,
+    autoReconnect: true,
+    maxAttempts: 3,
+    autoConnect: false,
+    routeDomains: ['hkust-gz.edu.cn'],
+  });
+  writeJson(layout.workspace.state, {
+    schemaVersion: 1,
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    accountKey: ACCOUNT_KEY,
+    accountRevision: 1,
+    workspaceKey: WORKSPACE_KEY,
+    activeContextEpoch: 1,
+  });
+  writeJson(layout.workspace.localResources, { schemaVersion: 1, resources: [] });
+  const loadAuthority = () => loadActiveProfileWorkspaceAuthority({ userData, profile: profile() });
+  return { userData, layout, loadAuthority };
+}
+
+function store(value, options = {}) {
+  return new ProfileWorkspaceSettingsStore({
+    loadAuthority: value.loadAuthority,
+    randomBytes: () => Buffer.alloc(16, 0x55),
+    now: () => 1_700_000_000_100,
+    ...options,
+  });
+}
+
+function nextSettings(value) {
+  return {
+    ...projectRuntimeSettings(value.loadAuthority()),
+    username: 'synthetic-user',
+    port: 6280,
+    autoReconnect: false,
+    maxAttempts: 5,
+    autoConnect: true,
+    closeAction: 'minimize',
+    language: 'en',
+    updateCheckedAt: 1_700_000_000_200,
+    routeDomains: ['hkust-gz.edu.cn', 'hkust.edu.hk'],
+    customResources: [{
+      id: 'local-synthetic',
+      name: 'Synthetic',
+      description: 'Local fixture',
+      url: 'https://example.edu/',
+      route: 'campus',
+    }],
+  };
+}
+
+test('settings transaction commits every split document and clears its redo intent', (t) => {
+  const value = fixture(t);
+  const result = store(value).save(nextSettings(value));
+  assert.equal(result.changed, true);
+  assert.equal(fs.existsSync(value.layout.global.settingsTransaction), false);
+  const authority = value.loadAuthority();
+  assert.equal(authority.globalSettings.port, 6280);
+  assert.equal(authority.workspaceSettings.autoReconnect, false);
+  assert.equal(authority.globalUpdateState.checkedAt, 1_700_000_000_200);
+  assert.equal(authority.localResources.resources.length, 1);
+  assert.equal(store(value).save(nextSettings(value)).changed, false);
+});
+
+test('crash during split writes resumes all-new from the durable redo intent', (t) => {
+  const value = fixture(t);
+  const injected = Object.create(fs);
+  injected.renameSync = (from, to) => {
+    if (to === value.layout.workspace.settings) throw new Error('simulated target crash');
+    return fs.renameSync(from, to);
+  };
+  assert.throws(() => store(value, { fileSystem: injected }).save(nextSettings(value)),
+    /target write failed/u);
+  assert.equal(fs.existsSync(value.layout.global.settingsTransaction), true);
+  assert.equal(
+    fs.readFileSync(value.layout.global.settingsTransaction, 'utf8').includes('synthetic-user'),
+    false,
+  );
+  assert.equal(JSON.parse(fs.readFileSync(value.layout.global.settings, 'utf8')).port, 6280);
+  assert.equal(JSON.parse(fs.readFileSync(value.layout.workspace.settings, 'utf8')).autoConnect, false);
+  assert.equal(store(value).reconcile().changed, true);
+  assert.equal(value.loadAuthority().workspaceSettings.autoConnect, true);
+  assert.equal(fs.existsSync(value.layout.global.settingsTransaction), false);
+});
+
+test('failure before the redo intent commit leaves every split document unchanged', (t) => {
+  const value = fixture(t);
+  const injected = Object.create(fs);
+  injected.renameSync = (from, to) => {
+    if (to === value.layout.global.settingsTransaction) throw new Error('simulated intent crash');
+    return fs.renameSync(from, to);
+  };
+  assert.throws(() => store(value, { fileSystem: injected }).save(nextSettings(value)),
+    /transaction write failed/u);
+  assert.equal(value.loadAuthority().globalSettings.port, 6180);
+  assert.equal(value.loadAuthority().workspaceSettings.autoConnect, false);
+  assert.equal(fs.existsSync(value.layout.global.settingsTransaction), false);
+});
+
+test('out-of-band mutation while an intent is pending blocks recovery', (t) => {
+  const value = fixture(t);
+  const injected = Object.create(fs);
+  injected.renameSync = (from, to) => {
+    if (to === value.layout.workspace.settings) throw new Error('simulated target crash');
+    return fs.renameSync(from, to);
+  };
+  assert.throws(() => store(value, { fileSystem: injected }).save(nextSettings(value)));
+  writeJson(value.layout.workspace.settings, {
+    schemaVersion: 1,
+    autoReconnect: true,
+    maxAttempts: 9,
+    autoConnect: false,
+    routeDomains: ['hkust-gz.edu.cn'],
+  });
+  assert.throws(() => store(value).reconcile(), /changed outside transaction/u);
+  assert.equal(fs.existsSync(value.layout.global.settingsTransaction), true);
+});
+
+test('failure to clear a completed intent resumes without rolling settings back', (t) => {
+  const value = fixture(t);
+  const injected = Object.create(fs);
+  injected.unlinkSync = (file) => {
+    if (file === value.layout.global.settingsTransaction) throw new Error('simulated clear crash');
+    return fs.unlinkSync(file);
+  };
+  assert.throws(() => store(value, { fileSystem: injected }).save(nextSettings(value)),
+    /transaction clear failed/u);
+  assert.equal(value.loadAuthority().globalSettings.port, 6280);
+  assert.equal(fs.existsSync(value.layout.global.settingsTransaction), true);
+  assert.equal(store(value).reconcile().changed, true);
+});
+
+test('account credential revision drift blocks a pending settings intent', (t) => {
+  const value = fixture(t);
+  const injected = Object.create(fs);
+  injected.renameSync = (from, to) => {
+    if (to === value.layout.workspace.settings) throw new Error('simulated target crash');
+    return fs.renameSync(from, to);
+  };
+  assert.throws(() => store(value, { fileSystem: injected }).save(nextSettings(value)));
+  const account = JSON.parse(fs.readFileSync(value.layout.account.document, 'utf8'));
+  writeJson(value.layout.account.document, {
+    ...account,
+    accountCredentialRevision: 2,
+    updatedAt: account.updatedAt + 1,
+  });
+  assert.throws(() => store(value).reconcile(), /binding/u);
+  assert.equal(fs.existsSync(value.layout.global.settingsTransaction), true);
+});
+
+test('simulated Windows settings transaction protects and verifies every private write', (t) => {
+  const value = fixture(t);
+  const protectedFiles = [];
+  const verifiedFiles = [];
+  const windowsAcl = {
+    protect(file) { protectedFiles.push(file); return true; },
+    verify(file) { verifiedFiles.push(file); return fs.existsSync(file); },
+  };
+  const loadAuthority = () => loadActiveProfileWorkspaceAuthority({
+    userData: value.userData,
+    profile: profile(),
+    platform: 'win32',
+    windowsAcl,
+  });
+  const result = new ProfileWorkspaceSettingsStore({
+    loadAuthority,
+    platform: 'win32',
+    windowsAcl,
+    randomBytes: () => Buffer.alloc(16, 0x55),
+    now: () => 1_700_000_000_100,
+  }).save(nextSettings({ loadAuthority }));
+  assert.equal(result.changed, true);
+  assert.equal(protectedFiles.some((file) => file.endsWith('.tmp')), true);
+  assert.equal(verifiedFiles.includes(value.layout.global.settings), true);
+});

--- a/desktop/test/profile-workspace-storage.test.js
+++ b/desktop/test/profile-workspace-storage.test.js
@@ -74,6 +74,10 @@ test('profile/account/workspace paths use only opaque keys beneath one absolute 
   );
   assert.equal(layout.workspace.routingRules, path.join(layout.workspace.root, 'routing-rules.json'));
   assert.equal(layout.workspace.engineLog, path.join(layout.workspace.root, 'engine.log'));
+  assert.equal(
+    layout.global.settingsTransaction,
+    path.join(layout.global.root, 'profile-workspace-settings-transaction.json'),
+  );
   assert.match(layout.browserPartition, /^persist:campus-workspace-[a-f0-9]{32}$/u);
   assert.equal(Object.isFrozen(layout.workspace), true);
   for (const sensitive of ['hkustgz', 'remote.hkust-gz.edu.cn', 'student001']) {
@@ -244,6 +248,8 @@ test('P3 foundation is packaged but does not activate migration in production Ma
     'legacy-credential-rollback-store',
     'profile-workspace-documents',
     'profile-workspace-runtime-authority',
+    'profile-workspace-settings-bundle',
+    'profile-workspace-settings-store',
     'legacy-flat-source-receipts',
     'vpn-credential-envelope',
     'vpn-credential-envelope-store',

--- a/docs/adr/0014-p3-runtime-settings-transaction.md
+++ b/docs/adr/0014-p3-runtime-settings-transaction.md
@@ -1,0 +1,56 @@
+# ADR-0014: P3 split runtime settings transaction
+
+- Status: Accepted as a non-activating P3h contract
+- Production storage switch: not enabled by this ADR
+- Parent contract: [`ADR-0013`](0013-p3-runtime-authority.md)
+
+## Context
+
+The 1.x settings API presents one normalized object, while the P3 destination correctly separates application
+settings, Workspace connection/routing settings, update state and local Web resources. A direct series of four
+atomic file writes would still permit a crash to expose a mixed old/new settings view. It would also tempt the
+compatibility layer to persist the account label that P3 intentionally keeps inside the encrypted VPN envelope.
+
+## Decision
+
+`profile-workspace-settings-bundle.js` is the compatibility projection boundary. It:
+
+- projects exact global/Workspace/update/resource documents into the current normalized settings shape;
+- accepts an optional in-memory account label for current UI compatibility;
+- splits a canonical settings object back into the four owner documents;
+- rejects password/unknown fields and never writes the account label;
+- stores Web resources without the runtime-only `builtin` origin marker.
+
+`ProfileWorkspaceSettingsStore` commits the four documents through one owner-only redo intent. The transaction is
+bound to Profile ID/key, Profile credential revision, Account key/credential revision, Workspace key/context
+epoch, Gateway origin and ProtocolFamily. It contains exact before/after receipts and bounded base64 after-bytes
+for these non-credential documents only.
+
+```text
+verify active authority and every before receipt
+  -> atomically persist redo intent
+  -> replace each before target with its exact after document
+  -> verify every after receipt
+  -> clear intent and fsync its directory
+```
+
+Before the intent commit, no target changes. Once the intent is committed, restart recovery deterministically
+finishes all-new. A target that matches neither receipt, a context/revision switch, malformed intent, private-file
+failure or untrusted ACL blocks; recovery never guesses or overwrites out-of-band state.
+
+The redo document may contain local URLs and settings, so it is private, bounded, never logged and cleared after
+commit. It contains no VPN password, website password, Cookie/token, account label or decrypted credential.
+
+## Verification
+
+Tests cover projection/split round trips, account-label non-persistence, unknown/password rejection, resource
+writer/reader idempotence, normal and no-op commits, crash during target writes, failure before intent commit,
+intent-clear crash, out-of-band mutation, Account credential-revision drift and simulated Windows ACLs. P3
+migration destination tests include the initially absent transaction path.
+
+## Non-activation boundary and next gate
+
+Production `desktop/main.js` imports neither settings projection nor transaction store. P3i must first add an
+equivalent Account/VPN credential transaction that composes rollback retirement, credential envelope and Account
+metadata. Only after settings and credential mutations share the new authority can startup migration switch Main
+and produce a test App.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -634,6 +634,9 @@ Non-activating storage foundation: [`ADR-0007`](../adr/0007-p3-storage-foundatio
 - load the destination authority from global active opaque keys through exact Profile/Account/Workspace
   documents, verify reviewed Gateway/protocol/revision and credential-presence bindings without decrypting the
   VPN credential, and share the same strict document validators with migration planning;
+- project the existing settings API over split global/Workspace/resource documents without persisting an account
+  label, and commit multi-document changes through a bound owner-only redo intent that recovers to all-new or
+  blocks on out-of-band drift;
 
 - split app-global and profile settings;
 - create `profiles/<profileKey>/accounts/<accountKey>/workspace/` from the start;


### PR DESCRIPTION
## What changed

- project the current normalized settings API over split global, Workspace, update, and local-resource documents
- keep the account label in memory only and reject password or unknown persistence fields
- add one exact writer/reader schema for local Web resources without runtime-only origin markers
- commit four settings documents through a bound owner-only redo intent
- recover crashes deterministically to all-new and block out-of-band or context-revision drift
- add an initially absent transaction path to the migration destination contract

## Safety boundary

- the redo intent contains no VPN password, website password, cookie/token, or account label
- before intent commit all targets remain old; after commit recovery completes exact after receipts
- malformed/private-file/ACL/binding failures remain fail-closed
- production Main remains unchanged; P3i composes Account/VPN credential mutation before activation

## Verification

- Desktop: 703 passed, 0 failed, 1 Windows-only skip
- architecture: 244 files, 372 edges, 0 cycles
- npm audit: 0 vulnerabilities
- staged secret gate and all JS syntax: PASS