### PR TITLE
2.0 P3m: select scoped storage before Electron ready

### DIFF
--- a/desktop/lib/profile-workspace-pre-ready-selection.js
+++ b/desktop/lib/profile-workspace-pre-ready-selection.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  loadActiveProfileAccountAuthority,
+} = require('./profile-workspace-runtime-authority');
+const { validateUserDataRoot } = require('./profile-workspace-layout');
+const {
+  createLegacyRuntimeStoragePaths,
+  createProfileWorkspaceRuntimeStoragePaths,
+} = require('./runtime-storage-paths');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+function exists(file, fileSystem) {
+  try {
+    fileSystem.lstatSync(file);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function selectProfileWorkspacePreReadyStorage({
+  userData,
+  profile,
+  fileSystem = fs,
+  platform = process.platform,
+  windowsAcl = {
+    protect: protectWindowsFileOwnerOnly,
+    verify: verifyWindowsFileOwnerOnly,
+  },
+} = {}) {
+  const root = validateUserDataRoot(userData);
+  const legacy = (reason) => Object.freeze({
+    mode: 'legacy-flat',
+    reason,
+    authority: null,
+    paths: createLegacyRuntimeStoragePaths(root),
+  });
+  const journal = path.join(root, 'global', 'profile-account-workspace-migration.json');
+  if (exists(journal, fileSystem)) return legacy('migration-recovery');
+  const globalSettings = path.join(root, 'global', 'settings.json');
+  if (!exists(globalSettings, fileSystem)) return legacy('no-destination');
+  const authority = loadActiveProfileAccountAuthority({
+    userData: root,
+    profile,
+    fileSystem,
+    platform,
+    windowsAcl,
+  });
+  return Object.freeze({
+    mode: 'profile-workspace',
+    reason: 'verified-destination',
+    authority,
+    paths: createProfileWorkspaceRuntimeStoragePaths(authority),
+  });
+}
+
+module.exports = { selectProfileWorkspacePreReadyStorage };

--- a/desktop/lib/school-profile-controller.js
+++ b/desktop/lib/school-profile-controller.js
@@ -59,6 +59,7 @@ function createSchoolProfileController(options = {}) {
     browserHomeUrl: profile.browser.homeUrl,
     healthTargets: profile.browser.healthTargets,
     builtInResourceCount: builtInResources.length,
+    withProfileDocument: (callback) => context.registry.withDefaultProfileDocument(callback),
     verifyEngineConfig: context.verifyEngineConfig,
     verifyEngineLaunchBinding() {
       const verified = context.verifyEngineConfig();

--- a/desktop/lib/school-profile-registry.js
+++ b/desktop/lib/school-profile-registry.js
@@ -412,6 +412,23 @@ class SchoolProfileRegistry {
     return this.getProfile(this.defaultProfileId);
   }
 
+  withProfileDocument(profileId, callback) {
+    this.ensureLoaded();
+    if (typeof callback !== 'function') throw new TypeError('profile document callback is required');
+    const record = this.records.get(String(profileId || ''));
+    if (!record) throw new Error('school profile is not present in the packaged manifest');
+    const result = callback(record.sourceDocument);
+    if (result && typeof result.then === 'function') {
+      throw new TypeError('profile document callback must be synchronous');
+    }
+    return result;
+  }
+
+  withDefaultProfileDocument(callback) {
+    this.ensureLoaded();
+    return this.withProfileDocument(this.defaultProfileId, callback);
+  }
+
   getBuiltinResources(profileId) {
     this.ensureLoaded();
     const record = this.records.get(String(profileId || ''));

--- a/desktop/test/profile-workspace-pre-ready-selection.test.js
+++ b/desktop/test/profile-workspace-pre-ready-selection.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { LEGACY_COPY_SOURCE_IDS } = require('../lib/hkust-migration-destination-plan');
+const {
+  selectProfileWorkspacePreReadyStorage,
+} = require('../lib/profile-workspace-pre-ready-selection');
+const { ProfileWorkspaceStartupRuntime } = require('../lib/profile-workspace-startup-runtime');
+const { createLegacyFlatSourcePaths } = require('../lib/profile-workspace-layout');
+const { normalizeSettings } = require('../lib/settings-store');
+
+function profile() {
+  return JSON.parse(fs.readFileSync(
+    path.join(__dirname, '..', 'assets', 'profiles', 'hkustgz', 'school-profile.json'),
+    'utf8',
+  ));
+}
+
+function safeStorage() {
+  return {
+    isEncryptionAvailable: () => true,
+    getSelectedStorageBackend: () => 'keychain',
+    encryptString: (value) => Buffer.from(value, 'utf8').map((byte) => byte ^ 0xa5),
+    decryptString: (value) => Buffer.from(value).map((byte) => byte ^ 0xa5).toString('utf8'),
+  };
+}
+
+function migratedFixture(t) {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-pre-ready-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const legacy = createLegacyFlatSourcePaths(userData);
+  const settings = Buffer.from(JSON.stringify(normalizeSettings({
+    username: 'synthetic-user',
+    port: 6180,
+  })), 'utf8');
+  fs.writeFileSync(legacy.settings, settings, { mode: 0o600 });
+  fs.writeFileSync(legacy.settingsBackup, settings, { mode: 0o600 });
+  fs.writeFileSync(legacy.vpnCredential, safeStorage().encryptString('synthetic-password'), {
+    mode: 0o600,
+  });
+  for (const id of LEGACY_COPY_SOURCE_IDS) {
+    if (id === 'routingRules') {
+      fs.writeFileSync(legacy[id], '{"schemaVersion":1,"rules":[]}', { mode: 0o600 });
+    }
+  }
+  let entropy = 1;
+  let timestamp = 1_700_000_000_000;
+  const runtime = new ProfileWorkspaceStartupRuntime({
+    userData,
+    profile: profile(),
+    safeStorage: safeStorage(),
+    platform: 'darwin',
+    randomBytes: () => Buffer.alloc(16, entropy++),
+    now: () => timestamp++,
+  }).initialize();
+  return { userData, runtime };
+}
+
+test('pre-ready selection uses legacy only when no destination exists', (t) => {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-pre-ready-empty-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const selected = selectProfileWorkspacePreReadyStorage({
+    userData,
+    profile: profile(),
+  });
+  assert.equal(selected.mode, 'legacy-flat');
+  assert.equal(selected.reason, 'no-destination');
+  assert.equal(selected.paths.settings, path.join(userData, 'settings.json'));
+});
+
+test('verified destination selects scoped paths even during credential presence mismatch', (t) => {
+  const value = migratedFixture(t);
+  fs.unlinkSync(value.runtime.paths.vpnCredential);
+  const selected = selectProfileWorkspacePreReadyStorage({
+    userData: value.userData,
+    profile: profile(),
+  });
+  assert.equal(selected.mode, 'profile-workspace');
+  assert.equal(selected.reason, 'verified-destination');
+  assert.equal(selected.paths.vpnCredential, value.runtime.paths.vpnCredential);
+  assert.equal(selected.authority.account.activeCredentialVersion, 1);
+});
+
+test('migration journal keeps pre-ready services on the legacy path set', (t) => {
+  const value = migratedFixture(t);
+  fs.writeFileSync(
+    path.join(value.userData, 'global', 'profile-account-workspace-migration.json'),
+    '{}',
+    { mode: 0o600 },
+  );
+  const selected = selectProfileWorkspacePreReadyStorage({
+    userData: value.userData,
+    profile: profile(),
+  });
+  assert.equal(selected.mode, 'legacy-flat');
+  assert.equal(selected.reason, 'migration-recovery');
+});

--- a/desktop/test/profile-workspace-storage.test.js
+++ b/desktop/test/profile-workspace-storage.test.js
@@ -255,6 +255,7 @@ test('P3 foundation is packaged but does not activate migration in production Ma
     'legacy-migration-inputs',
     'profile-workspace-migration-runtime',
     'profile-workspace-startup-runtime',
+    'profile-workspace-pre-ready-selection',
     'legacy-flat-source-receipts',
     'vpn-credential-envelope',
     'vpn-credential-envelope-store',

--- a/desktop/test/school-profile-controller.test.js
+++ b/desktop/test/school-profile-controller.test.js
@@ -134,3 +134,18 @@ test('presentation uses an explicit locale and bounded resource count', () => {
   assert.equal(presentation.campusAccount.hasCredential, true);
   assert.equal(presentation.workspace.resourceCount, 7);
 });
+
+test('controller exposes the reviewed raw Profile only through a synchronous callback', () => {
+  const profile = controller();
+  const result = profile.withProfileDocument((document) => ({
+    profileId: document.profileId,
+    gatewayOrigin: document.gateway.origin,
+    frozen: Object.isFrozen(document),
+  }));
+  assert.deepEqual(result, {
+    profileId: 'hkustgz',
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    frozen: true,
+  });
+  assert.throws(() => profile.withProfileDocument(async () => null), /synchronous/u);
+});

--- a/docs/adr/0019-p3-pre-ready-storage-selection.md
+++ b/docs/adr/0019-p3-pre-ready-storage-selection.md
@@ -1,0 +1,42 @@
+# ADR-0019: P3 pre-ready storage selection
+
+- Status: Accepted as a non-activating P3m seam
+- Production Main activation: next patch
+- Parent contracts: [`ADR-0016`](0016-p3-runtime-storage-path-seam.md),
+  [`ADR-0018`](0018-p3-startup-recovery-runtime.md)
+
+## Context
+
+Electron safeStorage migration must wait for `app.whenReady()`, but several existing services are constructed while
+Main is evaluated. On restart after migration, those services need scoped paths before safeStorage is touched. A
+credential transaction can leave envelope presence inconsistent with Account metadata, so pre-ready selection
+must not require complete credential authority or decrypt the envelope.
+
+## Decision
+
+The package-bound raw SchoolProfile is retained by `SchoolProfileRegistry` and exposed to Main only through
+`withDefaultProfileDocument(callback)`. The callback is synchronous and receives the already frozen, hash-verified
+source document; it cannot become an IPC or Renderer data path.
+
+`selectProfileWorkspacePreReadyStorage()` performs no writes and no safeStorage call:
+
+- active migration journal -> legacy path set, with migration recovery retaining ownership;
+- no global destination settings -> legacy path set;
+- destination global settings -> load recoverable Profile/Account/Workspace identity and select scoped paths.
+
+The recoverable authority verifies reviewed Profile/Gateway/protocol and opaque identity but deliberately does not
+require credential-file presence to match Account metadata. Startup recovery owns that intermediate state before
+any connection. Corrupt or mismatched destination identity throws; it never silently falls back to legacy.
+
+## Verification
+
+Tests prove empty startup selects exact existing flat paths, a verified destination selects global/Account/Workspace
+owners, selection remains possible during credential presence mismatch, an active migration journal retains legacy
+selection, and the controller exposes only the frozen raw Profile through a synchronous callback.
+
+## Next gate
+
+P3n must consume this selector in Main, defer or neutralize all path-bound side effects until startup recovery,
+branch settings/credential adapters by immutable runtime mode, and relaunch exactly once after a successful first
+migration so the next process constructs services on scoped paths. It must never show UI or start Engine in a
+partial/blocked state.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -646,6 +646,8 @@ Non-activating storage foundation: [`ADR-0007`](../adr/0007-p3-storage-foundatio
   restart-safe migration runtime before Main activation;
 - recover a pre-existing rollback retirement, Account/VPN redo and split-settings redo in strict order before
   re-validating destination authority, and return fully constructed new-mode stores only after every gate passes;
+- expose the package-bound raw Profile only through a synchronous Main callback and select legacy versus scoped
+  service paths before Electron readiness without reading or decrypting VPN credentials;
 
 - split app-global and profile settings;
 - create `profiles/<profileKey>/accounts/<accountKey>/workspace/` from the start;


### PR DESCRIPTION
## What changed

- expose the hash-verified frozen raw SchoolProfile through a synchronous Main-only callback
- select legacy or Profile Workspace runtime paths before Electron readiness without safeStorage
- use recoverable Account/Workspace identity so credential-presence intermediate state stays on scoped paths
- keep an active migration journal under migration recovery ownership

## Safety boundary

- selector performs no writes and decrypts no credential
- corrupt/mismatched destination identity fails instead of falling back to legacy
- raw Profile never enters IPC or Renderer state
- production Main consumption/relaunch remains the next patch

## Verification

- Desktop: 729 passed, 0 failed, 1 Windows-only skip
- architecture: 257 files, 443 edges, 0 cycles; Main unchanged
- empty, verified destination, credential mismatch, and migration-journal selection: PASS
- npm audit: 0 vulnerabilities
- staged secret gate and all JS syntax: PASS