### PR TITLE
2.0 P3i: transact workspace VPN credentials

### DIFF
--- a/desktop/lib/profile-workspace-credential-store.js
+++ b/desktop/lib/profile-workspace-credential-store.js
@@ -1,0 +1,432 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { atomicWritePrivateFile } = require('./credential-store');
+const { collectPrivateFileReceipt } = require('./legacy-flat-source-receipts');
+const { readPrivateFileBounded } = require('./private-file');
+const {
+  decryptVpnCredentialEnvelope,
+  encryptVpnCredentialEnvelope,
+} = require('./vpn-credential-envelope');
+const {
+  CREDENTIAL_TRANSACTION_VERSION,
+  MAX_ACCOUNT_DOCUMENT_BYTES,
+  MAX_CREDENTIAL_TRANSACTION_BYTES,
+  MAX_VPN_CREDENTIAL_BYTES,
+  bindingFromAuthority,
+  createNextAccountDocument,
+  positive,
+  receipt,
+  sameDocument,
+  sameReceipt,
+  serializeAccountDocument,
+  validateCredentialTransaction,
+} = require('./profile-workspace-credential-transaction');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+function fsyncDirectory(directory, fileSystem, platform) {
+  let descriptor = null;
+  try {
+    descriptor = fileSystem.openSync(directory, 'r');
+    fileSystem.fsyncSync?.(descriptor);
+    return true;
+  } catch {
+    return platform === 'win32';
+  } finally {
+    if (descriptor !== null) {
+      try { fileSystem.closeSync(descriptor); } catch {}
+    }
+  }
+}
+
+function storageOptions(platform, windowsAcl) {
+  return platform === 'win32' ? {
+    protectTemporary: (temporary) => windowsAcl.protect(temporary) === true,
+    verifyCommitted: (committed) => windowsAcl.verify(committed) === true,
+    removeCommittedOnFailure: true,
+  } : {};
+}
+
+class ProfileWorkspaceCredentialStore {
+  constructor({
+    loadAccountAuthority,
+    loadWorkspaceAuthority,
+    retireRollback,
+    safeStorage,
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+    randomBytes = crypto.randomBytes,
+    now = Date.now,
+  } = {}) {
+    if (typeof loadAccountAuthority !== 'function' ||
+        typeof loadWorkspaceAuthority !== 'function' || typeof retireRollback !== 'function' ||
+        !safeStorage || !fileSystem || typeof fileSystem.openSync !== 'function' ||
+        !['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' &&
+          (typeof windowsAcl?.protect !== 'function' || typeof windowsAcl?.verify !== 'function')) ||
+        typeof randomBytes !== 'function' || typeof now !== 'function') {
+      throw new TypeError('profile workspace credential store dependencies are invalid');
+    }
+    this.loadAccountAuthority = loadAccountAuthority;
+    this.loadWorkspaceAuthority = loadWorkspaceAuthority;
+    this.retireRollback = retireRollback;
+    this.safeStorage = safeStorage;
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+    this.randomBytes = randomBytes;
+    this.now = now;
+    this.running = false;
+  }
+
+  replace({ username, password } = {}) {
+    return this.#mutate('replace', { username, password });
+  }
+
+  clear() {
+    return this.#mutate('clear', null);
+  }
+
+  open() {
+    this.reconcile();
+    const authority = this.#workspaceAuthority();
+    if (!authority.hasCredential || authority.account.activeCredentialVersion === null) return null;
+    const data = this.#readCredential(authority.layout.account.vpnCredential);
+    try {
+      return decryptVpnCredentialEnvelope(data, {
+        expectedBinding: authority.credentialBinding,
+        safeStorage: this.safeStorage,
+        platform: this.platform,
+      });
+    } finally {
+      data.fill(0);
+    }
+  }
+
+  reconcile() {
+    return this.#singleFlight(() => {
+      const authority = this.#accountAuthority();
+      const paths = this.#paths(authority);
+      const intent = this.#readIntent(paths.intent, bindingFromAuthority(authority));
+      if (!intent) return Object.freeze({ changed: false });
+      this.#resume(intent, authority);
+      this.#workspaceAuthority();
+      return Object.freeze({ changed: true });
+    });
+  }
+
+  #mutate(operation, credential) {
+    return this.#singleFlight(() => {
+      this.#reconcileOnce();
+      const authority = this.#workspaceAuthority();
+      const paths = this.#paths(authority);
+      const beforeCredential = this.#credentialReceipt(paths.credential);
+      if (beforeCredential.present !== (authority.account.activeCredentialVersion !== null)) {
+        throw new Error('profile workspace credential presence does not match Account');
+      }
+      const retirementReason = operation === 'replace' ? 'credential_replaced' : 'credential_cleared';
+      const retirement = this.retireRollback({ authority, reason: retirementReason });
+      if (retirement && typeof retirement.then === 'function') {
+        throw new TypeError('rollback retirement must be synchronous');
+      }
+      if (!retirement || retirement.status !== 'retired') {
+        throw new Error('legacy rollback credential retirement was not proven');
+      }
+      if (operation === 'clear' && !beforeCredential.present &&
+          authority.account.activeCredentialVersion === null) {
+        return Object.freeze({ changed: false, hasCredential: false });
+      }
+      const timestamp = this.now();
+      positive(timestamp, 'updatedAt');
+      const nextCredentialRevision = authority.account.accountCredentialRevision + 1;
+      if (!Number.isSafeInteger(nextCredentialRevision)) {
+        throw new Error('Account credential revision is exhausted');
+      }
+      const nextCredentialVersion = operation === 'replace'
+        ? (authority.account.activeCredentialVersion || 0) + 1
+        : null;
+      const nextAccount = createNextAccountDocument(authority.account, {
+        accountCredentialRevision: nextCredentialRevision,
+        activeCredentialVersion: nextCredentialVersion,
+        updatedAt: timestamp,
+      });
+      const nextAccountBytes = serializeAccountDocument(nextAccount);
+      let nextCredential = null;
+      try {
+        if (operation === 'replace') {
+          nextCredential = encryptVpnCredentialEnvelope({
+            binding: {
+              ...authority.credentialBinding,
+              accountCredentialRevision: nextCredentialRevision,
+            },
+            credentialVersion: nextCredentialVersion,
+            username: credential?.username,
+            password: credential?.password,
+            updatedAt: timestamp,
+            safeStorage: this.safeStorage,
+            platform: this.platform,
+          });
+        }
+        const intent = this.#createIntent({
+          operation,
+          authority,
+          beforeAccount: this.#accountReceipt(paths.account),
+          beforeCredential,
+          nextAccountBytes,
+          nextCredential,
+          timestamp,
+        });
+        this.#writeIntent(paths.intent, intent);
+        this.#resume(intent, authority);
+        return Object.freeze({ changed: true, hasCredential: operation === 'replace' });
+      } finally {
+        nextAccountBytes.fill(0);
+        nextCredential?.fill(0);
+      }
+    });
+  }
+
+  #reconcileOnce() {
+    const authority = this.#accountAuthority();
+    const paths = this.#paths(authority);
+    const intent = this.#readIntent(paths.intent, bindingFromAuthority(authority));
+    if (intent) this.#resume(intent, authority);
+  }
+
+  #createIntent({
+    operation,
+    authority,
+    beforeAccount,
+    beforeCredential,
+    nextAccountBytes,
+    nextCredential,
+    timestamp,
+  }) {
+    let entropy = this.randomBytes(16);
+    if (!Buffer.isBuffer(entropy) || entropy.length !== 16) {
+      entropy?.fill?.(0);
+      throw new Error('profile workspace credential transaction entropy is invalid');
+    }
+    let transactionId;
+    try { transactionId = `transaction-${entropy.toString('hex')}`; }
+    finally { entropy.fill(0); entropy = null; }
+    return validateCredentialTransaction({
+      schemaVersion: CREDENTIAL_TRANSACTION_VERSION,
+      type: 'profile_workspace_credential_commit',
+      transactionId,
+      binding: bindingFromAuthority(authority),
+      operation,
+      createdAt: timestamp,
+      beforeAccount,
+      afterAccount: {
+        receipt: receipt(nextAccountBytes, { maxBytes: MAX_ACCOUNT_DOCUMENT_BYTES }),
+        data: nextAccountBytes.toString('base64'),
+      },
+      beforeCredential,
+      afterCredential: {
+        receipt: receipt(nextCredential, {
+          allowAbsent: true,
+          maxBytes: MAX_VPN_CREDENTIAL_BYTES,
+        }),
+        data: nextCredential === null ? null : nextCredential.toString('base64'),
+      },
+    });
+  }
+
+  #resume(intent, authority) {
+    if (!sameDocument(intent.binding, bindingFromAuthority(authority))) {
+      throw new Error('profile workspace credential transaction binding does not match');
+    }
+    const paths = this.#paths(authority);
+    const currentAccount = this.#accountReceipt(paths.account);
+    const currentCredential = this.#credentialReceipt(paths.credential);
+    if (![intent.beforeAccount, intent.afterAccount.receipt]
+      .some((candidate) => sameReceipt(currentAccount, candidate)) ||
+      ![intent.beforeCredential, intent.afterCredential.receipt]
+        .some((candidate) => sameReceipt(currentCredential, candidate))) {
+      throw new Error('profile workspace credential target changed outside transaction');
+    }
+
+    if (!sameReceipt(currentCredential, intent.afterCredential.receipt)) {
+      if (!sameReceipt(currentCredential, intent.beforeCredential)) {
+        throw new Error('profile workspace credential changed outside transaction');
+      }
+      if (intent.afterCredential.receipt.present) {
+        const data = Buffer.from(intent.afterCredential.data, 'base64');
+        try { this.#writePrivate(paths.credential, data, 'credential'); }
+        finally { data.fill(0); }
+      } else {
+        try {
+          this.fileSystem.unlinkSync(paths.credential);
+        } catch (error) {
+          if (error?.code !== 'ENOENT') {
+            throw new Error('profile workspace credential removal failed', { cause: error });
+          }
+        }
+        if (!fsyncDirectory(path.dirname(paths.credential), this.fileSystem, this.platform)) {
+          throw new Error('profile workspace credential removal was not durable');
+        }
+      }
+    }
+    if (!sameReceipt(this.#accountReceipt(paths.account), intent.afterAccount.receipt)) {
+      const data = Buffer.from(intent.afterAccount.data, 'base64');
+      try { this.#writePrivate(paths.account, data, 'Account'); }
+      finally { data.fill(0); }
+    }
+    if (!sameReceipt(this.#accountReceipt(paths.account), intent.afterAccount.receipt) ||
+        !sameReceipt(this.#credentialReceipt(paths.credential), intent.afterCredential.receipt)) {
+      throw new Error('profile workspace credential transaction verification failed');
+    }
+    try {
+      this.fileSystem.unlinkSync(paths.intent);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        throw new Error('profile workspace credential transaction clear failed', { cause: error });
+      }
+    }
+    if (!fsyncDirectory(path.dirname(paths.intent), this.fileSystem, this.platform)) {
+      throw new Error('profile workspace credential transaction clear was not durable');
+    }
+  }
+
+  #singleFlight(operation) {
+    if (this.running) throw new Error('profile workspace credential transaction is already running');
+    this.running = true;
+    try {
+      const value = operation();
+      if (value && typeof value.then === 'function') {
+        throw new TypeError('profile workspace credential transaction must be synchronous');
+      }
+      return value;
+    } finally {
+      this.running = false;
+    }
+  }
+
+  #accountAuthority() {
+    const value = this.loadAccountAuthority();
+    if (value && typeof value.then === 'function') {
+      throw new TypeError('Profile Account authority must be synchronous');
+    }
+    bindingFromAuthority(value);
+    return value;
+  }
+
+  #workspaceAuthority() {
+    const value = this.loadWorkspaceAuthority();
+    if (value && typeof value.then === 'function') {
+      throw new TypeError('Profile Workspace authority must be synchronous');
+    }
+    bindingFromAuthority(value);
+    return value;
+  }
+
+  #paths(authority) {
+    const values = {
+      account: authority?.layout?.account?.document,
+      credential: authority?.layout?.account?.vpnCredential,
+      intent: authority?.layout?.account?.credentialTransaction,
+    };
+    if (Object.values(values).some((file) => typeof file !== 'string' || !path.isAbsolute(file)) ||
+        new Set(Object.values(values)).size !== 3) {
+      throw new TypeError('profile workspace credential paths are invalid');
+    }
+    return values;
+  }
+
+  #accountReceipt(file) {
+    return collectPrivateFileReceipt({
+      file,
+      maxBytes: MAX_ACCOUNT_DOCUMENT_BYTES,
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+      windowsAcl: this.windowsAcl,
+      label: 'profile workspace Account document',
+    });
+  }
+
+  #credentialReceipt(file) {
+    return collectPrivateFileReceipt({
+      file,
+      maxBytes: MAX_VPN_CREDENTIAL_BYTES,
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+      windowsAcl: this.windowsAcl,
+      label: 'profile workspace VPN credential',
+    });
+  }
+
+  #readCredential(file) {
+    if (this.platform === 'win32' && !this.windowsAcl.verify(file)) {
+      throw new Error('profile workspace VPN credential ACL is invalid');
+    }
+    return readPrivateFileBounded(file, {
+      maxBytes: MAX_VPN_CREDENTIAL_BYTES,
+      platform: this.platform,
+      fileSystem: this.fileSystem,
+    }).data;
+  }
+
+  #readIntent(file, expectedBinding) {
+    try { this.fileSystem.lstatSync(file); }
+    catch (error) {
+      if (error?.code === 'ENOENT') return null;
+      throw error;
+    }
+    if (this.platform === 'win32' && !this.windowsAcl.verify(file)) {
+      throw new Error('profile workspace credential transaction ACL is invalid');
+    }
+    let data;
+    try {
+      ({ data } = readPrivateFileBounded(file, {
+        maxBytes: MAX_CREDENTIAL_TRANSACTION_BYTES,
+        minBytes: 2,
+        platform: this.platform,
+        fileSystem: this.fileSystem,
+      }));
+      return validateCredentialTransaction(JSON.parse(data.toString('utf8')), expectedBinding);
+    } finally {
+      data?.fill(0);
+    }
+  }
+
+  #writeIntent(file, intent) {
+    const data = Buffer.from(`${JSON.stringify(intent)}\n`, 'utf8');
+    try {
+      if (data.length > MAX_CREDENTIAL_TRANSACTION_BYTES || !atomicWritePrivateFile(
+        file,
+        data,
+        this.fileSystem,
+        storageOptions(this.platform, this.windowsAcl),
+      )) {
+        throw new Error('profile workspace credential transaction write failed');
+      }
+    } finally { data.fill(0); }
+  }
+
+  #writePrivate(file, data, label) {
+    if (!atomicWritePrivateFile(
+      file,
+      data,
+      this.fileSystem,
+      storageOptions(this.platform, this.windowsAcl),
+    )) {
+      throw new Error(`profile workspace ${label} write failed`);
+    }
+  }
+}
+
+module.exports = {
+  CREDENTIAL_TRANSACTION_VERSION,
+  MAX_CREDENTIAL_TRANSACTION_BYTES,
+  ProfileWorkspaceCredentialStore,
+};

