### PR TITLE
2.0 P3l: recover workspace transactions before startup

### DIFF
--- a/desktop/lib/legacy-credential-rollback-store.js
+++ b/desktop/lib/legacy-credential-rollback-store.js
@@ -460,7 +460,56 @@ class LegacyCredentialRollbackStore {
   }
 }
 
+function createLegacyCredentialRollbackStoreForAuthority({
+  authority,
+  fileSystem = fs,
+  platform = process.platform,
+  windowsAcl = {
+    protect: protectWindowsFileOwnerOnly,
+    verify: verifyWindowsFileOwnerOnly,
+  },
+} = {}) {
+  const layout = authority?.layout;
+  const statePath = layout?.account?.legacyCredentialRollbackState;
+  if (typeof statePath !== 'string' || !authority?.profileState || !authority?.account ||
+      (platform === 'win32' && !windowsAcl?.verify?.(statePath))) {
+    throw new TypeError('legacy rollback authority is incomplete');
+  }
+  let data;
+  let state;
+  try {
+    ({ data } = readPrivateFileBounded(statePath, {
+      maxBytes: MAX_ROLLBACK_DOCUMENT_BYTES,
+      minBytes: 2,
+      platform,
+      fileSystem,
+    }));
+    state = validateLegacyCredentialRollbackState(JSON.parse(data.toString('utf8')));
+  } finally {
+    data?.fill(0);
+  }
+  const accountOrigin = authority.account.gatewayOrigin?.origin;
+  if (state.migrationId !== authority.profileState.migrationId ||
+      state.profileId !== authority.profile.profileId ||
+      state.profileCredentialBindingRevision !==
+        authority.profileState.profileCredentialBindingRevision ||
+      state.accountKey !== authority.account.accountKey ||
+      state.accountCredentialRevision > authority.account.accountCredentialRevision ||
+      state.gatewayOrigin !== accountOrigin ||
+      state.protocolFamily !== authority.account.protocolFamily) {
+    throw new Error('legacy rollback metadata does not match runtime authority');
+  }
+  return new LegacyCredentialRollbackStore({
+    layout,
+    expectedBinding: bindingFromState(state),
+    fileSystem,
+    platform,
+    windowsAcl,
+  });
+}
+
 module.exports = {
+  createLegacyCredentialRollbackStoreForAuthority,
   LegacyCredentialRollbackStore,
   RETIREMENT_INTENT_VERSION,
 };

