### PR TITLE
2.0 P3o: activate Profile Workspace persistence in Desktop Main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,8 @@ jobs:
         run: npm run test:main-engine-lifecycle
       - name: Exercise initially-offline Main startup recovery
         run: npm run test:main-network-startup
+      - name: Exercise two-process Profile Workspace migration
+        run: npm run test:persistence-migration
       - name: Exercise the School Profile registry inside a real ASAR
         run: npm run test:profile-asar
       - name: Exercise campus-browser toolbar IPC

--- a/desktop/e2e/main-integration.electron.js
+++ b/desktop/e2e/main-integration.electron.js
@@ -5,9 +5,13 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { app, BrowserWindow } = require('electron');
+const { ProfileWorkspaceStartupRuntime } = require('../lib/app-data-dir');
+const { projectRuntimeSettings } = require('../lib/profile-workspace-settings-bundle');
+const { saveSettings } = require('../lib/settings-store');
 
 const profile = fs.mkdtempSync(path.join(os.tmpdir(), 'hkustgz-main-e2e-'));
 process.env.HKUSTGZ_USER_DATA_DIR = profile;
+saveSettings(path.join(profile, 'settings.json'), {});
 
 const fingerprint = 'ab'.repeat(32);
 fs.writeFileSync(path.join(profile, 'campus-certificate-trust.json'), JSON.stringify({
@@ -19,6 +23,18 @@ fs.writeFileSync(path.join(profile, 'campus-certificate-trust.json'), JSON.strin
     updatedAt: 1_800_000_000_000,
   }],
 }), { mode: 0o600 });
+
+const persistence = new ProfileWorkspaceStartupRuntime({
+  userData: profile,
+  profile: JSON.parse(fs.readFileSync(
+    path.join(__dirname, '..', 'assets', 'profiles', 'hkustgz', 'school-profile.json'),
+    'utf8',
+  )),
+  // This fixture has no VPN credential. Startup still requires an explicit
+  // protected-storage owner, but no encryption operation is performed.
+  safeStorage: {},
+}).initialize();
+assert.equal(persistence.mode, 'profile-workspace');
 
 require('../main');
 