--- a/desktop/lib/profile-workspace-credential-transaction.js
+++ b/desktop/lib/profile-workspace-credential-transaction.js
@@ -1,0 +1,206 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const {
+  normalizeGatewayOrigin,
+  validateCampusAccountDocument,
+  validateOpaqueKey,
+  validateProfileId,
+  validateProtocolFamily,
+} = require('./school-profile-schema');
+
+const CREDENTIAL_TRANSACTION_VERSION = 1;
+const MAX_CREDENTIAL_TRANSACTION_BYTES = 512 * 1024;
+const MAX_ACCOUNT_DOCUMENT_BYTES = 64 * 1024;
+const MAX_VPN_CREDENTIAL_BYTES = 64 * 1024;
+const DIGEST = /^[a-f0-9]{64}$/u;
+
+function plainObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+  return value;
+}
+
+function exactKeys(value, keys, name) {
+  const source = plainObject(value, name);
+  const actual = Object.keys(source).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${name} has an invalid schema`);
+  }
+  return source;
+}
+
+function positive(value, name) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function validateReceipt(value, name, { allowAbsent = false, maxBytes } = {}) {
+  const source = exactKeys(value, ['present', 'bytes', 'sha256'], name);
+  if (source.present === false && allowAbsent && source.bytes === 0 && source.sha256 === null) {
+    return Object.freeze({ present: false, bytes: 0, sha256: null });
+  }
+  if (source.present !== true || !Number.isSafeInteger(source.bytes) || source.bytes < 1 ||
+      source.bytes > maxBytes || typeof source.sha256 !== 'string' || !DIGEST.test(source.sha256)) {
+    throw new TypeError(`${name} is invalid`);
+  }
+  return Object.freeze({ present: true, bytes: source.bytes, sha256: source.sha256 });
+}
+
+function receipt(data, { allowAbsent = false, maxBytes } = {}) {
+  if (data === null && allowAbsent) {
+    return Object.freeze({ present: false, bytes: 0, sha256: null });
+  }
+  if (!Buffer.isBuffer(data) || data.length < 1 || data.length > maxBytes) {
+    throw new TypeError('credential transaction payload is invalid');
+  }
+  return Object.freeze({
+    present: true,
+    bytes: data.length,
+    sha256: crypto.createHash('sha256').update(data).digest('hex'),
+  });
+}
+
+function sameReceipt(left, right) {
+  return left.present === right.present && left.bytes === right.bytes && left.sha256 === right.sha256;
+}
+
+function validateBinding(value) {
+  const source = exactKeys(value, [
+    'profileId', 'profileKey', 'profileCredentialBindingRevision', 'accountKey',
+    'workspaceKey', 'activeContextEpoch', 'gatewayOrigin', 'protocolFamily',
+  ], 'profile workspace credential binding');
+  return Object.freeze({
+    profileId: validateProfileId(source.profileId),
+    profileKey: validateOpaqueKey(source.profileKey, 'profileKey'),
+    profileCredentialBindingRevision: positive(
+      source.profileCredentialBindingRevision,
+      'profileCredentialBindingRevision',
+    ),
+    accountKey: validateOpaqueKey(source.accountKey, 'accountKey'),
+    workspaceKey: validateOpaqueKey(source.workspaceKey, 'workspaceKey'),
+    activeContextEpoch: positive(source.activeContextEpoch, 'activeContextEpoch'),
+    gatewayOrigin: normalizeGatewayOrigin(source.gatewayOrigin).origin,
+    protocolFamily: validateProtocolFamily(source.protocolFamily),
+  });
+}
+
+function bindingFromAuthority(authority) {
+  return validateBinding({
+    profileId: authority.profile.profileId,
+    profileKey: authority.layout.identity.profileKey,
+    profileCredentialBindingRevision:
+      authority.profileState.profileCredentialBindingRevision,
+    accountKey: authority.account.accountKey,
+    workspaceKey: authority.account.workspaceKey,
+    activeContextEpoch: authority.workspaceState.activeContextEpoch,
+    gatewayOrigin: authority.profile.gateway.origin.origin,
+    protocolFamily: authority.profile.gateway.protocolFamily,
+  });
+}
+
+function sameDocument(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function encodedPayload(value, name, { allowAbsent = false, maxBytes }) {
+  const source = exactKeys(value, ['receipt', 'data'], name);
+  const expected = validateReceipt(source.receipt, `${name} receipt`, { allowAbsent, maxBytes });
+  if (!expected.present) {
+    if (source.data !== null) throw new TypeError(`${name} absent payload must be null`);
+    return Object.freeze({ receipt: expected, data: null });
+  }
+  if (typeof source.data !== 'string') throw new TypeError(`${name} payload is invalid`);
+  const data = Buffer.from(source.data, 'base64');
+  if (data.toString('base64') !== source.data ||
+      !sameReceipt(receipt(data, { maxBytes }), expected)) {
+    data.fill(0);
+    throw new TypeError(`${name} payload does not match its receipt`);
+  }
+  data.fill(0);
+  return Object.freeze({ receipt: expected, data: source.data });
+}
+
+function validateCredentialTransaction(value, expectedBinding = null) {
+  const source = exactKeys(value, [
+    'schemaVersion', 'type', 'transactionId', 'binding', 'operation', 'createdAt',
+    'beforeAccount', 'afterAccount', 'beforeCredential', 'afterCredential',
+  ], 'profile workspace credential transaction');
+  if (source.schemaVersion !== CREDENTIAL_TRANSACTION_VERSION ||
+      source.type !== 'profile_workspace_credential_commit' ||
+      !['replace', 'clear'].includes(source.operation)) {
+    throw new TypeError('profile workspace credential transaction is unsupported');
+  }
+  const binding = validateBinding(source.binding);
+  if (expectedBinding && !sameDocument(binding, expectedBinding)) {
+    throw new Error('profile workspace credential transaction binding does not match');
+  }
+  return Object.freeze({
+    schemaVersion: CREDENTIAL_TRANSACTION_VERSION,
+    type: 'profile_workspace_credential_commit',
+    transactionId: validateOpaqueKey(source.transactionId, 'transactionId'),
+    binding,
+    operation: source.operation,
+    createdAt: positive(source.createdAt, 'createdAt'),
+    beforeAccount: validateReceipt(source.beforeAccount, 'before Account receipt', {
+      maxBytes: MAX_ACCOUNT_DOCUMENT_BYTES,
+    }),
+    afterAccount: encodedPayload(source.afterAccount, 'after Account', {
+      maxBytes: MAX_ACCOUNT_DOCUMENT_BYTES,
+    }),
+    beforeCredential: validateReceipt(source.beforeCredential, 'before credential receipt', {
+      allowAbsent: true,
+      maxBytes: MAX_VPN_CREDENTIAL_BYTES,
+    }),
+    afterCredential: encodedPayload(source.afterCredential, 'after credential', {
+      allowAbsent: true,
+      maxBytes: MAX_VPN_CREDENTIAL_BYTES,
+    }),
+  });
+}
+
+function createNextAccountDocument(account, changes) {
+  return validateCampusAccountDocument({
+    schemaVersion: account.schemaVersion,
+    accountKey: account.accountKey,
+    accountRevision: account.accountRevision,
+    accountCredentialRevision: changes.accountCredentialRevision,
+    role: account.role,
+    state: account.state,
+    profileId: account.profileId,
+    profileRevision: account.profileRevision,
+    gatewayOrigin: account.gatewayOrigin.origin,
+    protocolFamily: account.protocolFamily,
+    workspaceKey: account.workspaceKey,
+    activeCredentialVersion: changes.activeCredentialVersion,
+    createdAt: account.createdAt,
+    updatedAt: changes.updatedAt,
+  });
+}
+
+function serializeAccountDocument(account) {
+  return Buffer.from(`${JSON.stringify({
+    ...account,
+    gatewayOrigin: account.gatewayOrigin.origin,
+  })}\n`, 'utf8');
+}
+
+module.exports = {
+  CREDENTIAL_TRANSACTION_VERSION,
+  MAX_ACCOUNT_DOCUMENT_BYTES,
+  MAX_CREDENTIAL_TRANSACTION_BYTES,
+  MAX_VPN_CREDENTIAL_BYTES,
+  bindingFromAuthority,
+  createNextAccountDocument,
+  positive,
+  receipt,
+  sameDocument,
+  sameReceipt,
+  serializeAccountDocument,
+  validateCredentialTransaction,
+};

--- a/desktop/lib/profile-workspace-runtime-authority.js
+++ b/desktop/lib/profile-workspace-runtime-authority.js
@@ -107,7 +107,18 @@ function bindingFrom(profile, profileState, account) {
   });
 }
 
-function loadActiveProfileWorkspaceAuthority({
+function authorityDependencies({ userData, profile: rawProfile, fileSystem, platform, windowsAcl }) {
+  if (!fileSystem || typeof fileSystem.openSync !== 'function' ||
+      !['darwin', 'linux', 'win32'].includes(platform) ||
+      (platform === 'win32' && typeof windowsAcl?.verify !== 'function')) {
+    throw new TypeError('active workspace authority dependencies are invalid');
+  }
+  const root = validateUserDataRoot(userData);
+  const profile = validateSchoolProfileDocument(rawProfile);
+  return { root, profile, fileSystem, platform, windowsAcl };
+}
+
+function loadActiveProfileAccountAuthority({
   userData,
   profile: rawProfile,
   fileSystem = fs,
@@ -117,14 +128,14 @@ function loadActiveProfileWorkspaceAuthority({
     verify: verifyWindowsFileOwnerOnly,
   },
 } = {}) {
-  if (!fileSystem || typeof fileSystem.openSync !== 'function' ||
-      !['darwin', 'linux', 'win32'].includes(platform) ||
-      (platform === 'win32' && typeof windowsAcl?.verify !== 'function')) {
-    throw new TypeError('active workspace authority dependencies are invalid');
-  }
-  const root = validateUserDataRoot(userData);
-  const profile = validateSchoolProfileDocument(rawProfile);
-  const deps = { root, fileSystem, platform, windowsAcl };
+  const deps = authorityDependencies({
+    userData,
+    profile: rawProfile,
+    fileSystem,
+    platform,
+    windowsAcl,
+  });
+  const { root, profile } = deps;
   const globalSettings = readDocument(
     path.join(root, 'global', 'settings.json'),
     validateGlobalSettingsDocument,
@@ -184,26 +195,10 @@ function loadActiveProfileWorkspaceAuthority({
     workspaceKey: account.workspaceKey,
     adoptLegacyHkustBrowserPartition: true,
   });
-  const workspaceSettings = readDocument(
-    layout.workspace.settings,
-    validateWorkspaceSettingsDocument,
-    deps,
-  );
   const workspaceState = readDocument(
     layout.workspace.state,
     (value) => validateWorkspaceScopeDocument(value, { account }),
     deps,
-  );
-  const localResources = readDocument(
-    layout.workspace.localResources,
-    validateLocalResourcesDocument,
-    deps,
-  );
-  const observedCredential = credentialReceipt(layout.account.vpnCredential, deps);
-  equal(
-    observedCredential.present,
-    account.activeCredentialVersion !== null,
-    'credential presence',
   );
 
   return Object.freeze({
@@ -214,10 +209,49 @@ function loadActiveProfileWorkspaceAuthority({
     profileSettings,
     profileState,
     account,
-    workspaceSettings,
     workspaceState,
-    localResources,
     credentialBinding: bindingFrom(profile, profileState, account),
+  });
+}
+
+function loadActiveProfileWorkspaceAuthority(options = {}) {
+  const fileSystem = options.fileSystem || fs;
+  const platform = options.platform || process.platform;
+  const windowsAcl = options.windowsAcl || {
+    protect: protectWindowsFileOwnerOnly,
+    verify: verifyWindowsFileOwnerOnly,
+  };
+  const accountAuthority = loadActiveProfileAccountAuthority({
+    ...options,
+    fileSystem,
+    platform,
+    windowsAcl,
+  });
+  const { layout } = accountAuthority;
+  const root = validateUserDataRoot(options.userData);
+  const deps = { root, fileSystem, platform, windowsAcl };
+  const workspaceSettings = readDocument(
+    layout.workspace.settings,
+    validateWorkspaceSettingsDocument,
+    deps,
+  );
+  const localResources = readDocument(
+    layout.workspace.localResources,
+    validateLocalResourcesDocument,
+    deps,
+  );
+  const observedCredential = credentialReceipt(layout.account.vpnCredential, deps);
+  equal(
+    observedCredential.present,
+    accountAuthority.account.activeCredentialVersion !== null,
+    'credential presence',
+  );
+
+  return Object.freeze({
+    ...accountAuthority,
+    layout,
+    workspaceSettings,
+    localResources,
     hasCredential: observedCredential.present,
   });
 }
@@ -225,5 +259,6 @@ function loadActiveProfileWorkspaceAuthority({
 module.exports = {
   MAX_RUNTIME_CREDENTIAL_BYTES,
   MAX_RUNTIME_DOCUMENT_BYTES,
+  loadActiveProfileAccountAuthority,
   loadActiveProfileWorkspaceAuthority,
 };

--- a/desktop/test/profile-workspace-credential-store.test.js
+++ b/desktop/test/profile-workspace-credential-store.test.js
@@ -1,0 +1,272 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { createProfileAccountWorkspaceLayout } = require('../lib/profile-workspace-layout');
+const {
+  loadActiveProfileAccountAuthority,
+  loadActiveProfileWorkspaceAuthority,
+} = require('../lib/profile-workspace-runtime-authority');
+const {
+  ProfileWorkspaceCredentialStore,
+} = require('../lib/profile-workspace-credential-store');
+
+const PROFILE_KEY = `profile-${'11'.repeat(16)}`;
+const ACCOUNT_KEY = `account-${'22'.repeat(16)}`;
+const WORKSPACE_KEY = `workspace-${'33'.repeat(16)}`;
+
+function profile() {
+  return JSON.parse(fs.readFileSync(
+    path.join(__dirname, '..', 'assets', 'profiles', 'hkustgz', 'school-profile.json'),
+    'utf8',
+  ));
+}
+
+function safeStorage() {
+  return {
+    isEncryptionAvailable: () => true,
+    getSelectedStorageBackend: () => 'keychain',
+    encryptString: (value) => Buffer.from(value, 'utf8').map((byte) => byte ^ 0xa5),
+    decryptString: (value) => Buffer.from(value).map((byte) => byte ^ 0xa5).toString('utf8'),
+  };
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+}
+
+function fixture(t) {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-credential-store-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const layout = createProfileAccountWorkspaceLayout({
+    userData,
+    profileKey: PROFILE_KEY,
+    accountKey: ACCOUNT_KEY,
+    workspaceKey: WORKSPACE_KEY,
+    adoptLegacyHkustBrowserPartition: true,
+  });
+  writeJson(layout.global.settings, {
+    schemaVersion: 1,
+    activeProfileKey: PROFILE_KEY,
+    activeAccountKey: ACCOUNT_KEY,
+    port: 6180,
+    strictProxyAuth: true,
+    proxySecurityVersion: 3,
+    proxyAuthMigrationPending: false,
+    closeAction: 'ask',
+    language: 'zh',
+    startAtLogin: false,
+  });
+  writeJson(layout.global.updateState, { schemaVersion: 1, checkedAt: 0 });
+  writeJson(layout.profile.settings, {
+    schemaVersion: 1,
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    primaryAccountKey: ACCOUNT_KEY,
+  });
+  writeJson(layout.profile.state, {
+    schemaVersion: 1,
+    migrationId: `migration-${'44'.repeat(16)}`,
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    profileCredentialBindingRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
+  });
+  writeJson(layout.account.document, {
+    schemaVersion: 1,
+    accountKey: ACCOUNT_KEY,
+    accountRevision: 1,
+    accountCredentialRevision: 1,
+    role: 'primary',
+    state: 'enabled',
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: 'easyconnect-password-modern-l3-v1',
+    workspaceKey: WORKSPACE_KEY,
+    activeCredentialVersion: null,
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+  });
+  writeJson(layout.workspace.settings, {
+    schemaVersion: 1,
+    autoReconnect: true,
+    maxAttempts: 3,
+    autoConnect: false,
+    routeDomains: ['hkust-gz.edu.cn'],
+  });
+  writeJson(layout.workspace.state, {
+    schemaVersion: 1,
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    accountKey: ACCOUNT_KEY,
+    accountRevision: 1,
+    workspaceKey: WORKSPACE_KEY,
+    activeContextEpoch: 1,
+  });
+  writeJson(layout.workspace.localResources, { schemaVersion: 1, resources: [] });
+  const loadAccountAuthority = () => loadActiveProfileAccountAuthority({
+    userData,
+    profile: profile(),
+  });
+  const loadWorkspaceAuthority = () => loadActiveProfileWorkspaceAuthority({
+    userData,
+    profile: profile(),
+  });
+  return { userData, layout, loadAccountAuthority, loadWorkspaceAuthority };
+}
+
+function createStore(value, options = {}) {
+  const retirementCalls = options.retirementCalls || [];
+  let timestamp = 1_700_000_000_100;
+  return new ProfileWorkspaceCredentialStore({
+    loadAccountAuthority: value.loadAccountAuthority,
+    loadWorkspaceAuthority: value.loadWorkspaceAuthority,
+    retireRollback: ({ reason }) => {
+      retirementCalls.push(reason);
+      return { status: 'retired', changed: true };
+    },
+    safeStorage: safeStorage(),
+    platform: 'darwin',
+    randomBytes: () => Buffer.alloc(16, 0x66),
+    now: () => timestamp++,
+    ...options,
+  });
+}
+
+test('replace and clear commit Account plus encrypted envelope without persistent identity', (t) => {
+  const value = fixture(t);
+  const retirementCalls = [];
+  const credentials = createStore(value, { retirementCalls });
+  assert.deepEqual(credentials.replace({
+    username: 'synthetic-user',
+    password: 'synthetic-password',
+  }), { changed: true, hasCredential: true });
+  let authority = value.loadWorkspaceAuthority();
+  assert.equal(authority.account.accountCredentialRevision, 2);
+  assert.equal(authority.account.activeCredentialVersion, 1);
+  assert.equal(authority.hasCredential, true);
+  const persisted = [
+    fs.readFileSync(value.layout.account.document),
+    fs.readFileSync(value.layout.account.vpnCredential),
+  ];
+  assert.equal(persisted.some((data) => data.includes(Buffer.from('synthetic-user'))), false);
+  assert.equal(persisted.some((data) => data.includes(Buffer.from('synthetic-password'))), false);
+  const owner = credentials.open();
+  assert.deepEqual(owner.withStrings((username, password) => ({ username, password })), {
+    username: 'synthetic-user',
+    password: 'synthetic-password',
+  });
+  owner.destroy();
+
+  assert.deepEqual(credentials.clear(), { changed: true, hasCredential: false });
+  authority = value.loadWorkspaceAuthority();
+  assert.equal(authority.account.accountCredentialRevision, 3);
+  assert.equal(authority.account.activeCredentialVersion, null);
+  assert.equal(authority.hasCredential, false);
+  assert.equal(fs.existsSync(value.layout.account.vpnCredential), false);
+  assert.deepEqual(retirementCalls, ['credential_replaced', 'credential_cleared']);
+});
+
+test('crash after credential write resumes Account commit without exposing plaintext intent', (t) => {
+  const value = fixture(t);
+  const injected = Object.create(fs);
+  injected.renameSync = (from, to) => {
+    if (to === value.layout.account.document) throw new Error('simulated Account crash');
+    return fs.renameSync(from, to);
+  };
+  assert.throws(() => createStore(value, { fileSystem: injected }).replace({
+    username: 'synthetic-user',
+    password: 'synthetic-password',
+  }), /Account write failed/u);
+  assert.equal(fs.existsSync(value.layout.account.credentialTransaction), true);
+  const intent = fs.readFileSync(value.layout.account.credentialTransaction);
+  assert.equal(intent.includes(Buffer.from('synthetic-user')), false);
+  assert.equal(intent.includes(Buffer.from('synthetic-password')), false);
+  assert.throws(() => value.loadWorkspaceAuthority(), /credential presence binding/u);
+  assert.equal(createStore(value).reconcile().changed, true);
+  assert.equal(value.loadWorkspaceAuthority().account.accountCredentialRevision, 2);
+});
+
+test('crash after credential removal resumes clear Account metadata', (t) => {
+  const value = fixture(t);
+  const credentials = createStore(value);
+  credentials.replace({ username: 'synthetic-user', password: 'synthetic-password' });
+  const injected = Object.create(fs);
+  injected.renameSync = (from, to) => {
+    if (to === value.layout.account.document) throw new Error('simulated Account crash');
+    return fs.renameSync(from, to);
+  };
+  assert.throws(() => createStore(value, { fileSystem: injected }).clear(), /Account write failed/u);
+  assert.equal(fs.existsSync(value.layout.account.vpnCredential), false);
+  assert.equal(createStore(value).reconcile().changed, true);
+  assert.equal(value.loadWorkspaceAuthority().account.activeCredentialVersion, null);
+});
+
+test('unproven rollback retirement blocks credential mutation before intent or target writes', (t) => {
+  const value = fixture(t);
+  const credentials = createStore(value, {
+    retireRollback: () => { throw new Error('simulated rollback retirement failure'); },
+  });
+  assert.throws(() => credentials.replace({ username: 'user', password: 'password' }),
+    /retirement failure/u);
+  assert.equal(fs.existsSync(value.layout.account.credentialTransaction), false);
+  assert.equal(fs.existsSync(value.layout.account.vpnCredential), false);
+  assert.equal(value.loadWorkspaceAuthority().account.accountCredentialRevision, 1);
+});
+
+test('credential-free clear still proves rollback retirement but does not churn Account revision', (t) => {
+  const value = fixture(t);
+  const retirementCalls = [];
+  const credentials = createStore(value, { retirementCalls });
+  assert.deepEqual(credentials.clear(), { changed: false, hasCredential: false });
+  assert.deepEqual(retirementCalls, ['credential_cleared']);
+  assert.equal(value.loadWorkspaceAuthority().account.accountCredentialRevision, 1);
+  assert.equal(fs.existsSync(value.layout.account.credentialTransaction), false);
+});
+
+test('out-of-band Account mutation blocks pending credential recovery', (t) => {
+  const value = fixture(t);
+  const injected = Object.create(fs);
+  injected.renameSync = (from, to) => {
+    if (to === value.layout.account.document) throw new Error('simulated Account crash');
+    return fs.renameSync(from, to);
+  };
+  assert.throws(() => createStore(value, { fileSystem: injected }).replace({
+    username: 'user',
+    password: 'password',
+  }));
+  const account = JSON.parse(fs.readFileSync(value.layout.account.document, 'utf8'));
+  writeJson(value.layout.account.document, { ...account, updatedAt: account.updatedAt + 5 });
+  assert.throws(() => createStore(value).reconcile(), /changed outside transaction/u);
+  assert.equal(fs.existsSync(value.layout.account.credentialTransaction), true);
+});
+
+test('simulated Windows credential writes are ACL protected and verified', (t) => {
+  const value = fixture(t);
+  const protectedFiles = [];
+  const verifiedFiles = [];
+  const windowsAcl = {
+    protect(file) { protectedFiles.push(file); return true; },
+    verify(file) { verifiedFiles.push(file); return fs.existsSync(file); },
+  };
+  const loadAccountAuthority = () => loadActiveProfileAccountAuthority({
+    userData: value.userData, profile: profile(), platform: 'win32', windowsAcl,
+  });
+  const loadWorkspaceAuthority = () => loadActiveProfileWorkspaceAuthority({
+    userData: value.userData, profile: profile(), platform: 'win32', windowsAcl,
+  });
+  const credentials = createStore({ loadAccountAuthority, loadWorkspaceAuthority }, {
+    platform: 'win32',
+    windowsAcl,
+  });
+  credentials.replace({ username: 'user', password: 'password' });
+  assert.equal(protectedFiles.some((file) => file.endsWith('.tmp')), true);
+  assert.equal(verifiedFiles.includes(value.layout.account.vpnCredential), true);
+  assert.equal(verifiedFiles.includes(value.layout.account.document), true);
+});

--- a/desktop/test/profile-workspace-storage.test.js
+++ b/desktop/test/profile-workspace-storage.test.js
@@ -250,6 +250,8 @@ test('P3 foundation is packaged but does not activate migration in production Ma
     'profile-workspace-runtime-authority',
     'profile-workspace-settings-bundle',
     'profile-workspace-settings-store',
+    'profile-workspace-credential-store',
+    'profile-workspace-credential-transaction',
     'legacy-flat-source-receipts',
     'vpn-credential-envelope',
     'vpn-credential-envelope-store',

--- a/docs/adr/0015-p3-runtime-credential-transaction.md
+++ b/docs/adr/0015-p3-runtime-credential-transaction.md
@@ -1,0 +1,66 @@
+# ADR-0015: P3 Account and VPN credential transaction
+
+- Status: Accepted as a non-activating P3i contract
+- Production storage switch: not enabled by this ADR
+- Parent contracts: [`ADR-0012`](0012-p3-rollback-retirement.md),
+  [`ADR-0013`](0013-p3-runtime-authority.md)
+
+## Context
+
+Replacing or clearing a VPN credential changes both the encrypted envelope and `account.json`. These files cannot
+be updated with the settings redo transaction because their intermediate states intentionally fail the complete
+runtime authority check. A clear may remove ciphertext before Account metadata is committed; a replacement may
+write a newly bound envelope while the Account still names the previous credential revision.
+
+Recovery therefore needs a narrower Profile/Account bootstrap authority that validates the immutable reviewed
+Profile, Gateway, protocol, Account and Workspace identity without requiring credential presence to match yet.
+Ordinary runtime and connection paths continue to use the complete authority and fail closed in intermediate
+states.
+
+## Decision
+
+`ProfileWorkspaceCredentialStore` owns replacement, clear, explicit decrypt and crash recovery for:
+
+- `account.json`;
+- `vpn-credential.bin`;
+- `credential-transaction.json`.
+
+Before either mutation it requires `LegacyCredentialRollbackStore` retirement to be proven. A failed rollback
+retirement prevents the credential intent and both targets from changing. Once retired, failure later in the new
+credential transaction never reactivates or restores legacy ciphertext.
+
+The redo intent is bound to the invariant Profile ID/key, Profile credential revision, Account key, Workspace
+key/context epoch, Gateway origin and ProtocolFamily. Exact Account and credential before/after receipts detect
+all out-of-band changes. The after Account document and encrypted after envelope are stored as bounded base64;
+username and password never appear in the intent, Account document, logs or Renderer state.
+
+Replacement increments the dedicated Account credential revision and active credential version, encrypts the
+username/password against the new binding, writes the envelope first, then commits Account metadata. Clear
+increments the credential revision, durably removes the envelope first, then commits `activeCredentialVersion =
+null`. A credential-free clear still proves rollback retirement but does not churn revisions.
+
+Explicit `open()` first reconciles pending intent, validates the complete runtime authority, then decrypts the
+envelope into a zeroizing Main-owned `DecryptedVpnCredential`. Status and settings reads never decrypt it.
+
+## Recovery and failure policy
+
+- no intent means neither target is repaired or guessed;
+- with an intent, each target must match its exact before or after receipt;
+- recovery writes/removes the after credential before committing after Account metadata;
+- all after receipts are verified before the intent is cleared;
+- malformed intent, binding drift, target drift, link/private-file failure or ACL failure blocks;
+- recovery must run before complete runtime authority or any connection attempt at production startup.
+
+## Verification
+
+Tests cover replacement/decryption/zeroization, clear, credential-free clear, legacy retirement ordering, no
+plaintext in persistent targets or redo intent, crash after credential write, crash after credential removal,
+out-of-band Account mutation and simulated Windows ACL protection. Existing authority tests prove complete reads
+reject credential-presence drift while the bootstrap reader remains available to the transaction owner.
+
+## Non-activation boundary and next gate
+
+Production `desktop/main.js` does not import this store. P3j must compose startup migration recovery, settings
+redo recovery, credential redo recovery, rollback retirement and new-path runtime adapters before any legacy flat
+authority is retired. Only after packaged restart/fault tests pass may P3j build a test version and directly replace
+the installed macOS App.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -637,6 +637,8 @@ Non-activating storage foundation: [`ADR-0007`](../adr/0007-p3-storage-foundatio
 - project the existing settings API over split global/Workspace/resource documents without persisting an account
   label, and commit multi-document changes through a bound owner-only redo intent that recovers to all-new or
   blocks on out-of-band drift;
+- retire the legacy rollback secret before Account credential mutation, then atomically recover the encrypted VPN
+  envelope and Account credential revision/version through a separate invariant-bound redo transaction;
 
 - split app-global and profile settings;
 - create `profiles/<profileKey>/accounts/<accountKey>/workspace/` from the start;


### PR DESCRIPTION
## What changed

- split the pure Account/VPN credential transaction contract from its persistent recovery store
- add a recoverable Profile/Account bootstrap authority that tolerates only transaction-owned credential intermediate states
- require legacy rollback retirement before replacement or clear
- bind encrypted envelopes to incremented Account credential revisions and versions
- recover credential-first then Account metadata from exact before/after receipts
- keep explicit decrypt Main-owned and zeroizing; status reads do not touch secure storage

## Safety boundary

- complete runtime authority still rejects credential-presence mismatch
- redo intent and Account metadata contain no username or password
- rollback retirement failure prevents intent and target writes
- out-of-band target/binding/private-file/ACL drift fails closed
- production Main remains unchanged; P3j is the separate activation gate

## Verification

- Desktop: 710 passed, 0 failed, 1 Windows-only skip
- architecture: 247 files, 382 edges, 0 cycles
- npm audit: 0 vulnerabilities
- staged secret gate and all JS syntax: PASS