--- a/desktop/lib/profile-workspace-startup-runtime.js
+++ b/desktop/lib/profile-workspace-startup-runtime.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  createLegacyCredentialRollbackStoreForAuthority,
+} = require('./legacy-credential-rollback-store');
+const {
+  ProfileWorkspaceCredentialStore,
+} = require('./profile-workspace-credential-store');
+const {
+  ProfileWorkspaceMigrationRuntime,
+} = require('./profile-workspace-migration-runtime');
+const {
+  loadActiveProfileAccountAuthority,
+  loadActiveProfileWorkspaceAuthority,
+} = require('./profile-workspace-runtime-authority');
+const {
+  ProfileWorkspaceSettingsStore,
+} = require('./profile-workspace-settings-store');
+const { validateUserDataRoot } = require('./profile-workspace-layout');
+const { createProfileWorkspaceRuntimeStoragePaths } = require('./runtime-storage-paths');
+const { validateSchoolProfileDocument } = require('./school-profile-schema');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}
+
+function cloneProfile(value) {
+  let cloned;
+  try { cloned = JSON.parse(JSON.stringify(value)); }
+  catch (error) { throw new TypeError('startup SchoolProfile could not be cloned', { cause: error }); }
+  validateSchoolProfileDocument(cloned);
+  return deepFreeze(cloned);
+}
+
+function exists(file, fileSystem) {
+  try {
+    fileSystem.lstatSync(file);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+class ProfileWorkspaceStartupRuntime {
+  constructor({
+    userData,
+    profile,
+    safeStorage,
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+    randomBytes,
+    now,
+  } = {}) {
+    if (!safeStorage || !fileSystem || typeof fileSystem.openSync !== 'function' ||
+        !['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' &&
+          (typeof windowsAcl?.protect !== 'function' || typeof windowsAcl?.verify !== 'function'))) {
+      throw new TypeError('Profile Workspace startup dependencies are invalid');
+    }
+    this.userData = validateUserDataRoot(userData);
+    this.profile = cloneProfile(profile);
+    this.safeStorage = safeStorage;
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+    this.randomBytes = randomBytes;
+    this.now = now;
+    this.running = false;
+    this.globalSettings = path.join(this.userData, 'global', 'settings.json');
+    this.migrationJournal = path.join(
+      this.userData,
+      'global',
+      'profile-account-workspace-migration.json',
+    );
+  }
+
+  initialize() {
+    if (this.running) throw new Error('Profile Workspace startup is already running');
+    this.running = true;
+    try {
+      // A runtime credential transaction can intentionally make the complete
+      // authority unreadable. Recover it before migration inspects an existing
+      // destination, except while a migration journal still owns partial files.
+      if (!exists(this.migrationJournal, this.fileSystem) &&
+          exists(this.globalSettings, this.fileSystem)) {
+        this.#recoverRuntimeTransactions();
+      }
+      const migrated = this.#migrationRuntime().run();
+      if (migrated.mode !== 'profile-workspace') return migrated;
+      const services = this.#recoverRuntimeTransactions();
+      return Object.freeze({
+        ...migrated,
+        authority: services.authority,
+        paths: createProfileWorkspaceRuntimeStoragePaths(services.authority),
+        settingsStore: services.settingsStore,
+        credentialStore: services.credentialStore,
+      });
+    } finally {
+      this.running = false;
+    }
+  }
+
+  #migrationRuntime() {
+    return new ProfileWorkspaceMigrationRuntime({
+      userData: this.userData,
+      profile: this.profile,
+      safeStorage: this.safeStorage,
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+      windowsAcl: this.windowsAcl,
+      ...(this.randomBytes ? { randomBytes: this.randomBytes } : {}),
+      ...(this.now ? { now: this.now } : {}),
+    });
+  }
+
+  #accountAuthority() {
+    return loadActiveProfileAccountAuthority({
+      userData: this.userData,
+      profile: this.profile,
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+      windowsAcl: this.windowsAcl,
+    });
+  }
+
+  #workspaceAuthority() {
+    return loadActiveProfileWorkspaceAuthority({
+      userData: this.userData,
+      profile: this.profile,
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+      windowsAcl: this.windowsAcl,
+    });
+  }
+
+  #rollbackStore(authority) {
+    return createLegacyCredentialRollbackStoreForAuthority({
+      authority,
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+      windowsAcl: this.windowsAcl,
+    });
+  }
+
+  #recoverRuntimeTransactions() {
+    let accountAuthority = this.#accountAuthority();
+    this.#rollbackStore(accountAuthority).reconcile();
+    const credentialStore = new ProfileWorkspaceCredentialStore({
+      loadAccountAuthority: () => this.#accountAuthority(),
+      loadWorkspaceAuthority: () => this.#workspaceAuthority(),
+      retireRollback: ({ authority, reason }) => this.#rollbackStore(authority).retire({ reason }),
+      safeStorage: this.safeStorage,
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+      windowsAcl: this.windowsAcl,
+      ...(this.randomBytes ? { randomBytes: this.randomBytes } : {}),
+      ...(this.now ? { now: this.now } : {}),
+    });
+    credentialStore.reconcile();
+    const settingsStore = new ProfileWorkspaceSettingsStore({
+      loadAuthority: () => this.#workspaceAuthority(),
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+      windowsAcl: this.windowsAcl,
+      ...(this.randomBytes ? { randomBytes: this.randomBytes } : {}),
+      ...(this.now ? { now: this.now } : {}),
+    });
+    settingsStore.reconcile();
+    accountAuthority = null;
+    const authority = this.#workspaceAuthority();
+    return Object.freeze({ authority, settingsStore, credentialStore });
+  }
+}
+
+module.exports = { ProfileWorkspaceStartupRuntime };

