### PR TITLE
2.0 P4a: persist active-context switch authority

### DIFF
--- a/desktop/lib/active-context-switch-journal.js
+++ b/desktop/lib/active-context-switch-journal.js
@@ -1,0 +1,288 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const {
+  validateOpaqueKey,
+  validateProfileId,
+} = require('./school-profile-schema');
+
+const ACTIVE_CONTEXT_SWITCH_JOURNAL_VERSION = 1;
+const ACTIVE_CONTEXT_SWITCH_TYPE = 'active_context_switch';
+const JOURNAL_STATES = Object.freeze(['prepared', 'ready', 'committed']);
+const DIGEST = /^[a-f0-9]{64}$/u;
+const MAX_GLOBAL_SETTINGS_BYTES = 512 * 1024;
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const entry of Object.values(value)) deepFreeze(entry);
+  return value;
+}
+
+function plainObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+  return value;
+}
+
+function exactKeys(value, keys, name) {
+  const source = plainObject(value, name);
+  const actual = Object.keys(source).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length ||
+      actual.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${name} has an invalid schema`);
+  }
+  return source;
+}
+
+function positive(value, name) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function nullablePositive(value, name) {
+  return value === null ? null : positive(value, name);
+}
+
+function timestamp(value, name) {
+  return value === null ? null : positive(value, name);
+}
+
+function context(value, name) {
+  const source = exactKeys(value, [
+    'profileId', 'profileKey', 'profileRevision', 'profileCredentialBindingRevision',
+    'accountKey', 'accountRevision', 'accountCredentialRevision', 'workspaceKey',
+    'activeContextEpoch',
+  ], name);
+  const result = {
+    profileId: validateProfileId(source.profileId),
+    profileKey: validateOpaqueKey(source.profileKey, `${name}.profileKey`),
+    profileRevision: positive(source.profileRevision, `${name}.profileRevision`),
+    profileCredentialBindingRevision: positive(
+      source.profileCredentialBindingRevision,
+      `${name}.profileCredentialBindingRevision`,
+    ),
+    accountKey: validateOpaqueKey(source.accountKey, `${name}.accountKey`),
+    accountRevision: positive(source.accountRevision, `${name}.accountRevision`),
+    accountCredentialRevision: positive(
+      source.accountCredentialRevision,
+      `${name}.accountCredentialRevision`,
+    ),
+    workspaceKey: validateOpaqueKey(source.workspaceKey, `${name}.workspaceKey`),
+    activeContextEpoch: positive(source.activeContextEpoch, `${name}.activeContextEpoch`),
+  };
+  if (new Set([result.profileKey, result.accountKey, result.workspaceKey]).size !== 3) {
+    throw new TypeError(`${name} persistent keys must be distinct`);
+  }
+  return Object.freeze(result);
+}
+
+function switchKind(from, to) {
+  if (from.profileId !== to.profileId) {
+    if (from.profileKey === to.profileKey || from.accountKey === to.accountKey ||
+        from.workspaceKey === to.workspaceKey) {
+      throw new TypeError('profile switch cannot reuse persistent context keys');
+    }
+    return 'profile';
+  }
+  if (from.profileKey !== to.profileKey ||
+      from.profileRevision !== to.profileRevision ||
+      from.profileCredentialBindingRevision !== to.profileCredentialBindingRevision) {
+    throw new TypeError('account switch cannot change the Profile authority');
+  }
+  if (from.accountKey === to.accountKey || from.workspaceKey === to.workspaceKey) {
+    throw new TypeError('account switch requires a distinct Account and Workspace');
+  }
+  return 'account';
+}
+
+function receipt(value, name) {
+  const source = exactKeys(value, ['present', 'bytes', 'sha256'], name);
+  if (source.present !== true || !Number.isSafeInteger(source.bytes) || source.bytes < 2 ||
+      source.bytes > MAX_GLOBAL_SETTINGS_BYTES || typeof source.sha256 !== 'string' ||
+      !DIGEST.test(source.sha256)) {
+    throw new TypeError(`${name} is invalid`);
+  }
+  return Object.freeze({ present: true, bytes: source.bytes, sha256: source.sha256 });
+}
+
+function activation(value) {
+  const source = exactKeys(value, ['before', 'after'], 'active context activation');
+  const before = receipt(source.before, 'active context activation before receipt');
+  const after = receipt(source.after, 'active context activation after receipt');
+  if (before.bytes === after.bytes && before.sha256 === after.sha256) {
+    throw new TypeError('active context activation must change GlobalSettings');
+  }
+  return Object.freeze({ before, after });
+}
+
+function expectedOutcomes(state, engineGeneration) {
+  const complete = state !== 'prepared';
+  return Object.freeze({
+    browserWorkspace: complete ? 'closed' : 'pending',
+    continuations: complete ? 'cancelled' : 'pending',
+    engine: complete
+      ? (engineGeneration === null ? 'not_required' : 'confirmed')
+      : (engineGeneration === null ? 'not_required' : 'pending'),
+    proxyAccess: complete ? 'revoked' : 'pending',
+    serverState: complete ? 'cleared' : 'pending',
+    destination: complete ? 'validated' : 'pending',
+  });
+}
+
+function outcomes(value, state, engineGeneration) {
+  const source = exactKeys(value, [
+    'browserWorkspace', 'continuations', 'engine', 'proxyAccess', 'serverState',
+    'destination',
+  ], 'active context switch outcomes');
+  const expected = expectedOutcomes(state, engineGeneration);
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    if (source[key] !== expectedValue) {
+      throw new TypeError(`active context switch outcome is invalid: ${key}`);
+    }
+  }
+  return expected;
+}
+
+function validateActiveContextSwitchJournal(value) {
+  const source = exactKeys(value, [
+    'schemaVersion', 'type', 'state', 'switchId', 'kind', 'from', 'to',
+    'nextActiveContextEpoch', 'engineGeneration', 'activation', 'outcomes',
+    'createdAt', 'readyAt', 'committedAt',
+  ], 'active context switch journal');
+  if (source.schemaVersion !== ACTIVE_CONTEXT_SWITCH_JOURNAL_VERSION ||
+      source.type !== ACTIVE_CONTEXT_SWITCH_TYPE || !JOURNAL_STATES.includes(source.state)) {
+    throw new TypeError('active context switch journal version, type or state is unsupported');
+  }
+  const from = context(source.from, 'active context switch source');
+  const to = context(source.to, 'active context switch destination');
+  const kind = switchKind(from, to);
+  if (source.kind !== kind) throw new TypeError('active context switch kind does not match');
+  const nextActiveContextEpoch = positive(
+    source.nextActiveContextEpoch,
+    'nextActiveContextEpoch',
+  );
+  if (nextActiveContextEpoch <= from.activeContextEpoch ||
+      nextActiveContextEpoch <= to.activeContextEpoch) {
+    throw new TypeError('nextActiveContextEpoch must advance every bound context');
+  }
+  const engineGeneration = nullablePositive(source.engineGeneration, 'engineGeneration');
+  const createdAt = positive(source.createdAt, 'createdAt');
+  const readyAt = timestamp(source.readyAt, 'readyAt');
+  const committedAt = timestamp(source.committedAt, 'committedAt');
+  if (source.state === 'prepared' && (readyAt !== null || committedAt !== null)) {
+    throw new TypeError('prepared active context switch contains completion timestamps');
+  }
+  if (source.state === 'ready' && (readyAt === null || committedAt !== null)) {
+    throw new TypeError('ready active context switch timestamps are invalid');
+  }
+  if (source.state === 'committed' && (readyAt === null || committedAt === null)) {
+    throw new TypeError('committed active context switch timestamps are incomplete');
+  }
+  if ((readyAt !== null && readyAt < createdAt) ||
+      (committedAt !== null && committedAt < readyAt)) {
+    throw new TypeError('active context switch timestamps are inconsistent');
+  }
+  return deepFreeze({
+    schemaVersion: ACTIVE_CONTEXT_SWITCH_JOURNAL_VERSION,
+    type: ACTIVE_CONTEXT_SWITCH_TYPE,
+    state: source.state,
+    switchId: validateOpaqueKey(source.switchId, 'switchId'),
+    kind,
+    from,
+    to,
+    nextActiveContextEpoch,
+    engineGeneration,
+    activation: activation(source.activation),
+    outcomes: outcomes(source.outcomes, source.state, engineGeneration),
+    createdAt,
+    readyAt,
+    committedAt,
+  });
+}
+
+function switchId(randomBytes) {
+  let entropy = randomBytes(16);
+  if (!Buffer.isBuffer(entropy) || entropy.length !== 16) {
+    entropy?.fill?.(0);
+    throw new TypeError('active context switch entropy is invalid');
+  }
+  try { return `switch-${entropy.toString('hex')}`; }
+  finally { entropy.fill(0); entropy = null; }
+}
+
+function createPreparedActiveContextSwitch({
+  from: sourceContext,
+  to: destinationContext,
+  nextActiveContextEpoch = null,
+  engineGeneration = null,
+  activation: activationReceipts,
+  randomBytes = crypto.randomBytes,
+  now = Date.now,
+} = {}) {
+  if (typeof randomBytes !== 'function' || typeof now !== 'function') {
+    throw new TypeError('active context switch dependencies are invalid');
+  }
+  const from = context(sourceContext, 'active context switch source');
+  const to = context(destinationContext, 'active context switch destination');
+  const epoch = nextActiveContextEpoch === null
+    ? Math.max(from.activeContextEpoch, to.activeContextEpoch) + 1
+    : nextActiveContextEpoch;
+  return validateActiveContextSwitchJournal({
+    schemaVersion: ACTIVE_CONTEXT_SWITCH_JOURNAL_VERSION,
+    type: ACTIVE_CONTEXT_SWITCH_TYPE,
+    state: 'prepared',
+    switchId: switchId(randomBytes),
+    kind: switchKind(from, to),
+    from,
+    to,
+    nextActiveContextEpoch: epoch,
+    engineGeneration,
+    activation: activationReceipts,
+    outcomes: expectedOutcomes('prepared', engineGeneration),
+    createdAt: now(),
+    readyAt: null,
+    committedAt: null,
+  });
+}
+
+function markActiveContextSwitchReady(document, { now = Date.now } = {}) {
+  const prepared = validateActiveContextSwitchJournal(document);
+  if (prepared.state !== 'prepared') {
+    throw new TypeError('only a prepared active context switch can become ready');
+  }
+  if (typeof now !== 'function') throw new TypeError('active context switch clock is invalid');
+  return validateActiveContextSwitchJournal({
+    ...prepared,
+    state: 'ready',
+    outcomes: expectedOutcomes('ready', prepared.engineGeneration),
+    readyAt: now(),
+  });
+}
+
+function commitActiveContextSwitch(document, { now = Date.now } = {}) {
+  const ready = validateActiveContextSwitchJournal(document);
+  if (ready.state !== 'ready') {
+    throw new TypeError('only a ready active context switch can commit');
+  }
+  if (typeof now !== 'function') throw new TypeError('active context switch clock is invalid');
+  return validateActiveContextSwitchJournal({
+    ...ready,
+    state: 'committed',
+    committedAt: now(),
+  });
+}
+
+module.exports = {
+  ACTIVE_CONTEXT_SWITCH_JOURNAL_VERSION,
+  ACTIVE_CONTEXT_SWITCH_TYPE,
+  commitActiveContextSwitch,
+  createPreparedActiveContextSwitch,
+  markActiveContextSwitchReady,
+  validateActiveContextSwitchJournal,
+};

--- a/desktop/lib/active-context-switch-store.js
+++ b/desktop/lib/active-context-switch-store.js
@@ -1,0 +1,262 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { readPrivateFileBounded } = require('./private-file');
+const {
+  validateActiveContextSwitchJournal,
+} = require('./active-context-switch-journal');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+const MAX_ACTIVE_CONTEXT_SWITCH_BYTES = 256 * 1024;
+let temporarySequence = 0;
+
+function normalizedPath(value) {
+  if (typeof value !== 'string' || !path.isAbsolute(value)) {
+    throw new TypeError('active context switch journal path must be absolute');
+  }
+  const normalized = path.resolve(value);
+  const root = path.parse(normalized).root;
+  if (normalized !== value || normalized === root || path.dirname(normalized) === root) {
+    throw new TypeError('active context switch journal path must be absolute and normalized');
+  }
+  return normalized;
+}
+
+function fsyncDirectory(directory, fileSystem, platform) {
+  let descriptor = null;
+  try {
+    descriptor = fileSystem.openSync(directory, 'r');
+    fileSystem.fsyncSync?.(descriptor);
+    return true;
+  } catch {
+    return platform === 'win32';
+  } finally {
+    if (descriptor !== null) {
+      try { fileSystem.closeSync(descriptor); } catch {}
+    }
+  }
+}
+
+function serialized(document) {
+  const normalized = validateActiveContextSwitchJournal(document);
+  const data = Buffer.from(JSON.stringify(normalized), 'utf8');
+  if (data.length < 2 || data.length > MAX_ACTIVE_CONTEXT_SWITCH_BYTES) {
+    data.fill(0);
+    throw new TypeError('active context switch journal exceeds its storage bound');
+  }
+  return { normalized, data };
+}
+
+function immutableBinding(value) {
+  return JSON.stringify({
+    schemaVersion: value.schemaVersion,
+    type: value.type,
+    switchId: value.switchId,
+    kind: value.kind,
+    from: value.from,
+    to: value.to,
+    nextActiveContextEpoch: value.nextActiveContextEpoch,
+    engineGeneration: value.engineGeneration,
+    activation: value.activation,
+    createdAt: value.createdAt,
+  });
+}
+
+function exactDocument(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+class ActiveContextSwitchJournalStore {
+  constructor({
+    filePath,
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+  } = {}) {
+    if (!fileSystem || typeof fileSystem.openSync !== 'function' ||
+        !['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' &&
+          (typeof windowsAcl?.protect !== 'function' || typeof windowsAcl?.verify !== 'function'))) {
+      throw new TypeError('active context switch store dependencies are invalid');
+    }
+    this.filePath = normalizedPath(filePath);
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+  }
+
+  read() {
+    try {
+      this.fileSystem.lstatSync(this.filePath);
+    } catch (error) {
+      if (error?.code === 'ENOENT') return null;
+      throw error;
+    }
+    if (this.platform === 'win32' && !this.windowsAcl.verify(this.filePath)) {
+      throw new Error('active context switch journal ACL is invalid');
+    }
+    let data;
+    try {
+      ({ data } = readPrivateFileBounded(this.filePath, {
+        maxBytes: MAX_ACTIVE_CONTEXT_SWITCH_BYTES,
+        minBytes: 2,
+        platform: this.platform,
+        fileSystem: this.fileSystem,
+      }));
+    } catch (error) {
+      if (error?.code === 'ENOENT') {
+        throw new Error('active context switch journal disappeared after observation', {
+          cause: error,
+        });
+      }
+      throw error;
+    }
+    try {
+      return validateActiveContextSwitchJournal(JSON.parse(data.toString('utf8')));
+    } catch (error) {
+      throw new Error('active context switch journal is invalid', { cause: error });
+    } finally {
+      data.fill(0);
+    }
+  }
+
+  prepare(document) {
+    const { normalized, data } = serialized(document);
+    if (normalized.state !== 'prepared') {
+      data.fill(0);
+      throw new TypeError('active context switch journal must be prepared before storage');
+    }
+    const directory = path.dirname(this.filePath);
+    let descriptor = null;
+    let created = false;
+    try {
+      this.fileSystem.mkdirSync(directory, { recursive: true, mode: 0o700 });
+      descriptor = this.fileSystem.openSync(this.filePath, 'wx', 0o600);
+      created = true;
+      this.fileSystem.writeFileSync(descriptor, data);
+      this.fileSystem.fsyncSync?.(descriptor);
+      this.fileSystem.closeSync(descriptor);
+      descriptor = null;
+      if (this.platform === 'win32' &&
+          (!this.windowsAcl.protect(this.filePath) || !this.windowsAcl.verify(this.filePath))) {
+        throw new Error('active context switch journal Windows ACL is invalid');
+      }
+      return {
+        prepared: true,
+        durabilityUnconfirmed: !fsyncDirectory(directory, this.fileSystem, this.platform),
+      };
+    } catch (error) {
+      if (descriptor !== null) {
+        try { this.fileSystem.closeSync(descriptor); } catch {}
+      }
+      if (created) {
+        try { this.fileSystem.unlinkSync(this.filePath); } catch {}
+        fsyncDirectory(directory, this.fileSystem, this.platform);
+      }
+      if (error?.code === 'EEXIST') {
+        throw new Error('active context switch journal already exists');
+      }
+      throw new Error('active context switch journal prepare failed', { cause: error });
+    } finally {
+      data.fill(0);
+    }
+  }
+
+  markReady(document) {
+    return this.#transition(document, 'prepared', 'ready');
+  }
+
+  commit(document) {
+    return this.#transition(document, 'ready', 'committed');
+  }
+
+  clearCommitted() {
+    const current = this.read();
+    if (current === null) return false;
+    if (current.state !== 'committed') {
+      throw new Error('uncommitted active context switch journal cannot be cleared');
+    }
+    const directory = path.dirname(this.filePath);
+    try {
+      this.fileSystem.unlinkSync(this.filePath);
+    } catch (error) {
+      throw new Error('active context switch journal clear failed', { cause: error });
+    }
+    if (!fsyncDirectory(directory, this.fileSystem, this.platform)) {
+      throw new Error('active context switch journal clear was not durable');
+    }
+    return true;
+  }
+
+  #transition(document, expectedState, targetState) {
+    const current = this.read();
+    if (!current || current.state !== expectedState) {
+      throw new Error(`active context switch journal is not ${expectedState}`);
+    }
+    const { normalized, data } = serialized(document);
+    if (normalized.state !== targetState) {
+      data.fill(0);
+      throw new TypeError(`active context switch journal must transition to ${targetState}`);
+    }
+    if (immutableBinding(current) !== immutableBinding(normalized)) {
+      data.fill(0);
+      throw new Error('active context switch journal binding does not match');
+    }
+    const directory = path.dirname(this.filePath);
+    const temporary = path.join(
+      directory,
+      `.${path.basename(this.filePath)}.${process.pid}.${Date.now()}.${temporarySequence++}.tmp`,
+    );
+    let descriptor = null;
+    let renamed = false;
+    try {
+      descriptor = this.fileSystem.openSync(temporary, 'wx', 0o600);
+      this.fileSystem.writeFileSync(descriptor, data);
+      this.fileSystem.fsyncSync?.(descriptor);
+      this.fileSystem.closeSync(descriptor);
+      descriptor = null;
+      if (this.platform === 'win32' &&
+          (!this.windowsAcl.protect(temporary) || !this.windowsAcl.verify(temporary))) {
+        throw new Error('active context switch temporary Windows ACL is invalid');
+      }
+      this.fileSystem.renameSync(temporary, this.filePath);
+      renamed = true;
+      if (this.platform === 'win32' && !this.windowsAcl.verify(this.filePath)) {
+        throw new Error('active context switch committed Windows ACL is invalid');
+      }
+      const durable = fsyncDirectory(directory, this.fileSystem, this.platform);
+      if (!durable) {
+        const observed = this.read();
+        if (!exactDocument(observed, normalized)) {
+          throw new Error('active context switch transition durability is unconfirmed');
+        }
+      }
+      return {
+        [targetState]: true,
+        durabilityUnconfirmed: !durable,
+      };
+    } catch (error) {
+      if (descriptor !== null) {
+        try { this.fileSystem.closeSync(descriptor); } catch {}
+      }
+      if (!renamed) {
+        try { this.fileSystem.unlinkSync(temporary); } catch {}
+      }
+      throw new Error(`active context switch journal ${targetState} failed`, { cause: error });
+    } finally {
+      data.fill(0);
+    }
+  }
+}
+
+module.exports = {
+  ActiveContextSwitchJournalStore,
+  MAX_ACTIVE_CONTEXT_SWITCH_BYTES,
+};

--- a/desktop/test/active-context-switch-journal.test.js
+++ b/desktop/test/active-context-switch-journal.test.js
@@ -1,0 +1,147 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  commitActiveContextSwitch,
+  createPreparedActiveContextSwitch,
+  markActiveContextSwitchReady,
+  validateActiveContextSwitchJournal,
+} = require('../lib/active-context-switch-journal');
+
+function key(name, seed) { return `${name}-${String(seed).repeat(32)}`; }
+
+function context({
+  profileId = 'school-a',
+  profileSeed = '1',
+  accountSeed = '2',
+  workspaceSeed = '3',
+  activeContextEpoch = 5,
+} = {}) {
+  return {
+    profileId,
+    profileKey: key('profile', profileSeed),
+    profileRevision: 1,
+    profileCredentialBindingRevision: 1,
+    accountKey: key('account', accountSeed),
+    accountRevision: 1,
+    accountCredentialRevision: 1,
+    workspaceKey: key('workspace', workspaceSeed),
+    activeContextEpoch,
+  };
+}
+
+function receipt(seed) {
+  return { present: true, bytes: seed + 20, sha256: seed.toString(16).padStart(64, '0') };
+}
+
+function profileSwitch(overrides = {}) {
+  return {
+    from: context(),
+    to: context({
+      profileId: 'school-b', profileSeed: '4', accountSeed: '5', workspaceSeed: '6',
+      activeContextEpoch: 3,
+    }),
+    engineGeneration: 7,
+    activation: { before: receipt(1), after: receipt(2) },
+    randomBytes: () => Buffer.alloc(16, 0xab),
+    now: () => 1_800_000_000_000,
+    ...overrides,
+  };
+}
+
+test('profile switch journal advances one immutable prepared ready committed chain', () => {
+  const prepared = createPreparedActiveContextSwitch(profileSwitch());
+  assert.equal(prepared.kind, 'profile');
+  assert.equal(prepared.nextActiveContextEpoch, 6);
+  assert.equal(prepared.outcomes.engine, 'pending');
+  assert.equal(Object.isFrozen(prepared.to), true);
+
+  const ready = markActiveContextSwitchReady(prepared, {
+    now: () => 1_800_000_000_100,
+  });
+  assert.equal(ready.state, 'ready');
+  assert.deepEqual(ready.outcomes, {
+    browserWorkspace: 'closed',
+    continuations: 'cancelled',
+    engine: 'confirmed',
+    proxyAccess: 'revoked',
+    serverState: 'cleared',
+    destination: 'validated',
+  });
+  const committed = commitActiveContextSwitch(ready, {
+    now: () => 1_800_000_000_200,
+  });
+  assert.equal(committed.state, 'committed');
+  assert.equal(committed.switchId, prepared.switchId);
+  assert.equal(committed.committedAt, 1_800_000_000_200);
+  assert.throws(() => markActiveContextSwitchReady(ready), /prepared/u);
+  assert.throws(() => commitActiveContextSwitch(prepared), /ready/u);
+});
+
+test('an Engine-free account switch records not_required and keeps Profile authority exact', () => {
+  const from = context();
+  const prepared = createPreparedActiveContextSwitch({
+    from,
+    to: context({ accountSeed: '7', workspaceSeed: '8', activeContextEpoch: 2 }),
+    nextActiveContextEpoch: 9,
+    engineGeneration: null,
+    activation: { before: receipt(3), after: receipt(4) },
+    randomBytes: () => Buffer.alloc(16, 0xcd),
+    now: () => 1_800_000_001_000,
+  });
+  assert.equal(prepared.kind, 'account');
+  assert.equal(prepared.outcomes.engine, 'not_required');
+  assert.equal(markActiveContextSwitchReady(prepared, {
+    now: () => 1_800_000_001_100,
+  }).outcomes.engine, 'not_required');
+});
+
+test('switch journal rejects no-op, key reuse, Profile drift and stale epochs', () => {
+  const from = context();
+  assert.throws(() => createPreparedActiveContextSwitch(profileSwitch({ to: from })),
+    /distinct Account/u);
+  assert.throws(() => createPreparedActiveContextSwitch(profileSwitch({
+    to: { ...context({ accountSeed: '7', workspaceSeed: '8' }), profileRevision: 2 },
+  })), /Profile authority/u);
+  assert.throws(() => createPreparedActiveContextSwitch(profileSwitch({
+    to: context({
+      profileId: 'school-b', profileSeed: '1', accountSeed: '5', workspaceSeed: '6',
+    }),
+  })), /reuse persistent context keys/u);
+  assert.throws(() => createPreparedActiveContextSwitch(profileSwitch({
+    nextActiveContextEpoch: 5,
+  })), /advance every bound context/u);
+});
+
+test('activation receipts and exact journal schema fail closed', () => {
+  assert.throws(() => createPreparedActiveContextSwitch(profileSwitch({
+    activation: { before: receipt(1), after: receipt(1) },
+  })), /must change GlobalSettings/u);
+  const prepared = createPreparedActiveContextSwitch(profileSwitch());
+  assert.throws(() => validateActiveContextSwitchJournal({ ...prepared, extra: true }),
+    /invalid schema/u);
+  assert.throws(() => validateActiveContextSwitchJournal({
+    ...prepared,
+    activation: {
+      ...prepared.activation,
+      after: { ...prepared.activation.after, sha256: 'A'.repeat(64) },
+    },
+  }), /receipt is invalid/u);
+  assert.throws(() => validateActiveContextSwitchJournal({
+    ...prepared,
+    outcomes: { ...prepared.outcomes, destination: 'validated' },
+  }), /outcome is invalid/u);
+});
+
+test('switch identity entropy is erased and bounded before persistence', () => {
+  const entropy = Buffer.alloc(16, 0xef);
+  const prepared = createPreparedActiveContextSwitch(profileSwitch({
+    randomBytes: () => entropy,
+  }));
+  assert.match(prepared.switchId, /^switch-[a-f0-9]{32}$/u);
+  assert.equal(entropy.every((value) => value === 0), true);
+  assert.throws(() => createPreparedActiveContextSwitch(profileSwitch({
+    randomBytes: () => Buffer.alloc(15),
+  })), /entropy/u);
+});

--- a/desktop/test/active-context-switch-store.test.js
+++ b/desktop/test/active-context-switch-store.test.js
@@ -1,0 +1,209 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  commitActiveContextSwitch,
+  createPreparedActiveContextSwitch,
+  markActiveContextSwitchReady,
+} = require('../lib/active-context-switch-journal');
+const {
+  ActiveContextSwitchJournalStore,
+} = require('../lib/active-context-switch-store');
+
+function key(name, seed) { return `${name}-${String(seed).repeat(32)}`; }
+
+function context(profileId, profileSeed, accountSeed, workspaceSeed, epoch) {
+  return {
+    profileId,
+    profileKey: key('profile', profileSeed),
+    profileRevision: 1,
+    profileCredentialBindingRevision: 1,
+    accountKey: key('account', accountSeed),
+    accountRevision: 1,
+    accountCredentialRevision: 1,
+    workspaceKey: key('workspace', workspaceSeed),
+    activeContextEpoch: epoch,
+  };
+}
+
+function receipt(seed) {
+  return { present: true, bytes: seed + 50, sha256: seed.toString(16).padStart(64, '0') };
+}
+
+function prepared(seed = 1) {
+  return createPreparedActiveContextSwitch({
+    from: context('school-a', '1', '2', '3', 4),
+    to: context('school-b', '4', '5', '6', 2),
+    engineGeneration: 9,
+    activation: { before: receipt(seed), after: receipt(seed + 1) },
+    randomBytes: () => Buffer.alloc(16, seed),
+    now: () => 1_800_000_000_000 + seed,
+  });
+}
+
+function ready(value) {
+  return markActiveContextSwitchReady(value, { now: () => 1_800_000_000_100 });
+}
+
+function committed(value) {
+  return commitActiveContextSwitch(value, { now: () => 1_800_000_000_200 });
+}
+
+function fixture(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'active-context-switch-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return {
+    root,
+    file: path.join(root, 'global', 'active-context-switch.json'),
+  };
+}
+
+test('owner-only store persists one prepared ready committed transition', (t) => {
+  const { file } = fixture(t);
+  const store = new ActiveContextSwitchJournalStore({ filePath: file });
+  const first = prepared();
+  const second = ready(first);
+  const third = committed(second);
+
+  assert.equal(store.read(), null);
+  assert.deepEqual(store.prepare(first), { prepared: true, durabilityUnconfirmed: false });
+  assert.deepEqual(store.markReady(second), { ready: true, durabilityUnconfirmed: false });
+  assert.deepEqual(store.commit(third), { committed: true, durabilityUnconfirmed: false });
+  assert.deepEqual(store.read(), third);
+  if (process.platform !== 'win32') assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+  assert.equal(store.clearCommitted(), true);
+  assert.equal(store.read(), null);
+  assert.equal(store.clearCommitted(), false);
+});
+
+test('store rejects skipped states, concurrent identity and premature clearing', (t) => {
+  const { file } = fixture(t);
+  const store = new ActiveContextSwitchJournalStore({ filePath: file });
+  const first = prepared();
+  store.prepare(first);
+  assert.throws(() => store.commit(committed(ready(first))), /not ready/u);
+  assert.throws(() => store.clearCommitted(), /uncommitted/u);
+  store.markReady(ready(first));
+  assert.throws(() => store.commit(committed(ready(prepared(7)))), /binding/u);
+  assert.throws(() => store.prepare(prepared(8)), /already exists/u);
+  assert.equal(store.read().switchId, first.switchId);
+});
+
+test('reads reject symbolic links, hard links and broad POSIX permissions', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const { root, file } = fixture(t);
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const unrelated = path.join(root, 'unrelated.json');
+  fs.writeFileSync(unrelated, JSON.stringify(prepared()), { mode: 0o600 });
+
+  fs.symlinkSync(unrelated, file);
+  assert.throws(() => new ActiveContextSwitchJournalStore({ filePath: file }).read(),
+    /private file/u);
+  fs.unlinkSync(file);
+  fs.linkSync(unrelated, file);
+  assert.throws(() => new ActiveContextSwitchJournalStore({ filePath: file }).read(),
+    /private file/u);
+  fs.unlinkSync(file);
+  fs.copyFileSync(unrelated, file);
+  fs.chmodSync(file, 0o644);
+  assert.throws(() => new ActiveContextSwitchJournalStore({ filePath: file }).read(),
+    /private file/u);
+});
+
+test('failure before rename preserves the previous state', (t) => {
+  const { file } = fixture(t);
+  const first = prepared();
+  const base = new ActiveContextSwitchJournalStore({ filePath: file });
+  base.prepare(first);
+  const injected = Object.create(fs);
+  injected.renameSync = () => { throw new Error('simulated rename failure'); };
+  const store = new ActiveContextSwitchJournalStore({ filePath: file, fileSystem: injected });
+  assert.throws(() => store.markReady(ready(first)), /ready failed/u);
+  assert.deepEqual(base.read(), first);
+});
+
+test('a readable transition resolves post-rename directory fsync uncertainty', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const { file } = fixture(t);
+  const first = prepared();
+  const base = new ActiveContextSwitchJournalStore({ filePath: file });
+  base.prepare(first);
+  const injected = Object.create(fs);
+  injected.fsyncSync = (descriptor) => {
+    if (fs.fstatSync(descriptor).isDirectory()) {
+      throw new Error('simulated directory fsync failure');
+    }
+    return fs.fsyncSync(descriptor);
+  };
+  const store = new ActiveContextSwitchJournalStore({ filePath: file, fileSystem: injected });
+  const next = ready(first);
+  assert.deepEqual(store.markReady(next), { ready: true, durabilityUnconfirmed: true });
+  assert.deepEqual(base.read(), next);
+});
+
+test('journal disappearance and malformed content are never treated as absence', (t) => {
+  const { file } = fixture(t);
+  const base = new ActiveContextSwitchJournalStore({ filePath: file });
+  base.prepare(prepared());
+  const injected = Object.create(fs);
+  let observations = 0;
+  injected.lstatSync = (value, ...args) => {
+    if (value === file && ++observations === 2) {
+      fs.unlinkSync(file);
+      const error = new Error('simulated disappearance');
+      error.code = 'ENOENT';
+      throw error;
+    }
+    return fs.lstatSync(value, ...args);
+  };
+  assert.throws(() => new ActiveContextSwitchJournalStore({
+    filePath: file,
+    fileSystem: injected,
+  }).read(), /disappeared after observation/u);
+
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, '{}', { mode: 0o600 });
+  assert.throws(() => base.read(), /journal is invalid/u);
+});
+
+test('simulated Windows store protects and verifies every journal generation', (t) => {
+  const { file } = fixture(t);
+  const protectedPaths = [];
+  const verifiedPaths = [];
+  const windowsAcl = {
+    protect(value) { protectedPaths.push(value); return true; },
+    verify(value) { verifiedPaths.push(value); return fs.existsSync(value); },
+  };
+  const store = new ActiveContextSwitchJournalStore({
+    filePath: file,
+    platform: 'win32',
+    windowsAcl,
+  });
+  const first = prepared();
+  store.prepare(first);
+  store.markReady(ready(first));
+  store.commit(committed(ready(first)));
+  assert.equal(store.read().state, 'committed');
+  assert.equal(protectedPaths.includes(file), true);
+  assert.equal(protectedPaths.filter((value) => value.endsWith('.tmp')).length, 2);
+  assert.equal(verifiedPaths.filter((value) => value === file).length >= 4, true);
+});
+
+test('store path is absolute and Windows ACL failure removes a new journal', (t) => {
+  assert.throws(() => new ActiveContextSwitchJournalStore({ filePath: 'relative.json' }),
+    /absolute/u);
+  const { file } = fixture(t);
+  const store = new ActiveContextSwitchJournalStore({
+    filePath: file,
+    platform: 'win32',
+    windowsAcl: { protect: () => false, verify: () => false },
+  });
+  assert.throws(() => store.prepare(prepared()), /prepare failed/u);
+  assert.equal(fs.existsSync(file), false);
+});


### PR DESCRIPTION
## 目标

为 P4 的 Profile/Account 切换建立 crash-authoritative、owner-only 的持久化 journal。生产仍只允许 HKUST/primary；本 PR 不添加学校选择器、第二账号或自定义 Gateway。

本 PR 堆叠在 #27 之上。

## 核心契约

- 精确绑定 source/destination Profile、Account、Workspace 的 opaque keys 与 revisions。
- 使用单调 `nextActiveContextEpoch`；任何 epoch 回退、Profile 漂移、Account/Workspace 复用均 fail closed。
- 绑定旧 Engine generation，以及 GlobalSettings 切换前/后的 SHA-256 receipts。
- 明确记录 Browser workspace、continuations、Engine cleanup、proxy access、server state 和 destination validation 的结果。
- 状态只能 `prepared → ready → committed`，不能跳步、回退或用另一个 switch identity 覆盖。
- `committed` 是唯一 activation marker；未提交 journal 不能被清除。
- owner-only 原子写入、文件与目录 fsync、POSIX link/permission 检查和 Windows ACL 验证。
- rename 前失败保留上一代；rename 后 durability 不确定时必须重读并精确匹配。

## 验证

- 新增 13 个 journal/store 测试：Profile switch、Account switch、Engine-free switch、identity/epoch/schema tamper、entropy zeroization、状态跳步、并发 identity、symlink/hardlink/permission、rename/fsync fault、disappearance、Windows ACL。
- Desktop 全量：754 passed，0 failed，1 Windows-only skipped。
- Architecture：0 cycles；Main 依赖/行数未增长。
- 全部 JS syntax、secret gate、npm audit：通过。

## 后续

P4b 将以该 journal 为唯一 crash authority，组合 gate/cancel/Engine cleanup/destination validation/GlobalSettings activation 与恢复逻辑；P4c 再把 active-context epoch 接入 Engine、Browser、health、route 和 MFA stale-event guards。
