### PR TITLE
2.0 P3j: centralize runtime storage paths

### DIFF
--- a/desktop/lib/app-data-dir.js
+++ b/desktop/lib/app-data-dir.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const { createLegacyRuntimeStoragePaths } = require('./runtime-storage-paths');
 
 function resolveUserDataOverride(rawValue) {
   if (rawValue == null || String(rawValue).trim() === '') return null;
@@ -11,4 +12,4 @@ function resolveUserDataOverride(rawValue) {
   return path.resolve(candidate);
 }
 
-module.exports = { resolveUserDataOverride };
+module.exports = { createLegacyRuntimeStoragePaths, resolveUserDataOverride };

--- a/desktop/lib/runtime-storage-paths.js
+++ b/desktop/lib/runtime-storage-paths.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const path = require('node:path');
+const {
+  createLegacyFlatSourcePaths,
+  validateUserDataRoot,
+} = require('./profile-workspace-layout');
+
+const RUNTIME_PATH_KEYS = Object.freeze([
+  'settings',
+  'settingsBackup',
+  'vpnCredential',
+  'engineLog',
+  'engineLogRotated',
+  'engineLogRetention',
+  'externalPac',
+  'browserPac',
+  'routingRules',
+  'siteCredentials',
+  'certificateTrust',
+  'engineOwner',
+  'credentialTransaction',
+  'proxyCredential',
+  'proxyHelperCredential',
+]);
+
+function finalize(mode, root, values) {
+  if (!['legacy-flat', 'profile-workspace'].includes(mode) ||
+      Object.keys(values).length !== RUNTIME_PATH_KEYS.length ||
+      RUNTIME_PATH_KEYS.some((key) => typeof values[key] !== 'string') ||
+      new Set(Object.values(values)).size !== RUNTIME_PATH_KEYS.length) {
+    throw new TypeError('runtime storage path set is incomplete');
+  }
+  for (const file of Object.values(values)) {
+    if (!path.isAbsolute(file) || path.resolve(file) !== file) {
+      throw new TypeError('runtime storage path must be absolute and normalized');
+    }
+    const relative = path.relative(root, file);
+    if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relative)) {
+      throw new TypeError('runtime storage path escapes userData');
+    }
+  }
+  return Object.freeze({ mode, root, ...values });
+}
+
+function createLegacyRuntimeStoragePaths(userData) {
+  const root = validateUserDataRoot(userData);
+  const legacy = createLegacyFlatSourcePaths(root);
+  return finalize('legacy-flat', root, {
+    settings: legacy.settings,
+    settingsBackup: legacy.settingsBackup,
+    vpnCredential: legacy.vpnCredential,
+    engineLog: legacy.engineLog,
+    engineLogRotated: legacy.engineLogRotated,
+    engineLogRetention: legacy.engineLogRetention,
+    externalPac: legacy.externalPac,
+    browserPac: legacy.browserPac,
+    routingRules: legacy.routingRules,
+    siteCredentials: legacy.siteCredentials,
+    certificateTrust: legacy.certificateTrust,
+    engineOwner: legacy.engineOwner,
+    credentialTransaction: legacy.credentialTransaction,
+    proxyCredential: legacy.proxyCredential,
+    proxyHelperCredential: legacy.proxyHelperCredential,
+  });
+}
+
+function createProfileWorkspaceRuntimeStoragePaths(authority) {
+  const layout = authority?.layout;
+  const root = validateUserDataRoot(layout?.root);
+  return finalize('profile-workspace', root, {
+    // Split settings are accessed through ProfileWorkspaceSettingsStore. This
+    // field is its global bootstrap authority, not a legacy-compatible file.
+    settings: layout.global.settings,
+    settingsBackup: layout.global.settingsTransaction,
+    vpnCredential: layout.account.vpnCredential,
+    engineLog: layout.workspace.engineLog,
+    engineLogRotated: layout.workspace.engineLogRotated,
+    engineLogRetention: layout.workspace.engineLogRetention,
+    externalPac: layout.workspace.externalPac,
+    browserPac: layout.workspace.browserPac,
+    routingRules: layout.workspace.routingRules,
+    siteCredentials: layout.workspace.siteCredentials,
+    certificateTrust: layout.workspace.certificateTrust,
+    engineOwner: layout.global.engineOwner,
+    credentialTransaction: layout.account.credentialTransaction,
+    proxyCredential: layout.global.proxyCredential,
+    proxyHelperCredential: layout.global.proxyHelperCredential,
+  });
+}
+
+module.exports = {
+  RUNTIME_PATH_KEYS,
+  createLegacyRuntimeStoragePaths,
+  createProfileWorkspaceRuntimeStoragePaths,
+};

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -20,7 +20,7 @@ const {
   recoverCredentialSettingsTransaction,
   runCredentialSettingsMutation,
 } = require('./lib/credential-settings-transaction');