--- a/desktop/test/profile-workspace-startup-runtime.test.js
+++ b/desktop/test/profile-workspace-startup-runtime.test.js
@@ -1,0 +1,187 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { LEGACY_COPY_SOURCE_IDS } = require('../lib/hkust-migration-destination-plan');
+const { createLegacyCredentialRollbackStoreForAuthority } =
+  require('../lib/legacy-credential-rollback-store');
+const { ProfileWorkspaceCredentialStore } = require('../lib/profile-workspace-credential-store');
+const {
+  loadActiveProfileAccountAuthority,
+  loadActiveProfileWorkspaceAuthority,
+} = require('../lib/profile-workspace-runtime-authority');
+const { ProfileWorkspaceSettingsStore } = require('../lib/profile-workspace-settings-store');
+const { ProfileWorkspaceStartupRuntime } = require('../lib/profile-workspace-startup-runtime');
+const { createLegacyFlatSourcePaths } = require('../lib/profile-workspace-layout');
+const { projectRuntimeSettings } = require('../lib/profile-workspace-settings-bundle');
+const { normalizeSettings } = require('../lib/settings-store');
+
+function profile() {
+  return JSON.parse(fs.readFileSync(
+    path.join(__dirname, '..', 'assets', 'profiles', 'hkustgz', 'school-profile.json'),
+    'utf8',
+  ));
+}
+
+function safeStorage() {
+  return {
+    isEncryptionAvailable: () => true,
+    getSelectedStorageBackend: () => 'keychain',
+    encryptString: (value) => Buffer.from(value, 'utf8').map((byte) => byte ^ 0xa5),
+    decryptString: (value) => Buffer.from(value).map((byte) => byte ^ 0xa5).toString('utf8'),
+  };
+}
+
+function fixture(t) {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-startup-runtime-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const legacy = createLegacyFlatSourcePaths(userData);
+  const settings = Buffer.from(JSON.stringify(normalizeSettings({
+    username: 'synthetic-user',
+    port: 6180,
+    routeDomains: ['hkust-gz.edu.cn'],
+  })), 'utf8');
+  fs.writeFileSync(legacy.settings, settings, { mode: 0o600 });
+  fs.writeFileSync(legacy.settingsBackup, settings, { mode: 0o600 });
+  fs.writeFileSync(legacy.vpnCredential, safeStorage().encryptString('synthetic-password'), {
+    mode: 0o600,
+  });
+  for (const id of LEGACY_COPY_SOURCE_IDS) {
+    if (id === 'routingRules') {
+      fs.writeFileSync(legacy[id], '{"schemaVersion":1,"rules":[]}', { mode: 0o600 });
+    }
+  }
+  let entropy = 1;
+  let timestamp = 1_700_000_000_000;
+  const options = {
+    userData,
+    profile: profile(),
+    safeStorage: safeStorage(),
+    platform: 'darwin',
+    randomBytes: () => Buffer.alloc(16, entropy++),
+    now: () => timestamp++,
+  };
+  return { userData, legacy, options };
+}
+
+function credentialStrings(store) {
+  const owner = store.open();
+  try { return owner?.withStrings((username, password) => ({ username, password })) || null; }
+  finally { owner?.destroy(); }
+}
+
+function authorityLoaders(value) {
+  return {
+    account: () => loadActiveProfileAccountAuthority({
+      userData: value.userData,
+      profile: profile(),
+    }),
+    workspace: () => loadActiveProfileWorkspaceAuthority({
+      userData: value.userData,
+      profile: profile(),
+    }),
+  };
+}
+
+function rollbackRetirer(authority, reason) {
+  return createLegacyCredentialRollbackStoreForAuthority({ authority }).retire({ reason });
+}
+
+test('startup migrates then exposes working settings and credential adapters', (t) => {
+  const value = fixture(t);
+  const startup = new ProfileWorkspaceStartupRuntime(value.options);
+  let result = startup.initialize();
+  assert.equal(result.mode, 'profile-workspace');
+  assert.equal(result.migration.status, 'migrated');
+  assert.deepEqual(credentialStrings(result.credentialStore), {
+    username: 'synthetic-user',
+    password: 'synthetic-password',
+  });
+  const nextSettings = {
+    ...projectRuntimeSettings(result.authority),
+    port: 6280,
+  };
+  assert.equal(result.settingsStore.save(nextSettings).changed, true);
+  assert.equal(loadActiveProfileWorkspaceAuthority({
+    userData: value.userData,
+    profile: profile(),
+  }).globalSettings.port, 6280);
+
+  result.credentialStore.replace({ username: 'next-user', password: 'next-password' });
+  assert.deepEqual(credentialStrings(result.credentialStore), {
+    username: 'next-user',
+    password: 'next-password',
+  });
+  assert.equal(fs.existsSync(result.authority.layout.account.legacyCredentialRollbackBlob), false);
+  result.credentialStore.clear();
+  assert.equal(credentialStrings(result.credentialStore), null);
+
+  result = startup.initialize();
+  assert.equal(result.migration.status, 'already_migrated');
+  assert.equal(result.authority.globalSettings.port, 6280);
+  assert.equal(result.authority.hasCredential, false);
+});
+
+test('startup repairs credential intermediate state before complete authority load', (t) => {
+  const value = fixture(t);
+  const first = new ProfileWorkspaceStartupRuntime(value.options).initialize();
+  first.credentialStore.replace({ username: 'current-user', password: 'current-password' });
+  const loaders = authorityLoaders(value);
+  const injected = Object.create(fs);
+  injected.renameSync = (from, to) => {
+    if (to === first.authority.layout.account.document) throw new Error('simulated Account crash');
+    return fs.renameSync(from, to);
+  };
+  const crashing = new ProfileWorkspaceCredentialStore({
+    loadAccountAuthority: loaders.account,
+    loadWorkspaceAuthority: loaders.workspace,
+    retireRollback: ({ authority, reason }) => rollbackRetirer(authority, reason),
+    safeStorage: safeStorage(),
+    platform: 'darwin',
+    fileSystem: injected,
+    randomBytes: () => Buffer.alloc(16, 0x77),
+    now: () => 1_700_000_001_000,
+  });
+  assert.throws(() => crashing.replace({ username: 'recovered-user', password: 'recovered-password' }),
+    /Account write failed/u);
+  assert.equal(fs.existsSync(first.authority.layout.account.credentialTransaction), true);
+
+  const recovered = new ProfileWorkspaceStartupRuntime(value.options).initialize();
+  assert.deepEqual(credentialStrings(recovered.credentialStore), {
+    username: 'recovered-user',
+    password: 'recovered-password',
+  });
+  assert.equal(fs.existsSync(recovered.authority.layout.account.credentialTransaction), false);
+});
+
+test('startup finishes a pending split settings redo after credential recovery', (t) => {
+  const value = fixture(t);
+  const first = new ProfileWorkspaceStartupRuntime(value.options).initialize();
+  const loaders = authorityLoaders(value);
+  const injected = Object.create(fs);
+  injected.renameSync = (from, to) => {
+    if (to === first.authority.layout.workspace.settings) {
+      throw new Error('simulated Workspace settings crash');
+    }
+    return fs.renameSync(from, to);
+  };
+  const crashing = new ProfileWorkspaceSettingsStore({
+    loadAuthority: loaders.workspace,
+    fileSystem: injected,
+    platform: 'darwin',
+    randomBytes: () => Buffer.alloc(16, 0x78),
+    now: () => 1_700_000_001_000,
+  });
+  assert.throws(() => crashing.save({
+    ...projectRuntimeSettings(first.authority),
+    port: 6380,
+    autoConnect: false,
+  }), /target write failed/u);
+  const recovered = new ProfileWorkspaceStartupRuntime(value.options).initialize();
+  assert.equal(recovered.authority.globalSettings.port, 6380);
+  assert.equal(recovered.authority.workspaceSettings.autoConnect, false);
+  assert.equal(fs.existsSync(recovered.authority.layout.global.settingsTransaction), false);
+});