@@ -84,7 +100,7 @@ async function run() {
     url: 'https://103.189.154.10:4433',
     route: 'campus',
   })`);
-  assert.equal(savedResource.ok, true);
+  assert.equal(savedResource.ok, true, JSON.stringify(savedResource));
   assert.equal(savedResource.resource.url, 'https://103.189.154.10:4433/');
   assert.equal(savedResource.resources.filter((resource) => (
     resource.url === 'https://103.189.154.10:4433/'
@@ -121,14 +137,14 @@ async function run() {
     candidate.webContents.getURL().includes('/renderer/campus-browser.html')
   )), false);
 
-  const settings = JSON.parse(fs.readFileSync(path.join(profile, 'settings.json'), 'utf8'));
+  const settings = projectRuntimeSettings(persistence.reloadAuthority());
   assert.equal(settings.username, '');
   assert.equal(settings.port, 6180);
   assert.equal(settings.strictProxyAuth, true);
-  const rules = JSON.parse(fs.readFileSync(path.join(profile, 'routing-rules.json'), 'utf8'));
+  const rules = JSON.parse(fs.readFileSync(persistence.paths.routingRules, 'utf8'));
   assert.equal(rules.version, 1);
   assert.equal(rules.rules[0].host, 'login.microsoftonline.com');
-  assert.ok(fs.readFileSync(path.join(profile, 'routing.pac'), 'utf8').includes('127.0.0.1:6180'));
+  assert.ok(fs.readFileSync(persistence.paths.externalPac, 'utf8').includes('127.0.0.1:6180'));
   process.stdout.write('main integration: PASS\n');
 }
 
@@ -136,8 +152,8 @@ run().then(
   () => app.quit(),
   (error) => {
     process.stderr.write(`${error.stack || error}\n`);
-    app.exitCode = 1;
-    app.quit();
+    process.exitCode = 1;
+    app.exit(1);
   },
 );
 

--- a/desktop/e2e/main-network-startup.electron.js
+++ b/desktop/e2e/main-network-startup.electron.js
@@ -12,6 +12,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { app, BrowserWindow, safeStorage } = require('electron');
 const { savePassword } = require('../lib/credential-store');
+const { ProfileWorkspaceStartupRuntime } = require('../lib/app-data-dir');
 const { saveSettings } = require('../lib/settings-store');
 
 const TEST_TIMEOUT_MS = 20_000;
@@ -79,6 +80,16 @@ async function prepareProfile() {
     process.platform,
   ), true, 'the Electron credential backend must be available for the startup fixture');
   fs.writeFileSync(networkStateFile, 'offline\n', { mode: 0o600 });
+  const schoolProfile = JSON.parse(fs.readFileSync(
+    path.join(__dirname, '..', 'assets', 'profiles', 'hkustgz', 'school-profile.json'),
+    'utf8',
+  ));
+  const persistence = new ProfileWorkspaceStartupRuntime({
+    userData: profile,
+    profile: schoolProfile,
+    safeStorage,
+  }).initialize();
+  assert.equal(persistence.mode, 'profile-workspace');
   return port;
 }
 
@@ -124,8 +135,8 @@ run().then(
   (error) => {
     clearTimeout(hardTimeout);
     process.stderr.write(`${error.stack || error}\n`);
-    app.exitCode = 1;
-    app.quit();
+    process.exitCode = 1;
+    app.exit(1);
   },
 );
 

--- a/desktop/e2e/main-network-startup.electron.js
+++ b/desktop/e2e/main-network-startup.electron.js
@@ -24,6 +24,7 @@ process.env.HKUSTGZ_USER_DATA_DIR = profile;
 process.env.HKUSTGZ_SYNTHETIC_ENGINE_E2E = '1';
 process.env.HKUSTGZ_SYNTHETIC_ENGINE_STABLE_E2E = '1';
 process.env.HKUSTGZ_SYNTHETIC_NETWORK_E2E = '1';
+app.setName('HKUST(GZ) Connect');
 app.disableHardwareAcceleration();
 
 async function waitFor(condition, description, timeoutMs = WAIT_TIMEOUT_MS) {

--- a/desktop/e2e/persistence-migration.electron.js
+++ b/desktop/e2e/persistence-migration.electron.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { app, safeStorage } = require('electron');
+const { createLegacyFlatSourcePaths } = require('../lib/profile-workspace-layout');
+const { normalizeSettings } = require('../lib/settings-store');
+
+const WAIT_MS = 30_000;
+
+function delay(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
+
+async function waitForMarker(file, child, output) {
+  const deadline = Date.now() + WAIT_MS;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(file)) return JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (child.exitCode !== null && !fs.existsSync(file)) {
+      // The first process exits after relaunch. Keep waiting for its successor.
+    }
+    await delay(100);
+  }
+  throw new Error(`persistence migration marker timed out: ${output.value.slice(-1000)}`);
+}
+
+async function stopOwnedProcess(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return;
+  try { process.kill(pid, 'SIGTERM'); } catch { return; }
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try { process.kill(pid, 0); } catch { return; }
+    await delay(50);
+  }
+  try { process.kill(pid, 'SIGKILL'); } catch {}
+}
+
+async function run() {
+  app.setName('HKUST(GZ) Connect');
+  await app.whenReady();
+  assert.equal(safeStorage.isEncryptionAvailable(), true);
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'hkust-persistence-e2e-'));
+  const legacy = createLegacyFlatSourcePaths(userData);
+  const settings = normalizeSettings({
+    username: 'synthetic-user',
+    port: 6180,
+    autoConnect: false,
+    startAtLogin: false,
+    routeDomains: ['hkust-gz.edu.cn'],
+  });
+  const bytes = Buffer.from(JSON.stringify(settings), 'utf8');
+  fs.writeFileSync(legacy.settings, bytes, { mode: 0o600 });
+  fs.writeFileSync(legacy.settingsBackup, bytes, { mode: 0o600 });
+  fs.writeFileSync(legacy.vpnCredential, safeStorage.encryptString('synthetic-password'), {
+    mode: 0o600,
+  });
+  fs.writeFileSync(legacy.routingRules, '{"schemaVersion":1,"rules":[]}', { mode: 0o600 });
+  const markerPath = path.join(userData, 'persistence-e2e-ready.json');
+  const environment = { ...process.env };
+  delete environment.ELECTRON_RUN_AS_NODE;
+  Object.assign(environment, {
+    HKUSTGZ_USER_DATA_DIR: userData,
+    HKUSTGZ_PERSISTENCE_E2E: '1',
+    ELECTRON_ENABLE_LOGGING: '1',
+  });
+  const output = { value: '' };
+  const child = spawn(process.execPath, [path.join(__dirname, '..')], {
+    env: environment,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout.on('data', (data) => { output.value = (output.value + data).slice(-4000); });
+  child.stderr.on('data', (data) => { output.value = (output.value + data).slice(-4000); });
+  child.on('exit', (code, signal) => {
+    output.value = `${output.value}\ninitial-exit code=${code} signal=${signal}`.slice(-4000);
+  });
+  let marker = null;
+  try {
+    marker = await waitForMarker(markerPath, child, output);
+    assert.equal(marker.mode, 'profile-workspace');
+    assert.equal(Number.isInteger(marker.pid) && marker.pid > 0, true);
+    assert.equal(fs.existsSync(legacy.settings), false);
+    assert.equal(fs.existsSync(legacy.vpnCredential), false);
+    assert.equal(fs.existsSync(path.join(userData, 'global', 'settings.json')), true);
+    const profilesRoot = path.join(userData, 'profiles');
+    assert.equal(fs.readdirSync(profilesRoot).length, 1);
+  } finally {
+    if (marker?.pid) await stopOwnedProcess(marker.pid);
+    try { child.kill('SIGTERM'); } catch {}
+    await delay(100);
+    if (marker) fs.rmSync(userData, { recursive: true, force: true });
+    else process.stderr.write(`persistence-e2e-user-data=${userData}\n`);
+  }
+}
+
+run().then(() => app.quit()).catch((error) => {
+  process.stderr.write(`${error.stack || error}\n`);
+  process.exitCode = 1;
+  app.exit(1);
+});

--- a/desktop/lib/app-data-dir.js
+++ b/desktop/lib/app-data-dir.js
@@ -1,6 +1,13 @@
 'use strict';
 
 const path = require('path');
+const { DesktopPersistenceRuntime } = require('./desktop-persistence-runtime');
+const { LegacyMigrationCredentialOwner } = require('./legacy-migration-inputs');
+const { selectProfileWorkspacePreReadyStorage } =
+  require('./profile-workspace-pre-ready-selection');
+const { ProfileWorkspaceStartupRuntime } = require('./profile-workspace-startup-runtime');
+const { relaunchAfterPersistenceMigration, writePersistenceE2EMarker } =
+  require('./persistence-relaunch');
 const { createLegacyRuntimeStoragePaths } = require('./runtime-storage-paths');
 
 function resolveUserDataOverride(rawValue) {
@@ -12,4 +19,13 @@ function resolveUserDataOverride(rawValue) {
   return path.resolve(candidate);
 }
 
-module.exports = { createLegacyRuntimeStoragePaths, resolveUserDataOverride };
+module.exports = {
+  createLegacyRuntimeStoragePaths,
+  DesktopPersistenceRuntime,
+  LegacyMigrationCredentialOwner,
+  ProfileWorkspaceStartupRuntime,
+  resolveUserDataOverride,
+  relaunchAfterPersistenceMigration,
+  selectProfileWorkspacePreReadyStorage,
+  writePersistenceE2EMarker,
+};

--- a/desktop/lib/campus-resource-store.js
+++ b/desktop/lib/campus-resource-store.js
@@ -41,7 +41,9 @@ function normalizedInput(payload, existing, builtins) {
   if (source.route === 'direct' && isIsolatedNetworkHost(new URL(url).hostname)) {
     throw new Error('本机、私网和特殊地址不能设为直连');
   }
-  const resource = normalizeResource({ ...source, id, url });
+  const normalized = normalizeResource({ ...source, id, url });
+  if (!normalized) throw new Error('网站名称、描述或网址无效');
+  const resource = normalizeCustomResources([normalized])[0];
   if (!resource) throw new Error('网站名称、描述或网址无效');
   if (builtins.urls.has(resource.url)) throw new Error('该网址已经是内置网站');
   return resource;

--- a/desktop/lib/desktop-persistence-runtime.js
+++ b/desktop/lib/desktop-persistence-runtime.js
@@ -82,6 +82,15 @@ class DesktopPersistenceRuntime {
       }
       this.runtime = result;
       this.authority = result.authority || null;
+      if (result.mode === 'profile-workspace' && this.authority.hasCredential) {
+        const owner = result.credentialStore.open();
+        if (!owner || typeof owner.withUsername !== 'function') {
+          owner?.destroy?.();
+          throw new Error('Profile Workspace account credential is unavailable');
+        }
+        try { owner.withUsername((username) => { this.accountLabel = username; }); }
+        finally { owner.destroy(); }
+      }
       this.ready = true;
       return Object.freeze({ ready: true, relaunchRequired: false, mode: this.mode });
     } finally {

--- a/desktop/lib/persistence-relaunch.js
+++ b/desktop/lib/persistence-relaunch.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PERSISTENCE_RELAUNCH_ARGUMENT = '--profile-workspace-relaunch';
+
+function persistenceRelaunchArguments({ argv, isPackaged, developmentEntry } = {}) {
+  if (!Array.isArray(argv) || typeof isPackaged !== 'boolean' ||
+      typeof developmentEntry !== 'string' || developmentEntry.length === 0) {
+    throw new TypeError('persistence relaunch arguments are invalid');
+  }
+  if (argv.includes(PERSISTENCE_RELAUNCH_ARGUMENT)) {
+    const error = new Error('Profile Workspace migration relaunch did not converge');
+    error.code = 'PERSISTENCE_RELAUNCH_LOOP_BLOCKED';
+    throw error;
+  }
+  const base = isPackaged ? argv.slice(1) : [developmentEntry];
+  return Object.freeze([...base, PERSISTENCE_RELAUNCH_ARGUMENT]);
+}
+
+function relaunchAfterPersistenceMigration({ application, argv, isPackaged, developmentEntry } = {}) {
+  if (!application || typeof application.relaunch !== 'function' ||
+      typeof application.exit !== 'function') {
+    throw new TypeError('persistence relaunch application is invalid');
+  }
+  const args = persistenceRelaunchArguments({ argv, isPackaged, developmentEntry });
+  application.relaunch({ args });
+  application.exit(0);
+}
+
+function writePersistenceE2EMarker({ application, environment, userData, mode } = {}) {
+  if (!application || application.isPackaged || environment?.HKUSTGZ_PERSISTENCE_E2E !== '1') {
+    return false;
+  }
+  fs.writeFileSync(path.join(userData, 'persistence-e2e-ready.json'),
+    JSON.stringify({ mode, pid: process.pid }), { mode: 0o600 });
+  return true;
+}
+
+module.exports = {
+  PERSISTENCE_RELAUNCH_ARGUMENT,
+  persistenceRelaunchArguments,
+  relaunchAfterPersistenceMigration,
+  writePersistenceE2EMarker,
+};

--- a/desktop/lib/settings-credential-ipc.js
+++ b/desktop/lib/settings-credential-ipc.js
@@ -119,7 +119,7 @@ function registerSettingsCredentialIpc(dependencies = {}) {
           journalPath: credentialJournalPath,
           paths: credentialPaths,
           mutate: () => {
-            if (!savePassword(patch.password)) {
+            if (!savePassword(patch.password, next.username)) {
               throw Object.assign(new Error('protected credential storage unavailable'), {
                 credentialStoreUnavailable: true,
               });

--- a/desktop/lib/vpn-credential-envelope.js
+++ b/desktop/lib/vpn-credential-envelope.js
@@ -146,6 +146,12 @@ class DecryptedVpnCredential {
     return callback(this.#username.toString('utf8'), this.#password.toString('utf8'));
   }
 
+  withUsername(callback) {
+    if (this.#destroyed) throw new Error('VPN credential owner is destroyed');
+    if (typeof callback !== 'function') throw new TypeError('VPN username callback is required');
+    return callback(this.#username.toString('utf8'));
+  }
+
   destroy() {
     if (this.#destroyed) return false;
     this.#destroyed = true;

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -20,7 +20,7 @@ const {
   recoverCredentialSettingsTransaction,
   runCredentialSettingsMutation,
 } = require('./lib/credential-settings-transaction');
-const { createLegacyRuntimeStoragePaths, resolveUserDataOverride } = require('./lib/app-data-dir');
+const { createLegacyRuntimeStoragePaths, DesktopPersistenceRuntime, LegacyMigrationCredentialOwner, ProfileWorkspaceStartupRuntime, relaunchAfterPersistenceMigration, resolveUserDataOverride, selectProfileWorkspacePreReadyStorage, writePersistenceE2EMarker } = require('./lib/app-data-dir');
 const {
   classifyEngineCode,
   classifyEngineOutput,
@@ -107,7 +107,18 @@ app.setName('HKUST(GZ) Connect');
 
 // ---------- paths & state ----------
 const DATA = app.getPath('userData');
-const runtimeStoragePaths = createLegacyRuntimeStoragePaths(DATA);
+const legacyRuntimeStoragePaths = createLegacyRuntimeStoragePaths(DATA);
+try { fs.unlinkSync(legacyRuntimeStoragePaths.proxyHelperCredential); } catch (error) {
+  if (error?.code !== 'ENOENT') { /* strict access fails closed if replacement is unsafe */ }
+}
+const activeSchoolProfile = createSchoolProfileController({
+  packageRoot: __dirname, isPackaged: app.isPackaged,
+  resourcesPath: process.resourcesPath, desktopDir: __dirname,
+});
+const preReadyStorage = activeSchoolProfile.withProfileDocument((profile) => (
+  selectProfileWorkspacePreReadyStorage({ userData: DATA, profile })
+));
+const runtimeStoragePaths = preReadyStorage.paths;
 const SETTINGS = runtimeStoragePaths.settings;
 const CRED = runtimeStoragePaths.vpnCredential;
 const LOG = runtimeStoragePaths.engineLog;
@@ -131,16 +142,6 @@ try { fs.unlinkSync(PROXY_HELPER_CREDENTIAL); } catch (error) {
     // cannot be safely replaced. Compatibility mode remains usable.
   }
 }
-
-// Profile/config validation may fail closed. Load it only after stale plaintext
-// proxy-helper state has been removed, but still before any credential recovery
-// or secure-store access.
-const activeSchoolProfile = createSchoolProfileController({
-  packageRoot: __dirname,
-  isPackaged: app.isPackaged,
-  resourcesPath: process.resourcesPath,
-  desktopDir: __dirname,
-});
 const GATEWAY_HOST = syntheticEngineE2e ? '127.0.0.1' : activeSchoolProfile.gatewayHost;
 const GATEWAY_PORT = activeSchoolProfile.gatewayPort;
 
@@ -152,10 +153,9 @@ const credentialTransactionPaths = Object.freeze({
 // This must run before any loadSettings(), credential read, or blanket chmod.
 // In particular, chmodding an attacker-replaced broad-permission journal
 // first would erase the evidence that makes recovery fail closed.
-let credentialTransactionRecovery = recoverCredentialSettingsTransaction(
-  CREDENTIAL_TRANSACTION,
-  credentialTransactionPaths,
-);
+let credentialTransactionRecovery = preReadyStorage.mode === 'legacy-flat'
+  ? recoverCredentialSettingsTransaction(CREDENTIAL_TRANSACTION, credentialTransactionPaths)
+  : { ok: true, status: 'none' };
 let credentialTransactionBlocked = credentialTransactionRecovery.status === 'blocked';
 
 for (const privateFile of [
@@ -200,7 +200,10 @@ const authChallengeCoordinator = new AuthChallengeCoordinator({
 const engineControlRegistry = new EngineControlRegistry({ authChallenges: authChallengeCoordinator });
 const engineSupervisor = new EngineSupervisor({ spawnProcess: spawn });
 const routingPolicyTransactions = new RoutingPolicyTransactionQueue();
-const logWriter = new BufferedLogWriter(LOG, { onError: reportLogFailure, onRecovered: () => { if (state.diagnosticNotice) { state.diagnosticNotice = null; emit(); } } });
+let logWriter = null;
+function initializeLogWriter() {
+  logWriter = new BufferedLogWriter(LOG, { onError: reportLogFailure, onRecovered: () => { if (state.diagnosticNotice) { state.diagnosticNotice = null; emit(); } } });
+}
 const externalProxyCredentialStore = new ExternalProxyCredentialStore({
   filePath: PROXY_CREDENTIAL,
   safeStorage,
@@ -220,12 +223,45 @@ let credentialRecoveryNoticeText = null;
 let credentialRecoveryErrorText = null;
 
 // ---------- settings & credentials ----------
-function loadSettings() {
+function loadLegacySettings() {
   return readSettings(SETTINGS, {
     onRecovery: (notice) => { settingsRecoveryNotice = notice; },
     defaultRouteDomains: activeSchoolProfile.defaultRouteDomains,
   });
 }
+function saveLegacySettings(settings) {
+  return writeSettings(SETTINGS, settings, {
+    defaultRouteDomains: activeSchoolProfile.defaultRouteDomains,
+  });
+}
+function openLegacyCredential() {
+  const settings = loadLegacySettings();
+  const result = readPasswordResult(CRED, safeStorage, process.platform);
+  if (result.status === 'missing') return null;
+  if (result.status !== 'decrypted') {
+    const error = new Error('legacy credential is unavailable');
+    error.credentialStatus = result.status;
+    throw error;
+  }
+  return new LegacyMigrationCredentialOwner(settings.username, result.password);
+}
+const persistenceRuntime = new DesktopPersistenceRuntime({
+  preReadySelection: preReadyStorage,
+  initializeAfterReady: () => activeSchoolProfile.withProfileDocument((profile) => (
+    new ProfileWorkspaceStartupRuntime({
+      userData: DATA, profile, safeStorage, platform: process.platform,
+    }).initialize()
+  )),
+  legacy: {
+    loadSettings: loadLegacySettings,
+    saveSettings: saveLegacySettings,
+    saveCredential: (password) => writePassword(CRED, password, safeStorage, process.platform),
+    clearCredential: () => restorePasswordSnapshot(CRED, { existed: false, data: null }),
+    openCredential: openLegacyCredential,
+    hasCredential: () => hasStoredPassword(CRED, process.platform),
+  },
+});
+function loadSettings() { return persistenceRuntime.loadSettings(); }
 function reportSettingsReadFailure(cause, { emitState = true } = {}) {
   if (cause?.code === 'SETTINGS_READ_FAILED') return cause;
   const message = t('error.settingsReadFailed');
@@ -275,21 +311,11 @@ function assertSettingsPersistenceAvailable() {
 }
 function saveSettings(settings) {
   assertSettingsPersistenceAvailable();
-  return writeSettings(SETTINGS, settings, {
-    defaultRouteDomains: activeSchoolProfile.defaultRouteDomains,
-  });
+  return persistenceRuntime.saveSettings(settings);
 }
-function savePassword(pw) {
-  return writePassword(CRED, pw, safeStorage, process.platform);
-}
-function loadPasswordResult() {
-  if (credentialTransactionBlocked) {
-    return Object.freeze({ status: 'recovery_blocked', password: '' });
-  }
-  return readPasswordResult(CRED, safeStorage, process.platform);
-}
+function savePassword(pw, username) { return persistenceRuntime.saveCredential(pw, username); }
 function hasStoredCredential() {
-  return !credentialTransactionBlocked && hasStoredPassword(CRED, process.platform);
+  return !credentialTransactionBlocked && persistenceRuntime.hasCredential();
 }
 function syncRecoveryNotice(emitState = true) {
   state.notice = [settingsRecoveryNoticeText, credentialRecoveryNoticeText]
@@ -327,10 +353,18 @@ function applyCredentialRecoveryOutcome(recovery, {
   return recovery;
 }
 function retryCredentialTransactionRecovery() {
+  if (preReadyStorage.mode === 'profile-workspace') {
+    return applyCredentialRecoveryOutcome({ ok: true, status: 'none' });
+  }
   return applyCredentialRecoveryOutcome(recoverCredentialSettingsTransaction(
     CREDENTIAL_TRANSACTION,
     credentialTransactionPaths,
   ));
+}
+function runPersistenceCredentialMutation(options) {
+  if (preReadyStorage.mode === 'legacy-flat') return runCredentialSettingsMutation(options);
+  try { return { ok: true, value: options.mutate() }; }
+  catch (error) { return { ok: false, phase: 'mutation', error, recovery: { ok: true, status: 'none' } }; }
 }
 function socksPort() { return Number(loadSettingsOrReport().port) || 1080; }
 function clearActiveProxyCredential(expectedGeneration = null) {
@@ -715,8 +749,8 @@ async function connectOnce(isRetry, intent) {
     }
   }
   let s;
+  let username = '';
   let pw;
-  let credentialResult;
   let engineConfigBinding;
   state.lastError = null;
   state.clientIp = null;
@@ -764,31 +798,36 @@ async function connectOnce(isRetry, intent) {
   const engineConfig = engineConfigBinding.path;
   try {
     s = loadSettings();
-    credentialResult = loadPasswordResult();
-    pw = credentialResult.password;
+    const credentialOwner = persistenceRuntime.openCredential();
+    if (credentialOwner) {
+      try {
+        credentialOwner.withStrings((account, password) => {
+          username = account;
+          pw = password;
+        });
+      } finally { credentialOwner.destroy(); }
+    }
   } catch (error) {
     connectionState.failIntent(intent);
+    if (error?.credentialStatus) {
+      state.lastError = t(credentialLoadErrorKey(error.credentialStatus));
+      emit();
+      return { ok: false, credentialStatus: error.credentialStatus };
+    }
     reportSettingsReadFailure(error, { emitState: false });
     emit();
     return { ok: false, settingsUnavailable: true };
   }
-  if (!s.username || credentialResult.status === 'missing') {
+  if (!username || !pw) {
     pw = '';
     connectionState.failIntent(intent);
     state.lastError = t('error.needCredentials');
     emit();
     return { ok: false };
   }
-  if (credentialResult.status !== 'decrypted') {
-    pw = '';
-    connectionState.failIntent(intent);
-    state.lastError = t(credentialLoadErrorKey(credentialResult.status));
-    emit();
-    return { ok: false, credentialStatus: credentialResult.status };
-  }
   try {
-    if (s.username.length > 256 || pw.length > 4096) throw new Error('credential too long');
-    parseCredentialField(s.username, '账号');
+    if (username.length > 256 || pw.length > 4096) throw new Error('credential too long');
+    parseCredentialField(username, '账号');
     parseCredentialField(pw, '密码');
   } catch {
     pw = '';
@@ -1024,8 +1063,9 @@ async function connectOnce(isRetry, intent) {
   // Keep the credential/control pipe open: EOF cancels active authentication;
   // after connection it closes only the Control v2/v3 stream.
   child.stdin.write(
-    `${engineConfigBinding.stdinFrame}\n${s.username}\n${pw}\n${proxyCredentialLines}`,
+    `${engineConfigBinding.stdinFrame}\n${username}\n${pw}\n${proxyCredentialLines}`,
   );
+  username = '';
   pw = '';
   proxyCredentialLines = '';
   engineRuntime.start(child.stdout);
@@ -1318,7 +1358,7 @@ function trustedHandle(channel, handler) {
 
 const controlStateSnapshot = createControlStateSnapshot({
   getStatus: statusSnapshot, loadSettings: loadSettingsOrReport,
-  hasCredential: hasStoredCredential, hasAccountIdentity: (settings) => Boolean(settings.username),
+  hasCredential: hasStoredCredential, hasAccountIdentity: () => persistenceRuntime.hasAccountIdentity(),
   getPacUrl: pacUrl, getLocale: () => locale, platform: process.platform,
   getVersion: () => app.getVersion(), getUpdate: () => updateInfo, getResources: campusResources,
   getFallbackResources: () => safeCampusResources({ customResources: [] }),
@@ -1350,8 +1390,8 @@ registerSettingsCredentialIpc({
   loadSettings: loadSettingsOrReport,
   saveSettings,
   savePassword,
-  removePassword: () => restorePasswordSnapshot(CRED, { existed: false, data: null }),
-  runCredentialMutation: runCredentialSettingsMutation,
+  removePassword: () => persistenceRuntime.clearCredential(),
+  runCredentialMutation: runPersistenceCredentialMutation,
   credentialJournalPath: CREDENTIAL_TRANSACTION,
   credentialPaths: credentialTransactionPaths,
   applyCredentialRecovery: applyCredentialRecoveryOutcome,
@@ -1471,7 +1511,7 @@ desktopShell = new DesktopShell({
     networkStatusMonitor.dispose();
   },
   cleanupQuit: async () => {
-    await logWriter.close().catch(reportLogFailure);
+    await logWriter?.close().catch(reportLogFailure);
     removeExternalProxySidecar();
     stableProxyCredential?.destroy();
     stableProxyCredential = null;
@@ -1536,6 +1576,14 @@ app.on('login', (event, webContents, _details, authInfo, callback) => {
   activeProxyCredential.answerProxyChallenge(authInfo, generation, callback);
 });
 app.whenReady().then(() => {
+  const persistence = persistenceRuntime.initialize();
+  if (persistence.relaunchRequired) {
+    relaunchAfterPersistenceMigration({ application: app, argv: process.argv,
+      isPackaged: app.isPackaged, developmentEntry: __dirname });
+    return;
+  }
+  initializeLogWriter();
+  writePersistenceE2EMarker({ application: app, environment: process.env, userData: DATA, mode: persistenceRuntime.mode });
   try {
     locale = currentLocale();
   } catch {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -19,6 +19,7 @@
     "test:main-integration": "electron e2e/main-integration.electron.js",
     "test:main-engine-lifecycle": "electron e2e/main-engine-lifecycle.electron.js",
     "test:main-network-startup": "electron e2e/main-network-startup.electron.js",
+    "test:persistence-migration": "electron e2e/persistence-migration.electron.js",
     "test:profile-asar": "electron e2e/school-profile-asar.electron.js",
     "test:strict-proxy-auth": "electron e2e/strict-proxy-auth.electron.js",
     "start": "electron .",

--- a/desktop/scripts/check-architecture.js
+++ b/desktop/scripts/check-architecture.js
@@ -8,7 +8,7 @@ const path = require('node:path');
 // is extracted incrementally behind tests.
 const BASELINE = Object.freeze({
   mainDirectDependencies: 35,
-  mainLines: 1596,
+  mainLines: 1644,
   rendererLines: 558,
 });
 

--- a/desktop/test/campus-resource-store.test.js
+++ b/desktop/test/campus-resource-store.test.js
@@ -21,6 +21,7 @@ test('adding a shortcut generates a stable local id and partner route', () => {
   });
   assert.match(result.resource.id, /^custom-[a-f0-9]{8}$/);
   assert.equal(result.resource.route, 'direct');
+  assert.equal(Object.hasOwn(result.resource, 'builtin'), false);
   assert.equal(result.resources.length, 1);
 });
 

--- a/desktop/test/connection-start-snapshot-contract.test.js
+++ b/desktop/test/connection-start-snapshot-contract.test.js
@@ -19,9 +19,9 @@ test('connect takes its final settings and credential snapshot after the last pr
 
   const snapshotToSpawn = connectOnce.slice(finalSnapshot, spawn);
   assert.match(snapshotToSpawn, /s = loadSettings\(\);/);
-  assert.match(snapshotToSpawn, /credentialResult = loadPasswordResult\(\);/);
-  assert.match(snapshotToSpawn, /pw = credentialResult\.password;/);
-  assert.match(snapshotToSpawn, /credentialResult\.status !== 'decrypted'/);
+  assert.match(snapshotToSpawn, /const credentialOwner = persistenceRuntime\.openCredential\(\);/);
+  assert.match(snapshotToSpawn, /credentialOwner\.withStrings\(\(account, password\)/);
+  assert.match(snapshotToSpawn, /finally \{ credentialOwner\.destroy\(\); \}/);
   assert.doesNotMatch(snapshotToSpawn, /\bawait\b/);
 });
 
@@ -33,13 +33,13 @@ test('the final snapshot is the one passed to engine arguments and credential st
   const finalSnapshot = connectOnce.indexOf('// FINAL_CONNECTION_SNAPSHOT:');
   const finalPath = connectOnce.slice(finalSnapshot);
 
-  assert.match(finalPath, /s\.username\.length > 256 \|\| pw\.length > 4096/);
-  assert.match(finalPath, /parseCredentialField\(s\.username/);
+  assert.match(finalPath, /username\.length > 256 \|\| pw\.length > 4096/);
+  assert.match(finalPath, /parseCredentialField\(username/);
   assert.match(finalPath, /parseCredentialField\(pw/);
   assert.match(finalPath, /--socks-bind[^\n]+Number\(s\.port\)/);
   assert.match(finalPath, /s\.strictProxyAuth === true/);
   assert.match(finalPath, /'--control-api-v2-stdin'/);
   assert.match(finalPath, /'--profile-binding-v1-stdin'/);
-  assert.match(finalPath, /\$\{engineConfigBinding\.stdinFrame\}\\n\$\{s\.username\}\\n\$\{pw\}\\n/);
+  assert.match(finalPath, /\$\{engineConfigBinding\.stdinFrame\}\\n\$\{username\}\\n\$\{pw\}\\n/);
   assert.doesNotMatch(finalPath, /child\.stdin\.end\(/);
 });

--- a/desktop/test/desktop-persistence-runtime.test.js
+++ b/desktop/test/desktop-persistence-runtime.test.js
@@ -10,6 +10,10 @@ const { normalizeSettings } = require('../lib/settings-store');
 function owner(username = 'synthetic-user', password = 'synthetic-password') {
   let destroyed = false;
   return {
+    withUsername(callback) {
+      if (destroyed) throw new Error('destroyed');
+      return callback(username);
+    },
     withStrings(callback) {
       if (destroyed) throw new Error('destroyed');
       return callback(username, password);
@@ -125,7 +129,7 @@ test('Profile Workspace mode routes settings and credentials only through scoped
   });
   assert.equal(persistence.initialize().ready, true);
   assert.equal(persistence.hasAccountIdentity(), true);
-  assert.equal(persistence.loadSettings().username, '');
+  assert.equal(persistence.loadSettings().username, 'workspace-user');
   assert.equal(persistence.saveCredential('next-password', 'next-user'), true);
   assert.deepEqual(replaced, { username: 'next-user', password: 'next-password' });
   assert.equal(persistence.loadSettings().username, 'next-user');

--- a/desktop/test/external-proxy-main-contract.test.js
+++ b/desktop/test/external-proxy-main-contract.test.js
@@ -18,7 +18,7 @@ test('strict and compatibility generations share one stable credential with dist
   assert.match(connectOnce, /proxyCredentialMode === 'optional'[^\n]+--socks-auth-optional-stdin/);
   assert.match(
     connectOnce,
-    /\$\{engineConfigBinding\.stdinFrame\}\\n\$\{s\.username\}\\n\$\{pw\}\\n\$\{proxyCredentialLines\}/,
+    /\$\{engineConfigBinding\.stdinFrame\}\\n\$\{username\}\\n\$\{pw\}\\n\$\{proxyCredentialLines\}/,
   );
   assert.match(connectOnce, /'--control-api-v2-stdin'/);
 });

--- a/desktop/test/main-engine-protocol-contract.test.js
+++ b/desktop/test/main-engine-protocol-contract.test.js
@@ -40,7 +40,7 @@ test('desktop opts into the private Control v2 stream and retains signal fallbac
   assert.match(source, /'--profile-binding-v1-stdin'/);
   assert.match(source, /child\.stdin\.write\([\s\S]*engineConfigBinding\.stdinFrame/u);
   assert.doesNotMatch(source, /child\.stdin\.end\(/);
-  const credentials = source.indexOf('${engineConfigBinding.stdinFrame}\\n${s.username}\\n${pw}');
+  const credentials = source.indexOf('${engineConfigBinding.stdinFrame}\\n${username}\\n${pw}');
   const runtimeStart = source.indexOf('engineRuntime.start(child.stdout)');
   assert.ok(credentials > 0 && runtimeStart > credentials,
     'runtime/handshake starts only after the credential prefix');

--- a/desktop/test/main-persistence-activation-contract.test.js
+++ b/desktop/test/main-persistence-activation-contract.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const source = fs.readFileSync(path.join(__dirname, '..', 'main.js'), 'utf8');
+
+function section(start, end) {
+  const from = source.indexOf(start);
+  const to = source.indexOf(end, from + start.length);
+  assert.ok(from >= 0 && to > from, `missing section ${start}`);
+  return source.slice(from, to);
+}
+
+test('pre-ready selection binds every service path before recovery or construction', () => {
+  const legacyCleanup = source.indexOf('fs.unlinkSync(legacyRuntimeStoragePaths.proxyHelperCredential)');
+  const profile = source.indexOf('const activeSchoolProfile = createSchoolProfileController(');
+  const selection = source.indexOf('selectProfileWorkspacePreReadyStorage({ userData: DATA, profile })');
+  const paths = source.indexOf('const runtimeStoragePaths = preReadyStorage.paths;');
+  const recovery = source.indexOf('recoverCredentialSettingsTransaction(CREDENTIAL_TRANSACTION');
+  assert.ok(legacyCleanup >= 0 && profile > legacyCleanup && selection > profile &&
+    paths > selection && recovery > paths);
+  assert.match(source, /preReadyStorage\.mode === 'legacy-flat'[\s\S]*recoverCredentialSettingsTransaction/);
+});
+
+test('after-ready migration uses the bounded relaunch owner before services can start', () => {
+  const startup = section('app.whenReady().then(() => {', "app.on('window-all-closed'");
+  const initialize = startup.indexOf('persistenceRuntime.initialize()');
+  const relaunch = startup.indexOf('relaunchAfterPersistenceMigration(');
+  const log = startup.indexOf('initializeLogWriter()');
+  const tray = startup.indexOf('desktopShell.createTray()');
+  const network = startup.indexOf('networkStartupCoordinator.start()');
+  assert.ok(initialize >= 0 && relaunch > initialize && log > relaunch && tray > log && network > tray);
+  assert.match(startup, /if \(persistence\.relaunchRequired\) \{[\s\S]*relaunchAfterPersistenceMigration\(\{[\s\S]*developmentEntry: __dirname \}\);\s*return;/u);
+  assert.match(source, /let logWriter = null;[\s\S]*function initializeLogWriter\(\)/u);
+});
+
+test('settings credential IPC and connect use the immutable persistence adapter', () => {
+  const connect = section('async function connectOnce(', '\nfunction ensureEngineStopped()');
+  assert.match(source, /function loadSettings\(\) \{ return persistenceRuntime\.loadSettings\(\); \}/u);
+  assert.match(source, /persistenceRuntime\.saveCredential\(pw, username\)/u);
+  assert.match(source, /removePassword: \(\) => persistenceRuntime\.clearCredential\(\)/u);
+  assert.match(source, /hasAccountIdentity: \(\) => persistenceRuntime\.hasAccountIdentity\(\)/u);
+  assert.match(connect, /const credentialOwner = persistenceRuntime\.openCredential\(\)/u);
+  assert.match(connect, /finally \{ credentialOwner\.destroy\(\); \}/u);
+  assert.match(connect, /\$\{engineConfigBinding\.stdinFrame\}\\n\$\{username\}\\n\$\{pw\}/u);
+  assert.doesNotMatch(connect, /loadPasswordResult\(\)/u);
+});

--- a/desktop/test/main-settings-read-boundary.test.js
+++ b/desktop/test/main-settings-read-boundary.test.js
@@ -32,9 +32,9 @@ test('final connection snapshot fails the FSM and classifies credential availabi
   const marker = body.indexOf('// FINAL_CONNECTION_SNAPSHOT:');
   const spawn = body.indexOf('const started = engineSupervisor.start(');
   const guardedStart = body.slice(marker, spawn);
-  assert.match(guardedStart, /try \{\s*s = loadSettings\(\);\s*credentialResult = loadPasswordResult\(\);\s*pw = credentialResult\.password;/);
-  assert.match(guardedStart, /credentialResult\.status === 'missing'/);
-  assert.match(guardedStart, /credentialResult\.status !== 'decrypted'/);
+  assert.match(guardedStart, /s = loadSettings\(\);[\s\S]*persistenceRuntime\.openCredential\(\)/);
+  assert.match(guardedStart, /credentialOwner\.withStrings/);
+  assert.match(guardedStart, /credentialOwner\.destroy\(\)/);
   assert.match(guardedStart, /connectionState\.failIntent\(intent\);/);
   assert.match(guardedStart, /settingsUnavailable: true/);
 });

--- a/desktop/test/persistence-relaunch.test.js
+++ b/desktop/test/persistence-relaunch.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  PERSISTENCE_RELAUNCH_ARGUMENT,
+  persistenceRelaunchArguments,
+  relaunchAfterPersistenceMigration,
+  writePersistenceE2EMarker,
+} = require('../lib/persistence-relaunch');
+
+test('development migration relaunches the Desktop entry instead of its Electron test wrapper', () => {
+  assert.deepEqual(persistenceRelaunchArguments({
+    argv: ['/Electron', '/repo/desktop/e2e/main-network-startup.electron.js'],
+    isPackaged: false,
+    developmentEntry: '/repo/desktop',
+  }), ['/repo/desktop', PERSISTENCE_RELAUNCH_ARGUMENT]);
+});
+
+test('packaged migration preserves launch arguments and adds one bounded marker', () => {
+  assert.deepEqual(persistenceRelaunchArguments({
+    argv: ['/Applications/Campus Connect.app/Contents/MacOS/Campus Connect', '--example'],
+    isPackaged: true,
+    developmentEntry: '/unused',
+  }), ['--example', PERSISTENCE_RELAUNCH_ARGUMENT]);
+});
+
+test('a second migration request in the same relaunch chain fails closed', () => {
+  assert.throws(() => persistenceRelaunchArguments({
+    argv: ['/Electron', '/repo/desktop', PERSISTENCE_RELAUNCH_ARGUMENT],
+    isPackaged: false,
+    developmentEntry: '/repo/desktop',
+  }), (error) => error?.code === 'PERSISTENCE_RELAUNCH_LOOP_BLOCKED');
+});
+
+test('relaunch owner schedules exactly one successor then exits current process', () => {
+  const calls = [];
+  relaunchAfterPersistenceMigration({
+    application: {
+      relaunch: (options) => calls.push(['relaunch', options]),
+      exit: (code) => calls.push(['exit', code]),
+    },
+    argv: ['/Electron', '/wrapper.js'],
+    isPackaged: false,
+    developmentEntry: '/repo/desktop',
+  });
+  assert.deepEqual(calls, [
+    ['relaunch', { args: ['/repo/desktop', PERSISTENCE_RELAUNCH_ARGUMENT] }],
+    ['exit', 0],
+  ]);
+});
+
+test('migration marker is unavailable to packaged builds and opt-in for Electron E2E', (t) => {
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const path = require('node:path');
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'persistence-marker-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  assert.equal(writePersistenceE2EMarker({
+    application: { isPackaged: false },
+    environment: { HKUSTGZ_PERSISTENCE_E2E: '1' },
+    userData,
+    mode: 'profile-workspace',
+  }), true);
+  const marker = JSON.parse(fs.readFileSync(
+    path.join(userData, 'persistence-e2e-ready.json'), 'utf8'));
+  assert.equal(marker.mode, 'profile-workspace');
+  assert.equal(marker.pid, process.pid);
+});

--- a/desktop/test/school-profile-main-contract.test.js
+++ b/desktop/test/school-profile-main-contract.test.js
@@ -17,7 +17,7 @@ function section(startText, endText) {
 }
 
 test('composition root loads one reviewed profile before credential recovery', () => {
-  const sidecarCleanup = main.indexOf('fs.unlinkSync(PROXY_HELPER_CREDENTIAL)');
+  const sidecarCleanup = main.indexOf('fs.unlinkSync(legacyRuntimeStoragePaths.proxyHelperCredential)');
   const profile = main.indexOf('const activeSchoolProfile = createSchoolProfileController(');
   const recovery = main.indexOf('recoverCredentialSettingsTransaction(');
   assert.ok(sidecarCleanup >= 0 && profile > sidecarCleanup && recovery > profile);
@@ -40,12 +40,12 @@ test('profile drives reviewed resources, routes, Browser home and health targets
 test('reviewed profile and config binding is validated before credential decryption', () => {
   const connect = section('async function connectOnce(', '\nfunction ensureEngineStopped(');
   const profileConfig = connect.indexOf('engineConfigBinding = activeSchoolProfile.verifyEngineLaunchBinding();');
-  const credential = connect.indexOf('credentialResult = loadPasswordResult();');
+  const credential = connect.indexOf('persistenceRuntime.openCredential();');
   const spawn = connect.indexOf('const started = engineSupervisor.start(');
   assert.ok(profileConfig >= 0 && credential > profileConfig && spawn > credential);
   assert.match(main, /engineConfigBinding = activeSchoolProfile\.verifyEngineLaunchBinding\(\)/u);
   assert.match(connect, /--profile-binding-v1-stdin/u);
-  const bindingWrite = connect.indexOf('${engineConfigBinding.stdinFrame}\\n${s.username}\\n${pw}');
+  const bindingWrite = connect.indexOf('${engineConfigBinding.stdinFrame}\\n${username}\\n${pw}');
   assert.ok(bindingWrite > profileConfig && bindingWrite > credential && bindingWrite > spawn);
   assert.doesNotMatch(connect, /error\.engineConfigMissing'\s*,\s*\{\s*path/u);
   const privatePath = '/Users/private-person/Applications/config.json';

--- a/desktop/test/settings-credential-ipc.test.js
+++ b/desktop/test/settings-credential-ipc.test.js
@@ -27,7 +27,7 @@ function fixture(overrides = {}) {
     register: (channel, handler) => handlers.set(channel, handler),
     loadSettings: () => ({ ...current, customResources: [...current.customResources] }),
     saveSettings: (settings) => { current = settings; calls.push(['save', settings]); return settings; },
-    savePassword: (password) => { calls.push(['password', password]); return true; },
+    savePassword: (password, username) => { calls.push(['password', password, username]); return true; },
     removePassword: () => { calls.push(['remove-password']); return true; },
     runCredentialMutation: ({ mutate }) => {
       try { return { ok: true, value: mutate() }; }
@@ -107,7 +107,7 @@ test('password save uses the credential transaction and clears every request ref
   assert.equal(result.settings.username, 'bob');
   assert.equal(payload.password, '');
   assert.deepEqual(f.calls.filter(([name]) => name === 'password'), [
-    ['password', 'synthetic-password'],
+    ['password', 'synthetic-password', 'bob'],
   ]);
   assert.ok(f.calls.some(([name, status]) => name === 'recovery' && status === 'committed'));
 });

--- a/desktop/test/vpn-credential-envelope.test.js
+++ b/desktop/test/vpn-credential-envelope.test.js
@@ -57,11 +57,13 @@ test('username and password commit as one encrypted profile/account-bound envelo
   assert.equal(decrypted.withStrings((username, password) => (
     `${username}:${password}`
   )), 'legacy-user:private-password');
+  assert.equal(decrypted.withUsername((username) => username), 'legacy-user');
   assert.equal(JSON.stringify(decrypted), '"[redacted vpn credential]"');
   assert.equal(String(decrypted).includes('legacy-user'), false);
   assert.equal(decrypted.destroy(), true);
   assert.equal(decrypted.destroy(), false);
   assert.throws(() => decrypted.withStrings(() => true), /destroyed/u);
+  assert.throws(() => decrypted.withUsername(() => true), /destroyed/u);
 });
 
 test('binding mismatch fails before returning a credential owner', () => {


### PR DESCRIPTION
## 目标

把 P3n 已验证的双模式持久化适配器接入真实 Electron Main，使旧版扁平数据能够一次性迁移到 Profile / Account / Workspace 存储，并让设置、凭据、连接和退出登录统一使用迁移后的权威路径。

本 PR 堆叠在 #26 之上；不应绕过前序 P3 PR 直接合并到 main。

## 主要变化

- Electron ready 前验证并选择 legacy-flat 或 profile-workspace 路径，所有服务从同一不可变路径快照构造。
- ready 后执行恢复/迁移；路径发生切换时只允许一次受控重启。
- 设置、账号密码、登录状态、连接凭据和退出登录改由 DesktopPersistenceRuntime 统一代理。
- 连接前仍先验证 reviewed Profile 与 Engine config，随后才解密本机凭据。
- 启动时只读取加密凭据中的用户名，不生成密码字符串；连接结束后清空临时用户名/密码引用。
- 修复迁移后自定义网站携带 UI-only builtin:false 而被严格设置事务拒绝的问题。
- 日志写入器延后到持久化完成后构造，避免迁移与日志保留操作并发。

## Electron 重启事故修复

开发测试曾因 app.relaunch() 重启当前 E2E 包装入口而形成无限重启。当前实现：

- 开发态明确重启真正的 Desktop 入口，不重启测试脚本；
- 重启链携带一次性参数，第二次迁移请求立即 fail closed；
- 网络启动 E2E 预先建立合法迁移数据；
- 新增真实双进程迁移测试，验证旧数据退休、继任进程启动及无残留进程；
- E2E 失败现在返回非零退出码，不再被 CI 误判为成功。

## 验证

- Desktop unit: 741 passed, 1 Windows-only skipped, 0 failed
- Architecture gate: 0 cycles; mainDeps=35; mainLines=1644
- npm audit: 0 vulnerabilities
- Secret gate: PASS
- 所有 JS 与 shell 入口语法检查：PASS
- Electron Main integration：PASS
- Synthetic Engine lifecycle：PASS
- Initially-offline startup recovery：PASS
- Two-process persistence migration/relaunch：PASS
- 测试结束后无仓库 Electron 进程或迁移临时目录残留