-const { resolveUserDataOverride } = require('./lib/app-data-dir');
+const { createLegacyRuntimeStoragePaths, resolveUserDataOverride } = require('./lib/app-data-dir');
 const {
   classifyEngineCode,
   classifyEngineOutput,
@@ -107,18 +107,19 @@ app.setName('HKUST(GZ) Connect');
 
 // ---------- paths & state ----------
 const DATA = app.getPath('userData');
-const SETTINGS = path.join(DATA, 'settings.json');
-const CRED = path.join(DATA, 'cred.bin');
-const LOG = path.join(DATA, 'engine.log');
-const PAC_FILE = path.join(DATA, 'routing.pac');
-const CAMPUS_BROWSER_PAC_FILE = path.join(DATA, 'campus-browser-routing.pac');
-const ROUTING_RULES = path.join(DATA, 'routing-rules.json');
-const CAMPUS_CREDENTIALS = path.join(DATA, 'campus-credentials.json');
-const CAMPUS_CERTIFICATE_TRUST = path.join(DATA, 'campus-certificate-trust.json');
-const ENGINE_OWNER = path.join(DATA, 'engine-owner.json');
-const CREDENTIAL_TRANSACTION = path.join(DATA, 'credential-settings-transaction.json');
-const PROXY_CREDENTIAL = path.join(DATA, 'proxy-credential.bin');
-const PROXY_HELPER_CREDENTIAL = path.join(DATA, 'proxy-helper-credential.txt');
+const runtimeStoragePaths = createLegacyRuntimeStoragePaths(DATA);
+const SETTINGS = runtimeStoragePaths.settings;
+const CRED = runtimeStoragePaths.vpnCredential;
+const LOG = runtimeStoragePaths.engineLog;
+const PAC_FILE = runtimeStoragePaths.externalPac;
+const CAMPUS_BROWSER_PAC_FILE = runtimeStoragePaths.browserPac;
+const ROUTING_RULES = runtimeStoragePaths.routingRules;
+const CAMPUS_CREDENTIALS = runtimeStoragePaths.siteCredentials;
+const CAMPUS_CERTIFICATE_TRUST = runtimeStoragePaths.certificateTrust;
+const ENGINE_OWNER = runtimeStoragePaths.engineOwner;
+const CREDENTIAL_TRANSACTION = runtimeStoragePaths.credentialTransaction;
+const PROXY_CREDENTIAL = runtimeStoragePaths.proxyCredential;
+const PROXY_HELPER_CREDENTIAL = runtimeStoragePaths.proxyHelperCredential;
 const syntheticEngineE2e = !app.isPackaged && process.env[SYNTHETIC_ENGINE_E2E_ENV] === '1';
 
 // The helper sidecar is a short-lived, owner-only plaintext projection of the

--- a/desktop/test/external-proxy-main-contract.test.js
+++ b/desktop/test/external-proxy-main-contract.test.js
@@ -11,7 +11,7 @@ const connectEnd = source.indexOf('\nfunction ensureEngineStopped()', connectSta
 const connectOnce = source.slice(connectStart, connectEnd);
 
 test('strict and compatibility generations share one stable credential with distinct policies', () => {
-  assert.match(source, /const PROXY_CREDENTIAL = path\.join\(DATA, 'proxy-credential\.bin'\)/);
+  assert.match(source, /const PROXY_CREDENTIAL = runtimeStoragePaths\.proxyCredential/);
   assert.match(connectOnce, /proxyCredential = generationProxyCredential\(Number\(s\.port\)\);\s*proxyCredentialMode = 'required'/);
   assert.match(connectOnce, /stableProxyCredential \|\| fs\.existsSync\(PROXY_CREDENTIAL\)[\s\S]*proxyCredentialMode = 'optional'/);
   assert.match(connectOnce, /proxyCredentialMode === 'required'[^\n]+--socks-auth-stdin/);

--- a/desktop/test/runtime-storage-paths.test.js
+++ b/desktop/test/runtime-storage-paths.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const { createProfileAccountWorkspaceLayout } = require('../lib/profile-workspace-layout');
+const {
+  RUNTIME_PATH_KEYS,
+  createLegacyRuntimeStoragePaths,
+  createProfileWorkspaceRuntimeStoragePaths,
+} = require('../lib/runtime-storage-paths');
+
+const USER_DATA = path.resolve('/tmp/campus-runtime-storage');
+
+test('legacy path seam is an exact behavior-preserving projection', () => {
+  const paths = createLegacyRuntimeStoragePaths(USER_DATA);
+  assert.equal(paths.mode, 'legacy-flat');
+  assert.equal(paths.settings, path.join(USER_DATA, 'settings.json'));
+  assert.equal(paths.settingsBackup, path.join(USER_DATA, 'settings.json.bak'));
+  assert.equal(paths.vpnCredential, path.join(USER_DATA, 'cred.bin'));
+  assert.equal(paths.externalPac, path.join(USER_DATA, 'routing.pac'));
+  assert.equal(paths.browserPac, path.join(USER_DATA, 'campus-browser-routing.pac'));
+  assert.deepEqual(
+    Object.keys(paths).filter((key) => !['mode', 'root'].includes(key)),
+    [...RUNTIME_PATH_KEYS],
+  );
+  assert.equal(Object.isFrozen(paths), true);
+});
+
+test('Profile Workspace path seam assigns every service to its owner scope', () => {
+  const layout = createProfileAccountWorkspaceLayout({
+    userData: USER_DATA,
+    profileKey: `profile-${'11'.repeat(16)}`,
+    accountKey: `account-${'22'.repeat(16)}`,
+    workspaceKey: `workspace-${'33'.repeat(16)}`,
+  });
+  const paths = createProfileWorkspaceRuntimeStoragePaths({ layout });
+  assert.equal(paths.mode, 'profile-workspace');
+  assert.equal(paths.vpnCredential, layout.account.vpnCredential);
+  assert.equal(paths.engineOwner, layout.global.engineOwner);
+  assert.equal(paths.proxyCredential, layout.global.proxyCredential);
+  assert.equal(paths.routingRules, layout.workspace.routingRules);
+  assert.equal(paths.siteCredentials, layout.workspace.siteCredentials);
+  assert.equal(paths.settingsBackup, layout.global.settingsTransaction);
+  for (const sensitive of ['student001', 'remote.hkust-gz.edu.cn']) {
+    assert.equal(JSON.stringify(paths).includes(sensitive), false);
+  }
+});
+
+test('path seam rejects missing duplicate and escaping runtime targets', () => {
+  assert.throws(() => createLegacyRuntimeStoragePaths('relative'), /userData/u);
+  const layout = createProfileAccountWorkspaceLayout({
+    userData: USER_DATA,
+    profileKey: `profile-${'11'.repeat(16)}`,
+    accountKey: `account-${'22'.repeat(16)}`,
+    workspaceKey: `workspace-${'33'.repeat(16)}`,
+  });
+  assert.throws(() => createProfileWorkspaceRuntimeStoragePaths({
+    layout: {
+      ...layout,
+      global: { ...layout.global, settingsTransaction: layout.global.settings },
+    },
+  }), /incomplete/u);
+});
+
+test('production Main obtains all legacy paths through the seam', () => {
+  const main = fs.readFileSync(path.join(__dirname, '..', 'main.js'), 'utf8');
+  assert.equal(main.includes('createLegacyRuntimeStoragePaths(DATA)'), true);
+  assert.equal(main.includes("path.join(DATA, 'settings.json')"), false);
+  assert.equal(main.includes("path.join(DATA, 'cred.bin')"), false);
+});

--- a/docs/adr/0016-p3-runtime-storage-path-seam.md
+++ b/docs/adr/0016-p3-runtime-storage-path-seam.md
@@ -1,0 +1,56 @@
+# ADR-0016: P3 runtime storage path seam
+
+- Status: Accepted as a behavior-preserving P3j seam
+- Production migration: not enabled by this ADR
+- Parent contracts: [`ADR-0013`](0013-p3-runtime-authority.md),
+  [`ADR-0015`](0015-p3-runtime-credential-transaction.md)
+
+## Context
+
+Production Main previously constructed eleven flat user-data paths directly at module load and immediately handed
+them to log, routing, certificate, Browser credential, Engine-owner and proxy-credential services. Running the P3
+migration while those services still point at retired flat files would create a split authority and break the
+application even if migration itself succeeded.
+
+Moving all service initialization and migration in one patch would combine path ownership, lifecycle ordering,
+credential recovery and user-visible behavior. The first safe step is a path seam whose legacy projection is byte
+for byte identical to 1.2.3.
+
+## Decision
+
+`runtime-storage-paths.js` defines one exact set of runtime targets:
+
+```text
+settings + transaction/backup authority
+VPN credential + credential transaction
+Engine log/rotation/retention
+external and Browser PAC
+routing rules
+website credential vault
+certificate trust
+Engine owner record
+stable proxy credential and helper sidecar
+```
+
+`createLegacyRuntimeStoragePaths()` maps these names to the existing flat paths. Production Main now obtains every
+path from this projection through its existing `app-data-dir` dependency, so Main dependency count and external
+behavior remain unchanged.
+
+`createProfileWorkspaceRuntimeStoragePaths()` maps the same service owners to global, Account or Workspace paths
+from a validated runtime authority. Its settings field names only the global bootstrap document; split settings
+must still be accessed through `ProfileWorkspaceSettingsStore`, never by the old flat settings parser.
+
+Both projections require an absolute normalized userData root, exact complete unique targets and containment below
+that root. No username, Gateway hostname or other user-derived value participates in a filesystem path.
+
+## Verification
+
+Tests prove every legacy path is unchanged, every Profile Workspace service maps to its documented owner, malformed
+or duplicate targets fail, opaque paths contain no identity/Gateway material and Main no longer constructs
+`settings.json` or `cred.bin` directly. Existing full Desktop tests cover the behavior-preserving production seam.
+
+## Next gate
+
+P3k must defer construction of path-bound services until `app.whenReady()`, run legacy/P3 transaction recovery and
+migration before choosing one immutable runtime path set, and prevent any service or connection from starting when
+authority is ambiguous. Only then can a packaged test App replace the installed version.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -639,6 +639,8 @@ Non-activating storage foundation: [`ADR-0007`](../adr/0007-p3-storage-foundatio
   blocks on out-of-band drift;
 - retire the legacy rollback secret before Account credential mutation, then atomically recover the encrypted VPN
   envelope and Account credential revision/version through a separate invariant-bound redo transaction;
+- route every Main-owned file through one exact legacy/Profile-Workspace storage path seam before deferring service
+  construction and activating migration, with a behavior-preserving legacy projection as the first production use;
 
 - split app-global and profile settings;
 - create `profiles/<profileKey>/accounts/<accountKey>/workspace/` from the start;


### PR DESCRIPTION
## What changed

- add one exact runtime path vocabulary for every Main-owned persistent service
- map the current legacy flat layout byte-for-byte through that seam
- define the future Profile Workspace mapping by global, Account, and Workspace owner
- make production Main stop constructing settings and credential paths directly
- preserve the existing app-data dependency and architecture ratchets

## Compatibility

- every currently used path remains unchanged
- migration and Profile Workspace storage are still not activated
- no installed file, credential, Browser partition, route, PAC, log, or Engine lifecycle changes

## Verification

- Desktop: 714 passed, 0 failed, 1 Windows-only skip
- architecture: 249 files, 386 edges, 0 cycles; Main 35 deps / 1596 lines
- npm audit: 0 vulnerabilities
- staged secret gate and all JS syntax: PASS