--- a/desktop/test/profile-workspace-storage.test.js
+++ b/desktop/test/profile-workspace-storage.test.js
@@ -254,6 +254,7 @@ test('P3 foundation is packaged but does not activate migration in production Ma
     'profile-workspace-credential-transaction',
     'legacy-migration-inputs',
     'profile-workspace-migration-runtime',
+    'profile-workspace-startup-runtime',
     'legacy-flat-source-receipts',
     'vpn-credential-envelope',
     'vpn-credential-envelope-store',

--- a/docs/adr/0018-p3-startup-recovery-runtime.md
+++ b/docs/adr/0018-p3-startup-recovery-runtime.md
@@ -1,0 +1,60 @@
+# ADR-0018: P3 startup recovery runtime
+
+- Status: Accepted as a non-activating P3l composition
+- Production Main activation: next gate
+- Parent contracts: [`ADR-0014`](0014-p3-runtime-settings-transaction.md),
+  [`ADR-0015`](0015-p3-runtime-credential-transaction.md),
+  [`ADR-0017`](0017-p3-production-migration-runtime.md)
+
+## Context
+
+After migration, a process can crash during legacy rollback retirement, Account/VPN credential redo or split
+settings redo. Migration authority detection alone cannot safely repair those states. In particular, clearing a
+credential removes ciphertext before Account metadata changes, so the complete runtime authority correctly fails
+until the credential transaction owner repairs it.
+
+The recovery order matters. A settings intent binds the Account credential revision; recovering settings before a
+pending credential commit may bind it to stale identity. Conversely, credential recovery only needs Profile,
+Account and Workspace identity documents and can tolerate its own credential intermediate state.
+
+## Decision
+
+`ProfileWorkspaceStartupRuntime.initialize()` is the only composition allowed to hand a Profile Workspace runtime
+to production service construction. For an existing destination without an active migration journal it runs:
+
+```text
+load recoverable Profile/Account/Workspace identity
+  -> reconcile legacy rollback retirement intent
+  -> reconcile Account/VPN credential redo
+  -> load complete runtime authority
+  -> reconcile split settings redo
+  -> reload complete authority
+  -> run migration authority verification
+  -> return immutable paths + settings store + credential store
+```
+
+When a migration journal exists, migration recovery retains ownership of partial destination files first. A new
+migration completes and then the same runtime transaction recovery runs. Empty first launch remains legacy mode at
+this gate.
+
+The rollback store factory reads and validates its own original migration/account credential revision. It requires
+that revision to be no newer than the active Account and still binds exact migration, Profile, Account, Gateway
+and protocol identity. This permits a retired revision-1 rollback record to remain verifiable after later Account
+credential rotations without treating the current revision as the original rollback authority.
+
+No Engine, Browser, IPC, tray, log writer or path-bound store is created by this module. It returns owners only
+after all recovery and authority checks succeed.
+
+## Verification
+
+Tests cover migration plus usable settings/credential adapters, credential replacement and clear, retired rollback
+verification across Account revision changes, restart with a credential redo stopped after envelope write, and
+restart with a split settings redo stopped between global and Workspace writes. Every recovery ends with no intent
+file and one complete authority.
+
+## Next gate
+
+P3m must expose the reviewed raw SchoolProfile to Main through a callback-only controller boundary, invoke startup
+runtime after Electron `ready`/safeStorage availability, defer all path-bound service construction until it returns,
+and route settings/credential calls through mode-specific adapters. Engine/Browser/UI startup remains prohibited on
+any bootstrap error. Packaged restart tests must run before replacing the installed App.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -644,6 +644,8 @@ Non-activating storage foundation: [`ADR-0007`](../adr/0007-p3-storage-foundatio
 - compose real receipt-bound legacy reads, zeroizing legacy credential decryption, destination planning,
   materialization, source retirement, runtime authority verification and final path selection behind one
   restart-safe migration runtime before Main activation;
+- recover a pre-existing rollback retirement, Account/VPN redo and split-settings redo in strict order before
+  re-validating destination authority, and return fully constructed new-mode stores only after every gate passes;
 
 - split app-global and profile settings;
 - create `profiles/<profileKey>/accounts/<accountKey>/workspace/` from the start;


### PR DESCRIPTION
## What changed

- add one startup owner that orders rollback retirement, Account/VPN redo, and split-settings redo recovery
- recover existing destination transactions before migration authority inspection when no migration journal owns partial files
- make rollback metadata remain verifiable after later Account credential revisions
- return settings and credential stores only after reloading one complete runtime authority

## Recovery order

1. recoverable Profile/Account/Workspace identity
2. legacy rollback retirement
3. Account/VPN credential redo
4. complete runtime authority
5. split settings redo
6. migration/destination verification
7. immutable runtime paths and stores

## Safety boundary

- no Engine, Browser, IPC, tray, log writer, or path-bound service is created here
- migration journal retains priority over partial destination files
- wrong binding, future rollback revision, unsafe file/ACL, or out-of-band target blocks
- production Main activation remains the next separate gate

## Verification

- Desktop: 725 passed, 0 failed, 1 Windows-only skip
- architecture: 255 files, 434 edges, 0 cycles; Main unchanged
- credential redo and split-settings redo crash recovery: PASS
- npm audit: 0 vulnerabilities
- staged secret gate and all JS syntax: PASS