### PR TITLE
2.0 P3k: compose production workspace migration runtime

### DIFF
--- a/desktop/lib/legacy-migration-inputs.js
+++ b/desktop/lib/legacy-migration-inputs.js
@@ -1,0 +1,186 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const util = require('node:util');
+const { protectedStorageAvailable } = require('./credential-store');
+const { LEGACY_SOURCE_MAX_BYTES } = require('./legacy-flat-source-receipts');
+const { readPrivateFileBounded } = require('./private-file');
+const {
+  LEGACY_SOURCE_IDS,
+  legacySourceReceiptDigest,
+} = require('./profile-workspace-migration-journal');
+const { createLegacyFlatSourcePaths } = require('./profile-workspace-layout');
+const { normalizeSettings } = require('./settings-store');
+const { parseCredentialField } = require('./settings-update');
+const { verifyWindowsFileOwnerOnly } = require('./windows-private-file');
+
+function sameReceipt(expected, data) {
+  return expected.present === true && expected.bytes === data.length &&
+    expected.sha256 === crypto.createHash('sha256').update(data).digest('hex');
+}
+
+class LegacyMigrationPayloadOwner {
+  #payloads;
+  #destroyed = false;
+
+  constructor(payloads) {
+    this.#payloads = payloads;
+    Object.freeze(this);
+  }
+
+  withPayloads(callback) {
+    if (this.#destroyed) throw new Error('legacy migration payload owner is destroyed');
+    if (typeof callback !== 'function') throw new TypeError('legacy migration callback is required');
+    const result = callback(Object.freeze({ ...this.#payloads }));
+    if (result && typeof result.then === 'function') {
+      throw new TypeError('legacy migration payload access must be synchronous');
+    }
+    return result;
+  }
+
+  destroy() {
+    if (this.#destroyed) return false;
+    this.#destroyed = true;
+    for (const payload of Object.values(this.#payloads)) payload?.fill?.(0);
+    this.#payloads = {};
+    return true;
+  }
+
+  toJSON() { return '[redacted legacy migration payloads]'; }
+  toString() { return '[redacted legacy migration payloads]'; }
+  [util.inspect.custom]() { return '[redacted legacy migration payloads]'; }
+}
+
+class LegacyMigrationCredentialOwner {
+  #username;
+  #password;
+  #destroyed = false;
+
+  constructor(username, password) {
+    const account = parseCredentialField(username, 'account');
+    const secret = parseCredentialField(password, 'password');
+    if (!account || account.length > 256 || !secret || secret.length > 4096) {
+      throw new TypeError('legacy migration credential is invalid');
+    }
+    this.#username = Buffer.from(account, 'utf8');
+    this.#password = Buffer.from(secret, 'utf8');
+    Object.freeze(this);
+  }
+
+  withStrings(callback) {
+    if (this.#destroyed) throw new Error('legacy migration credential owner is destroyed');
+    if (typeof callback !== 'function') throw new TypeError('legacy credential callback is required');
+    const result = callback(this.#username.toString('utf8'), this.#password.toString('utf8'));
+    if (result && typeof result.then === 'function') {
+      throw new TypeError('legacy credential access must be synchronous');
+    }
+    return result;
+  }
+
+  destroy() {
+    if (this.#destroyed) return false;
+    this.#destroyed = true;
+    this.#username.fill(0);
+    this.#password.fill(0);
+    return true;
+  }
+
+  toJSON() { return '[redacted legacy migration credential]'; }
+  toString() { return '[redacted legacy migration credential]'; }
+  [util.inspect.custom]() { return '[redacted legacy migration credential]'; }
+}
+
+function readLegacyMigrationPayloads({
+  userData,
+  expectedReceipts,
+  fileSystem = fs,
+  platform = process.platform,
+  windowsAcl = { verify: verifyWindowsFileOwnerOnly },
+} = {}) {
+  if (!fileSystem || typeof fileSystem.openSync !== 'function' ||
+      !['darwin', 'linux', 'win32'].includes(platform) ||
+      (platform === 'win32' && typeof windowsAcl?.verify !== 'function')) {
+    throw new TypeError('legacy migration input dependencies are invalid');
+  }
+  legacySourceReceiptDigest(expectedReceipts);
+  const paths = createLegacyFlatSourcePaths(userData);
+  const payloads = {};
+  try {
+    for (const id of LEGACY_SOURCE_IDS) {
+      const expected = expectedReceipts[id];
+      if (!expected.present) {
+        try {
+          fileSystem.lstatSync(paths[id]);
+          throw new Error(`unexpected legacy migration source appeared: ${id}`);
+        } catch (error) {
+          if (error?.code !== 'ENOENT') throw error;
+        }
+        payloads[id] = null;
+        continue;
+      }
+      if (platform === 'win32' && !windowsAcl.verify(paths[id])) {
+        throw new Error(`legacy migration source ACL is invalid: ${id}`);
+      }
+      let data;
+      try {
+        ({ data } = readPrivateFileBounded(paths[id], {
+          maxBytes: LEGACY_SOURCE_MAX_BYTES[id],
+          platform,
+          fileSystem,
+        }));
+      } catch (error) {
+        throw new Error(`legacy migration source could not be read: ${id}`, { cause: error });
+      }
+      if (!sameReceipt(expected, data)) {
+        data.fill(0);
+        throw new Error(`legacy migration source receipt changed: ${id}`);
+      }
+      payloads[id] = data;
+    }
+    return new LegacyMigrationPayloadOwner(payloads);
+  } catch (error) {
+    for (const payload of Object.values(payloads)) payload?.fill?.(0);
+    throw error;
+  }
+}
+
+function openLegacyMigrationCredential({
+  settingsBytes,
+  encryptedCredential,
+  safeStorage,
+  platform = process.platform,
+} = {}) {
+  if (!Buffer.isBuffer(settingsBytes) || settingsBytes.length < 2 ||
+      (encryptedCredential !== null && !Buffer.isBuffer(encryptedCredential))) {
+    throw new TypeError('legacy migration credential inputs are invalid');
+  }
+  let parsed;
+  try { parsed = JSON.parse(settingsBytes.toString('utf8')); }
+  catch (error) { throw new Error('legacy migration settings are invalid', { cause: error }); }
+  const settings = normalizeSettings(parsed);
+  if (encryptedCredential === null) {
+    if (settings.username) throw new Error('legacy migration credential pair is incomplete');
+    return null;
+  }
+  if (!settings.username || !protectedStorageAvailable(safeStorage, platform)) {
+    throw new Error('legacy migration credential pair is unavailable');
+  }
+  let password = '';
+  try {
+    password = safeStorage.decryptString(encryptedCredential);
+    return new LegacyMigrationCredentialOwner(settings.username, password);
+  } catch (error) {
+    throw new Error('legacy migration credential could not be decrypted', { cause: error });
+  } finally {
+    password = '';
+    if (parsed && typeof parsed === 'object') parsed.username = '';
+  }
+}
+
+module.exports = {
+  LegacyMigrationCredentialOwner,
+  LegacyMigrationPayloadOwner,
+  openLegacyMigrationCredential,
+  readLegacyMigrationPayloads,
+};

--- a/desktop/lib/profile-workspace-migration-runtime.js
+++ b/desktop/lib/profile-workspace-migration-runtime.js
@@ -1,0 +1,271 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { createHkustMigrationDestinationPlan, LEGACY_COPY_SOURCE_IDS } =
+  require('./hkust-migration-destination-plan');
+const {
+  openLegacyMigrationCredential,
+  readLegacyMigrationPayloads,
+} = require('./legacy-migration-inputs');
+const {
+  collectLegacyFlatSourceReceipts,
+} = require('./legacy-flat-source-receipts');
+const { retireLegacyFlatSources } = require('./legacy-flat-source-retirement');
+const {
+  destinationPathMap,
+  materializeDestinationFiles,
+  verifyDestinationFiles,
+} = require('./profile-workspace-destination-files');
+const {
+  createPreparedMigrationJournal,
+  LEGACY_SOURCE_IDS,
+} = require('./profile-workspace-migration-journal');
+const { ProfileWorkspaceMigrationCoordinator } =
+  require('./profile-workspace-migration-coordinator');
+const { ProfileWorkspaceMigrationJournalStore } =
+  require('./profile-workspace-migration-store');
+const {
+  loadActiveProfileWorkspaceAuthority,
+} = require('./profile-workspace-runtime-authority');
+const { validateUserDataRoot } = require('./profile-workspace-layout');
+const {
+  createLegacyRuntimeStoragePaths,
+  createProfileWorkspaceRuntimeStoragePaths,
+} = require('./runtime-storage-paths');
+const { validateSchoolProfileDocument } = require('./school-profile-schema');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+function pathExists(file, fileSystem) {
+  try {
+    fileSystem.lstatSync(file);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function exactPayloads(payloads) {
+  return Object.freeze(Object.fromEntries(LEGACY_COPY_SOURCE_IDS.map((id) => [id, payloads[id]])));
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}
+
+function cloneProfileDocument(value) {
+  let cloned;
+  try { cloned = JSON.parse(JSON.stringify(value)); }
+  catch (error) { throw new TypeError('SchoolProfile document could not be cloned', { cause: error }); }
+  validateSchoolProfileDocument(cloned);
+  return deepFreeze(cloned);
+}
+
+class ProfileWorkspaceMigrationRuntime {
+  constructor({
+    userData,
+    profile: rawProfile,
+    safeStorage,
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+    randomBytes = crypto.randomBytes,
+    now = Date.now,
+  } = {}) {
+    if (!safeStorage || !fileSystem || typeof fileSystem.openSync !== 'function' ||
+        !['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' &&
+          (typeof windowsAcl?.protect !== 'function' || typeof windowsAcl?.verify !== 'function')) ||
+        typeof randomBytes !== 'function' || typeof now !== 'function') {
+      throw new TypeError('Profile Workspace migration runtime dependencies are invalid');
+    }
+    this.userData = validateUserDataRoot(userData);
+    this.profileDocument = cloneProfileDocument(rawProfile);
+    this.profile = validateSchoolProfileDocument(this.profileDocument);
+    this.safeStorage = safeStorage;
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+    this.randomBytes = randomBytes;
+    this.now = now;
+    this.running = false;
+    this.journalPath = path.join(
+      this.userData,
+      'global',
+      'profile-account-workspace-migration.json',
+    );
+  }
+
+  run() {
+    if (this.running) throw new Error('Profile Workspace migration runtime is already running');
+    this.running = true;
+    try {
+      const coordinator = this.#coordinator();
+      const migration = coordinator.run();
+      if (!migration.ok && migration.status === 'blocked') {
+        const error = new Error('Profile Workspace migration is blocked');
+        error.code = migration.code;
+        throw error;
+      }
+      if (['migrated', 'already_migrated'].includes(migration.status)) {
+        const authority = this.#loadAuthority();
+        return Object.freeze({
+          migration,
+          mode: 'profile-workspace',
+          authority,
+          paths: createProfileWorkspaceRuntimeStoragePaths(authority),
+        });
+      }
+      return Object.freeze({
+        migration,
+        mode: 'legacy-flat',
+        authority: null,
+        paths: createLegacyRuntimeStoragePaths(this.userData),
+      });
+    } finally {
+      this.running = false;
+    }
+  }
+
+  #coordinator() {
+    const journalStore = new ProfileWorkspaceMigrationJournalStore({
+      filePath: this.journalPath,
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+      windowsAcl: this.windowsAcl,
+    });
+    return new ProfileWorkspaceMigrationCoordinator({
+      userData: this.userData,
+      journalStore,
+      legacyAuthorityExists: () => this.#legacyAuthorityExists(),
+      destinationAuthorityExists: (context) => this.#destinationAuthorityExists(context),
+      collectSourceReceipts: () => this.#sourceReceipts(),
+      prepareJournal: (sourceReceipts) => createPreparedMigrationJournal({
+        profileId: this.profile.profileId,
+        profileRevision: this.profile.profileRevision,
+        profileCredentialBindingRevision: this.profile.profileCredentialBindingRevision,
+        gatewayOrigin: this.profile.gateway.origin.origin,
+        protocolFamily: this.profile.gateway.protocolFamily,
+        sourceReceipts,
+        randomBytes: this.randomBytes,
+        now: this.now,
+      }),
+      buildDestination: ({ journal, layout }) => this.#buildDestination(journal, layout),
+      verifyDestination: ({ layout }) => verifyDestinationFiles({
+        layout,
+        fileSystem: this.fileSystem,
+        platform: this.platform,
+        windowsAcl: this.windowsAcl,
+      }),
+      retireLegacy: ({ journal }) => retireLegacyFlatSources({
+        userData: this.userData,
+        expectedReceipts: journal.sourceReceipts,
+        fileSystem: this.fileSystem,
+        platform: this.platform,
+        windowsAcl: this.windowsAcl,
+      }),
+      now: this.now,
+    });
+  }
+
+  #sourceReceipts() {
+    return collectLegacyFlatSourceReceipts({
+      userData: this.userData,
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+      windowsAcl: this.windowsAcl,
+    });
+  }
+
+  #legacyAuthorityExists() {
+    const receipts = this.#sourceReceipts();
+    if (receipts.settings.present) return true;
+    if (LEGACY_SOURCE_IDS.some((id) => receipts[id].present)) {
+      throw new Error('orphaned legacy storage exists without settings authority');
+    }
+    return false;
+  }
+
+  #destinationAuthorityExists(context) {
+    if (context?.layout) {
+      return verifyDestinationFiles({
+        layout: context.layout,
+        fileSystem: this.fileSystem,
+        platform: this.platform,
+        windowsAcl: this.windowsAcl,
+      }).globalSettings.present;
+    }
+    const globalSettings = path.join(this.userData, 'global', 'settings.json');
+    if (!pathExists(globalSettings, this.fileSystem)) return false;
+    this.#loadAuthority();
+    return true;
+  }
+
+  #buildDestination(journal, layout) {
+    const owner = readLegacyMigrationPayloads({
+      userData: this.userData,
+      expectedReceipts: journal.sourceReceipts,
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+      windowsAcl: this.windowsAcl,
+    });
+    try {
+      return owner.withPayloads((payloads) => {
+        const credentialOwner = openLegacyMigrationCredential({
+          settingsBytes: payloads.settings,
+          encryptedCredential: payloads.vpnCredential,
+          safeStorage: this.safeStorage,
+          platform: this.platform,
+        });
+        let plan = null;
+        try {
+          plan = createHkustMigrationDestinationPlan({
+            journal,
+            settingsBytes: payloads.settings,
+            legacyCredential: payloads.vpnCredential,
+            payloads: exactPayloads(payloads),
+            credentialOwner,
+            protectedStorage: this.safeStorage,
+            platform: this.platform,
+            now: this.now,
+          });
+          return materializeDestinationFiles({
+            layout,
+            files: plan.files,
+            fileSystem: this.fileSystem,
+            platform: this.platform,
+            windowsAcl: this.windowsAcl,
+          });
+        } finally {
+          credentialOwner?.destroy();
+          for (const data of Object.values(plan?.files || {})) data?.fill?.(0);
+        }
+      });
+    } finally {
+      owner.destroy();
+    }
+  }
+
+  #loadAuthority() {
+    return loadActiveProfileWorkspaceAuthority({
+      userData: this.userData,
+      profile: this.profileDocument,
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+      windowsAcl: this.windowsAcl,
+    });
+  }
+}
+
+module.exports = { ProfileWorkspaceMigrationRuntime };

--- a/desktop/test/legacy-migration-inputs.test.js
+++ b/desktop/test/legacy-migration-inputs.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { collectLegacyFlatSourceReceipts } = require('../lib/legacy-flat-source-receipts');
+const {
+  openLegacyMigrationCredential,
+  readLegacyMigrationPayloads,
+} = require('../lib/legacy-migration-inputs');
+const { createLegacyFlatSourcePaths } = require('../lib/profile-workspace-layout');
+const { normalizeSettings } = require('../lib/settings-store');
+
+function safeStorage() {
+  return {
+    isEncryptionAvailable: () => true,
+    getSelectedStorageBackend: () => 'keychain',
+    encryptString: (value) => Buffer.from(value, 'utf8').map((byte) => byte ^ 0xa5),
+    decryptString: (value) => Buffer.from(value).map((byte) => byte ^ 0xa5).toString('utf8'),
+  };
+}
+
+function fixture(t) {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-migration-inputs-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const paths = createLegacyFlatSourcePaths(userData);
+  const settings = Buffer.from(JSON.stringify(normalizeSettings({
+    username: 'synthetic-user',
+    port: 6180,
+  })), 'utf8');
+  fs.writeFileSync(paths.settings, settings, { mode: 0o600 });
+  fs.writeFileSync(paths.settingsBackup, settings, { mode: 0o600 });
+  fs.writeFileSync(paths.vpnCredential, safeStorage().encryptString('synthetic-password'), {
+    mode: 0o600,
+  });
+  fs.writeFileSync(paths.routingRules, 'synthetic-routing', { mode: 0o600 });
+  return {
+    userData,
+    paths,
+    expected: collectLegacyFlatSourceReceipts({ userData }),
+  };
+}
+
+test('payload owner reads exact receipts through bounded private files and zeroizes on destroy', (t) => {
+  const value = fixture(t);
+  const owner = readLegacyMigrationPayloads({
+    userData: value.userData,
+    expectedReceipts: value.expected,
+  });
+  let observed;
+  owner.withPayloads((payloads) => {
+    observed = payloads.routingRules;
+    assert.equal(payloads.settings.length > 0, true);
+    assert.equal(payloads.externalPac, null);
+  });
+  assert.equal(observed.equals(Buffer.from('synthetic-routing')), true);
+  assert.equal(owner.destroy(), true);
+  assert.equal(observed.equals(Buffer.alloc(observed.length)), true);
+  assert.throws(() => owner.withPayloads(() => {}), /destroyed/u);
+  assert.equal(JSON.stringify(owner).includes('synthetic'), false);
+});
+
+test('legacy credential decrypts only into a zeroizing callback owner', (t) => {
+  const value = fixture(t);
+  const settings = fs.readFileSync(value.paths.settings);
+  const encrypted = fs.readFileSync(value.paths.vpnCredential);
+  const owner = openLegacyMigrationCredential({
+    settingsBytes: settings,
+    encryptedCredential: encrypted,
+    safeStorage: safeStorage(),
+    platform: 'darwin',
+  });
+  assert.deepEqual(owner.withStrings((username, password) => ({ username, password })), {
+    username: 'synthetic-user',
+    password: 'synthetic-password',
+  });
+  owner.destroy();
+  assert.throws(() => owner.withStrings(() => {}), /destroyed/u);
+  assert.equal(JSON.stringify(owner).includes('synthetic'), false);
+});
+
+test('changed missing unexpected and linked migration inputs fail closed', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const changed = fixture(t);
+  fs.writeFileSync(changed.paths.routingRules, 'changed', { mode: 0o600 });
+  assert.throws(() => readLegacyMigrationPayloads({
+    userData: changed.userData,
+    expectedReceipts: changed.expected,
+  }), /receipt changed/u);
+
+  const unexpected = fixture(t);
+  fs.writeFileSync(unexpected.paths.externalPac, 'unexpected', { mode: 0o600 });
+  assert.throws(() => readLegacyMigrationPayloads({
+    userData: unexpected.userData,
+    expectedReceipts: unexpected.expected,
+  }), /unexpected/u);
+
+  const linked = fixture(t);
+  const target = path.join(linked.userData, 'unrelated');
+  fs.writeFileSync(target, fs.readFileSync(linked.paths.routingRules), { mode: 0o600 });
+  fs.unlinkSync(linked.paths.routingRules);
+  fs.symlinkSync(target, linked.paths.routingRules);
+  assert.throws(() => readLegacyMigrationPayloads({
+    userData: linked.userData,
+    expectedReceipts: linked.expected,
+  }), /could not be read/u);
+  assert.equal(fs.readFileSync(target, 'utf8'), 'synthetic-routing');
+});

--- a/desktop/test/profile-workspace-migration-runtime.test.js
+++ b/desktop/test/profile-workspace-migration-runtime.test.js
@@ -1,0 +1,166 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { LEGACY_COPY_SOURCE_IDS } = require('../lib/hkust-migration-destination-plan');
+const { ProfileWorkspaceMigrationRuntime } =
+  require('../lib/profile-workspace-migration-runtime');
+const { createLegacyFlatSourcePaths } = require('../lib/profile-workspace-layout');
+const { normalizeSettings } = require('../lib/settings-store');
+const { decryptVpnCredentialEnvelope } = require('../lib/vpn-credential-envelope');
+
+function profile() {
+  return JSON.parse(fs.readFileSync(
+    path.join(__dirname, '..', 'assets', 'profiles', 'hkustgz', 'school-profile.json'),
+    'utf8',
+  ));
+}
+
+function safeStorage() {
+  return {
+    isEncryptionAvailable: () => true,
+    getSelectedStorageBackend: () => 'keychain',
+    encryptString: (value) => Buffer.from(value, 'utf8').map((byte) => byte ^ 0xa5),
+    decryptString: (value) => Buffer.from(value).map((byte) => byte ^ 0xa5).toString('utf8'),
+  };
+}
+
+function fixture(t, { credential = true } = {}) {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-migration-runtime-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const paths = createLegacyFlatSourcePaths(userData);
+  const settings = Buffer.from(JSON.stringify(normalizeSettings({
+    username: credential ? 'synthetic-user' : '',
+    port: 6180,
+    autoConnect: false,
+    routeDomains: ['hkust-gz.edu.cn'],
+    customResources: [],
+  })), 'utf8');
+  fs.writeFileSync(paths.settings, settings, { mode: 0o600 });
+  fs.writeFileSync(paths.settingsBackup, settings, { mode: 0o600 });
+  if (credential) {
+    fs.writeFileSync(paths.vpnCredential, safeStorage().encryptString('synthetic-password'), {
+      mode: 0o600,
+    });
+  }
+  for (const id of LEGACY_COPY_SOURCE_IDS) {
+    if (id === 'routingRules') {
+      fs.writeFileSync(paths[id], '{"schemaVersion":1,"rules":[]}', { mode: 0o600 });
+    }
+  }
+  let entropy = 1;
+  let timestamp = 1_700_000_000_000;
+  const options = {
+    userData,
+    profile: profile(),
+    safeStorage: safeStorage(),
+    platform: 'darwin',
+    randomBytes: () => Buffer.alloc(16, entropy++),
+    now: () => timestamp++,
+  };
+  return { userData, paths, options };
+}
+
+test('runtime migrates real flat files to one verified Profile Workspace authority', (t) => {
+  const value = fixture(t);
+  const runtime = new ProfileWorkspaceMigrationRuntime(value.options);
+  const result = runtime.run();
+  assert.equal(result.mode, 'profile-workspace');
+  assert.equal(result.migration.status, 'migrated');
+  assert.equal(result.authority.globalSettings.port, 6180);
+  assert.equal(result.authority.workspaceSettings.autoConnect, false);
+  assert.equal(result.authority.hasCredential, true);
+  assert.equal(Object.values(value.paths).some((file) => fs.existsSync(file)), false);
+  assert.equal(result.paths.vpnCredential, result.authority.layout.account.vpnCredential);
+  assert.equal(fs.existsSync(result.authority.layout.account.legacyCredentialRollbackBlob), true);
+
+  const encrypted = fs.readFileSync(result.paths.vpnCredential);
+  const owner = decryptVpnCredentialEnvelope(encrypted, {
+    expectedBinding: result.authority.credentialBinding,
+    safeStorage: safeStorage(),
+    platform: 'darwin',
+  });
+  assert.deepEqual(owner.withStrings((username, password) => ({ username, password })), {
+    username: 'synthetic-user',
+    password: 'synthetic-password',
+  });
+  owner.destroy();
+
+  const repeated = runtime.run();
+  assert.equal(repeated.mode, 'profile-workspace');
+  assert.equal(repeated.migration.status, 'already_migrated');
+});
+
+test('credential-free migration creates an explicit retired rollback state', (t) => {
+  const value = fixture(t, { credential: false });
+  const result = new ProfileWorkspaceMigrationRuntime(value.options).run();
+  assert.equal(result.authority.hasCredential, false);
+  assert.equal(fs.existsSync(result.paths.vpnCredential), false);
+  const rollback = JSON.parse(fs.readFileSync(
+    result.authority.layout.account.legacyCredentialRollbackState,
+    'utf8',
+  ));
+  assert.equal(rollback.state, 'retired');
+  assert.equal(rollback.retirementReason, 'no_legacy_credential');
+});
+
+test('empty first launch remains legacy-compatible while orphaned files block', (t) => {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-first-launch-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const base = {
+    userData,
+    profile: profile(),
+    safeStorage: safeStorage(),
+    platform: 'darwin',
+  };
+  const first = new ProfileWorkspaceMigrationRuntime(base).run();
+  assert.equal(first.mode, 'legacy-flat');
+  assert.equal(first.migration.status, 'not_applicable');
+  const paths = createLegacyFlatSourcePaths(userData);
+  fs.writeFileSync(paths.vpnCredential, 'orphaned', { mode: 0o600 });
+  assert.throws(() => new ProfileWorkspaceMigrationRuntime(base).run(), /orphaned/u);
+});
+
+test('retirement interruption keeps committed destination and resumes safely', (t) => {
+  const value = fixture(t);
+  const injected = Object.create(fs);
+  let failed = false;
+  injected.unlinkSync = (file) => {
+    if (!failed && file === value.paths.vpnCredential) {
+      failed = true;
+      throw new Error('simulated retirement crash');
+    }
+    return fs.unlinkSync(file);
+  };
+  assert.throws(() => new ProfileWorkspaceMigrationRuntime({
+    ...value.options,
+    fileSystem: injected,
+  }).run(), /retirement failed/u);
+  assert.equal(fs.existsSync(value.paths.settings), true);
+  const recovered = new ProfileWorkspaceMigrationRuntime(value.options).run();
+  assert.equal(recovered.mode, 'profile-workspace');
+  assert.equal(recovered.migration.status, 'migrated');
+  assert.equal(fs.existsSync(value.paths.settings), false);
+});
+
+test('simulated Windows runtime protects destinations and verifies every private source', (t) => {
+  const value = fixture(t);
+  const protectedFiles = [];
+  const verifiedFiles = [];
+  const windowsAcl = {
+    protect(file) { protectedFiles.push(file); return true; },
+    verify(file) { verifiedFiles.push(file); return fs.existsSync(file); },
+  };
+  const result = new ProfileWorkspaceMigrationRuntime({
+    ...value.options,
+    platform: 'win32',
+    windowsAcl,
+  }).run();
+  assert.equal(result.mode, 'profile-workspace');
+  assert.equal(protectedFiles.some((file) => file.endsWith('.tmp')), true);
+  assert.equal(verifiedFiles.includes(result.paths.vpnCredential), true);
+  assert.equal(verifiedFiles.length > 10, true);
+});

--- a/desktop/test/profile-workspace-storage.test.js
+++ b/desktop/test/profile-workspace-storage.test.js
@@ -252,6 +252,8 @@ test('P3 foundation is packaged but does not activate migration in production Ma
     'profile-workspace-settings-store',
     'profile-workspace-credential-store',
     'profile-workspace-credential-transaction',
+    'legacy-migration-inputs',
+    'profile-workspace-migration-runtime',
     'legacy-flat-source-receipts',
     'vpn-credential-envelope',
     'vpn-credential-envelope-store',

--- a/docs/adr/0017-p3-production-migration-runtime.md
+++ b/docs/adr/0017-p3-production-migration-runtime.md
@@ -1,0 +1,64 @@
+# ADR-0017: P3 production migration runtime composition
+
+- Status: Accepted as a non-activating P3k composition
+- Production Main activation: deferred to the next gate
+- Parent contracts: [`ADR-0010`](0010-p3-destination-and-retirement.md),
+  [`ADR-0016`](0016-p3-runtime-storage-path-seam.md)
+
+## Context
+
+The coordinator and destination planner previously had one synthetic filesystem composition in tests, but
+production still lacked an owner for reading real flat payloads, decrypting the legacy safeStorage password,
+sequencing migration and returning one verified runtime authority/path set. Reimplementing that sequence in Main
+would mix credentials, filesystem recovery and UI lifecycle.
+
+## Decision
+
+`legacy-migration-inputs.js` reads every source through a bounded no-follow private-file descriptor and requires
+its bytes to match the prepared journal receipt. Expected absence is also authoritative: a newly appeared file
+blocks. `LegacyMigrationPayloadOwner` zeroizes all buffers after the synchronous planner callback.
+
+The old safeStorage password is decrypted only into `LegacyMigrationCredentialOwner`, which stores username and
+password in zeroizing buffers and exposes them only through a synchronous callback. Both owners are redacted for
+JSON, string and diagnostic inspection.
+
+`ProfileWorkspaceMigrationRuntime` composes:
+
+```text
+inspect exact legacy and destination authority
+  -> prepare owner-only journal and opaque keys
+  -> re-read every journal-bound legacy payload
+  -> decrypt the paired legacy credential in Main memory
+  -> build and materialize exact destination documents
+  -> commit destination receipts
+  -> verify destination authority
+  -> retire receipt-matched flat files with settings last
+  -> clear committed journal
+  -> load complete Profile Workspace runtime authority
+  -> return one immutable Profile Workspace runtime path set
+```
+
+A committed journal makes partial source retirement restart-safe. A second run recognizes the destination as
+already migrated. Orphaned legacy files without `settings.json`, dual authority, changed receipts, invalid
+credentials or incomplete destination state block rather than choosing an authority.
+
+An empty first launch remains in legacy-compatible mode for this gate because direct initialization of a new P3
+Account has not yet been connected to the login flow. The next activation gate must either initialize an empty P3
+Account or migrate immediately after first credential commit; it may not leave two writable authorities.
+
+The runtime clones and freezes the original SchoolProfile document for repeated independent validation and keeps a
+separate normalized Profile for internal fields. This prevents caller mutation and avoids passing a normalized
+Gateway object back into a raw-document validator.
+
+## Verification
+
+Tests cover real flat-file migration with and without credentials, envelope decrypt round-trip, payload and
+credential zeroization/redaction, changed/unexpected/symlink source rejection, empty first launch, orphaned legacy
+authority, interrupted source retirement recovery and simulated Windows source/destination ACL enforcement.
+
+## Next gate
+
+P3l must run this composition only after Electron safeStorage is ready and before constructing any path-bound
+service. It must reconcile settings and credential redo intents, choose one immutable runtime mode, create every
+service from that mode and prevent Engine/Browser/UI startup on ambiguous recovery. Packaged migration/restart
+tests are required before replacing the installed App.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -641,6 +641,9 @@ Non-activating storage foundation: [`ADR-0007`](../adr/0007-p3-storage-foundatio
   envelope and Account credential revision/version through a separate invariant-bound redo transaction;
 - route every Main-owned file through one exact legacy/Profile-Workspace storage path seam before deferring service
   construction and activating migration, with a behavior-preserving legacy projection as the first production use;
+- compose real receipt-bound legacy reads, zeroizing legacy credential decryption, destination planning,
+  materialization, source retirement, runtime authority verification and final path selection behind one
+  restart-safe migration runtime before Main activation;
 
 - split app-global and profile settings;
 - create `profiles/<profileKey>/accounts/<accountKey>/workspace/` from the start;


### PR DESCRIPTION
## What changed

- read every real legacy source through bounded no-follow owner-only descriptors and recheck prepared journal receipts
- add zeroizing/redacted owners for migration payloads and the legacy username/password
- compose journal preparation, destination planning/materialization, destination verification, legacy retirement, authority load, and final runtime path selection
- clone/freeze the original SchoolProfile document while keeping a separate normalized internal profile
- preserve restart recovery after committed destination and partial source retirement

## Safety boundary

- changed, unexpected, missing, linked, broad-permission, orphaned, or dual authority fails closed
- no credential or payload enters logs/diagnostics/Renderer; owners zeroize after synchronous use
- empty first launch remains legacy-compatible at this gate instead of inventing a partial P3 Account
- production Main still does not activate migration; P3l owns Electron-ready startup sequencing

## Verification

- Desktop: 722 passed, 0 failed, 1 Windows-only skip
- architecture: 253 files, 416 edges, 0 cycles; Main 35 deps / 1596 lines
- normal and credential-free migration, repeat startup, orphan detection, retirement interruption, Windows ACL: PASS
- npm audit: 0 vulnerabilities
- staged secret gate and all JS syntax: PASS