### PR TITLE
2.0 P4b: coordinate recoverable active-context switches

### DIFF
--- a/desktop/lib/active-context-switch-coordinator.js
+++ b/desktop/lib/active-context-switch-coordinator.js
@@ -1,0 +1,285 @@
+'use strict';
+
+const {
+  commitActiveContextSwitch,
+  createPreparedActiveContextSwitch,
+  markActiveContextSwitchReady,
+  validateActiveContextSwitchJournal,
+} = require('./active-context-switch-journal');
+
+class ActiveContextSwitchError extends Error {
+  constructor(code, stage, cause = null) {
+    super(`active context switch blocked at ${stage}`, cause ? { cause } : undefined);
+    this.name = 'ActiveContextSwitchError';
+    this.code = code;
+    this.stage = stage;
+  }
+}
+
+function sameReceipt(value, expected) {
+  return Boolean(value && typeof value === 'object' && value.present === true &&
+    value.bytes === expected.bytes && value.sha256 === expected.sha256);
+}
+
+function sameDocument(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function requiredFunction(value, name) {
+  if (typeof value !== 'function') throw new TypeError(`${name} must be a function`);
+  return value;
+}
+
+class ActiveContextSwitchCoordinator {
+  constructor({
+    journalStore,
+    readActivationReceipt,
+    applyActivation,
+    gateBrowser,
+    validateSource,
+    cancelContinuations,
+    closeBrowserWorkspace,
+    stopEngine,
+    revokeProxyAccess,
+    clearServerState,
+    validateDestination,
+    activateRuntime,
+    createPrepared = createPreparedActiveContextSwitch,
+    markReady = markActiveContextSwitchReady,
+    commit = commitActiveContextSwitch,
+  } = {}) {
+    if (!journalStore || typeof journalStore.read !== 'function' ||
+        typeof journalStore.prepare !== 'function' ||
+        typeof journalStore.markReady !== 'function' ||
+        typeof journalStore.commit !== 'function' ||
+        typeof journalStore.clearCommitted !== 'function') {
+      throw new TypeError('active context switch journal store is invalid');
+    }
+    this.journalStore = journalStore;
+    this.readActivationReceipt = requiredFunction(
+      readActivationReceipt,
+      'readActivationReceipt',
+    );
+    this.applyActivation = requiredFunction(applyActivation, 'applyActivation');
+    this.gateBrowser = requiredFunction(gateBrowser, 'gateBrowser');
+    this.validateSource = requiredFunction(validateSource, 'validateSource');
+    this.cancelContinuations = requiredFunction(cancelContinuations, 'cancelContinuations');
+    this.closeBrowserWorkspace = requiredFunction(
+      closeBrowserWorkspace,
+      'closeBrowserWorkspace',
+    );
+    this.stopEngine = requiredFunction(stopEngine, 'stopEngine');
+    this.revokeProxyAccess = requiredFunction(revokeProxyAccess, 'revokeProxyAccess');
+    this.clearServerState = requiredFunction(clearServerState, 'clearServerState');
+    this.validateDestination = requiredFunction(validateDestination, 'validateDestination');
+    this.activateRuntime = requiredFunction(activateRuntime, 'activateRuntime');
+    this.createPrepared = requiredFunction(createPrepared, 'createPrepared');
+    this.markReady = requiredFunction(markReady, 'markReady');
+    this.commit = requiredFunction(commit, 'commit');
+    this.running = false;
+  }
+
+  begin(request) {
+    return this.#singleFlight(async () => {
+      if (this.journalStore.read() !== null) {
+        throw new ActiveContextSwitchError(
+          'ACTIVE_CONTEXT_SWITCH_ALREADY_PENDING',
+          'prepare',
+        );
+      }
+      const prepared = validateActiveContextSwitchJournal(this.createPrepared(request));
+      let result;
+      try { result = this.journalStore.prepare(prepared); }
+      catch (error) {
+        throw new ActiveContextSwitchError(
+          'ACTIVE_CONTEXT_SWITCH_PREPARE_FAILED',
+          'prepare',
+          error,
+        );
+      }
+      if (!result || result.prepared !== true) {
+        throw new ActiveContextSwitchError(
+          'ACTIVE_CONTEXT_SWITCH_PREPARE_UNCONFIRMED',
+          'prepare',
+        );
+      }
+      const observed = this.journalStore.read();
+      if (!sameDocument(observed, prepared)) {
+        throw new ActiveContextSwitchError(
+          'ACTIVE_CONTEXT_SWITCH_PREPARE_UNCONFIRMED',
+          'prepare',
+        );
+      }
+      return this.#resumePrepared(prepared);
+    });
+  }
+
+  recover() {
+    return this.#singleFlight(async () => {
+      let journal;
+      try { journal = this.journalStore.read(); }
+      catch (error) {
+        throw new ActiveContextSwitchError(
+          'ACTIVE_CONTEXT_SWITCH_JOURNAL_UNREADABLE',
+          'recover',
+          error,
+        );
+      }
+      if (journal === null) return Object.freeze({ ok: true, status: 'none' });
+      if (journal.state === 'prepared') return this.#resumePrepared(journal);
+      if (journal.state === 'ready') return this.#activateReady(journal);
+      if (journal.state === 'committed') return this.#finishCommitted(journal);
+      throw new ActiveContextSwitchError(
+        'ACTIVE_CONTEXT_SWITCH_JOURNAL_UNSUPPORTED',
+        'recover',
+      );
+    });
+  }
+
+  async #resumePrepared(journal) {
+    await this.#requireStep('browser-gate', this.gateBrowser, journal);
+    this.#requireActivationReceipt(journal.activation.before, 'source-authority');
+    await this.#requireStep('source-validation', this.validateSource, journal);
+    await this.#requireStep('continuation-cancel', this.cancelContinuations, journal);
+    await this.#requireStep('browser-close', this.closeBrowserWorkspace, journal);
+    await this.#requireStep('engine-stop', this.stopEngine, journal);
+    await this.#requireStep('proxy-revoke', this.revokeProxyAccess, journal);
+    await this.#requireStep('server-state-clear', this.clearServerState, journal);
+    await this.#requireStep('destination-validation', this.validateDestination, journal);
+
+    const ready = validateActiveContextSwitchJournal(this.markReady(journal));
+    let result;
+    try { result = this.journalStore.markReady(ready); }
+    catch (error) {
+      throw new ActiveContextSwitchError(
+        'ACTIVE_CONTEXT_SWITCH_READY_FAILED',
+        'ready',
+        error,
+      );
+    }
+    if (!result || result.ready !== true || !sameDocument(this.journalStore.read(), ready)) {
+      throw new ActiveContextSwitchError(
+        'ACTIVE_CONTEXT_SWITCH_READY_UNCONFIRMED',
+        'ready',
+      );
+    }
+    return this.#activateReady(ready);
+  }
+
+  async #activateReady(journal) {
+    const observed = this.#activationReceipt();
+    if (sameReceipt(observed, journal.activation.before)) {
+      try {
+        if (await this.applyActivation(journal) !== true) {
+          throw new Error('activation callback did not confirm its commit');
+        }
+      } catch (error) {
+        throw new ActiveContextSwitchError(
+          'ACTIVE_CONTEXT_SWITCH_ACTIVATION_FAILED',
+          'activation',
+          error,
+        );
+      }
+      this.#requireActivationReceipt(journal.activation.after, 'activation');
+    } else if (!sameReceipt(observed, journal.activation.after)) {
+      throw new ActiveContextSwitchError(
+        'ACTIVE_CONTEXT_SWITCH_ACTIVATION_AMBIGUOUS',
+        'activation',
+      );
+    }
+
+    const committed = validateActiveContextSwitchJournal(this.commit(journal));
+    let result;
+    try { result = this.journalStore.commit(committed); }
+    catch (error) {
+      throw new ActiveContextSwitchError(
+        'ACTIVE_CONTEXT_SWITCH_COMMIT_FAILED',
+        'commit',
+        error,
+      );
+    }
+    if (!result || result.committed !== true ||
+        !sameDocument(this.journalStore.read(), committed)) {
+      throw new ActiveContextSwitchError(
+        'ACTIVE_CONTEXT_SWITCH_COMMIT_UNCONFIRMED',
+        'commit',
+      );
+    }
+    return this.#finishCommitted(committed);
+  }
+
+  async #finishCommitted(journal) {
+    this.#requireActivationReceipt(journal.activation.after, 'committed-authority');
+    try {
+      if (this.journalStore.clearCommitted() !== true) {
+        throw new Error('committed journal was not cleared');
+      }
+    } catch (error) {
+      throw new ActiveContextSwitchError(
+        'ACTIVE_CONTEXT_SWITCH_CLEAR_FAILED',
+        'clear',
+        error,
+      );
+    }
+    await this.#requireStep('runtime-activation', this.activateRuntime, journal);
+    return Object.freeze({
+      ok: true,
+      status: 'activated',
+      switchId: journal.switchId,
+      kind: journal.kind,
+      activeContextEpoch: journal.nextActiveContextEpoch,
+    });
+  }
+
+  #activationReceipt() {
+    try { return this.readActivationReceipt(); }
+    catch (error) {
+      throw new ActiveContextSwitchError(
+        'ACTIVE_CONTEXT_SWITCH_AUTHORITY_UNREADABLE',
+        'authority-read',
+        error,
+      );
+    }
+  }
+
+  #requireActivationReceipt(expected, stage) {
+    if (!sameReceipt(this.#activationReceipt(), expected)) {
+      throw new ActiveContextSwitchError(
+        'ACTIVE_CONTEXT_SWITCH_AUTHORITY_MISMATCH',
+        stage,
+      );
+    }
+  }
+
+  async #requireStep(stage, operation, journal) {
+    try {
+      if (await operation(journal) !== true) {
+        throw new Error(`${stage} did not confirm completion`);
+      }
+    } catch (error) {
+      throw new ActiveContextSwitchError(
+        `ACTIVE_CONTEXT_SWITCH_${stage.replaceAll('-', '_').toUpperCase()}_FAILED`,
+        stage,
+        error,
+      );
+    }
+  }
+
+  #singleFlight(operation) {
+    if (this.running) {
+      return Promise.reject(new ActiveContextSwitchError(
+        'ACTIVE_CONTEXT_SWITCH_ALREADY_RUNNING',
+        'single-flight',
+      ));
+    }
+    this.running = true;
+    return Promise.resolve()
+      .then(operation)
+      .finally(() => { this.running = false; });
+  }
+}
+
+module.exports = {
+  ActiveContextSwitchCoordinator,
+  ActiveContextSwitchError,
+};

--- a/desktop/test/active-context-switch-coordinator.test.js
+++ b/desktop/test/active-context-switch-coordinator.test.js
@@ -1,0 +1,276 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  ActiveContextSwitchCoordinator,
+} = require('../lib/active-context-switch-coordinator');
+const {
+  commitActiveContextSwitch,
+  createPreparedActiveContextSwitch,
+  markActiveContextSwitchReady,
+} = require('../lib/active-context-switch-journal');
+const {
+  ActiveContextSwitchJournalStore,
+} = require('../lib/active-context-switch-store');
+
+function key(name, seed) { return `${name}-${String(seed).repeat(32)}`; }
+
+function context(profileId, profileSeed, accountSeed, workspaceSeed, epoch = 1) {
+  return {
+    profileId,
+    profileKey: key('profile', profileSeed),
+    profileRevision: 1,
+    profileCredentialBindingRevision: 1,
+    accountKey: key('account', accountSeed),
+    accountRevision: 1,
+    accountCredentialRevision: 1,
+    workspaceKey: key('workspace', workspaceSeed),
+    activeContextEpoch: epoch,
+  };
+}
+
+function receipt(seed) {
+  return { present: true, bytes: seed + 100, sha256: seed.toString(16).padStart(64, '0') };
+}
+
+function switchRequest(overrides = {}) {
+  return {
+    from: context('school-a', '1', '2', '3', 3),
+    to: context('school-b', '4', '5', '6', 1),
+    engineGeneration: 8,
+    activation: { before: receipt(1), after: receipt(2) },
+    randomBytes: () => Buffer.alloc(16, 0xaa),
+    now: () => 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function fixture(t, overrides = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'active-context-coordinator-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const store = new ActiveContextSwitchJournalStore({
+    filePath: path.join(root, 'global', 'active-context-switch.json'),
+  });
+  let currentReceipt = overrides.currentReceipt || receipt(1);
+  const calls = [];
+  const outcomes = {
+    gateBrowser: true,
+    validateSource: true,
+    cancelContinuations: true,
+    closeBrowserWorkspace: true,
+    stopEngine: true,
+    revokeProxyAccess: true,
+    clearServerState: true,
+    validateDestination: true,
+    activateRuntime: true,
+    ...overrides.outcomes,
+  };
+  const operation = (name) => async (journal) => {
+    calls.push([name, journal.state, journal.switchId]);
+    const value = outcomes[name];
+    return typeof value === 'function' ? value(journal) : value;
+  };
+  const coordinator = new ActiveContextSwitchCoordinator({
+    journalStore: store,
+    readActivationReceipt: () => currentReceipt,
+    applyActivation: async (journal) => {
+      calls.push(['applyActivation', journal.state, journal.switchId]);
+      const value = outcomes.applyActivation;
+      if (typeof value === 'function') return value(journal, (next) => { currentReceipt = next; });
+      if (value === false) return false;
+      currentReceipt = journal.activation.after;
+      return true;
+    },
+    gateBrowser: operation('gateBrowser'),
+    validateSource: operation('validateSource'),
+    cancelContinuations: operation('cancelContinuations'),
+    closeBrowserWorkspace: operation('closeBrowserWorkspace'),
+    stopEngine: operation('stopEngine'),
+    revokeProxyAccess: operation('revokeProxyAccess'),
+    clearServerState: operation('clearServerState'),
+    validateDestination: operation('validateDestination'),
+    activateRuntime: operation('activateRuntime'),
+    markReady: (journal) => markActiveContextSwitchReady(journal, {
+      now: () => journal.createdAt + 100,
+    }),
+    commit: (journal) => commitActiveContextSwitch(journal, {
+      now: () => journal.readyAt + 100,
+    }),
+  });
+  return {
+    store,
+    coordinator,
+    calls,
+    receipt: () => currentReceipt,
+    setReceipt: (value) => { currentReceipt = value; },
+    outcomes,
+  };
+}
+
+test('clean switch gates old context before one activation and clears its journal', async (t) => {
+  const value = fixture(t);
+  const result = await value.coordinator.begin(switchRequest());
+  assert.deepEqual(result, {
+    ok: true,
+    status: 'activated',
+    switchId: `switch-${'aa'.repeat(16)}`,
+    kind: 'profile',
+    activeContextEpoch: 4,
+  });
+  assert.deepEqual(value.calls.map(([name]) => name), [
+    'gateBrowser',
+    'validateSource',
+    'cancelContinuations',
+    'closeBrowserWorkspace',
+    'stopEngine',
+    'revokeProxyAccess',
+    'clearServerState',
+    'validateDestination',
+    'applyActivation',
+    'activateRuntime',
+  ]);
+  assert.deepEqual(value.receipt(), receipt(2));
+  assert.equal(value.store.read(), null);
+});
+
+test('failed cleanup leaves prepared authority gated and a later recovery resumes idempotently', async (t) => {
+  const value = fixture(t, { outcomes: { stopEngine: false } });
+  await assert.rejects(value.coordinator.begin(switchRequest()), (error) => (
+    error.code === 'ACTIVE_CONTEXT_SWITCH_ENGINE_STOP_FAILED'
+  ));
+  assert.equal(value.store.read().state, 'prepared');
+  assert.deepEqual(value.receipt(), receipt(1));
+  assert.equal(value.calls.some(([name]) => name === 'applyActivation'), false);
+
+  value.outcomes.stopEngine = true;
+  const recovered = await value.coordinator.recover();
+  assert.equal(recovered.status, 'activated');
+  assert.equal(value.calls.filter(([name]) => name === 'gateBrowser').length, 2);
+  assert.equal(value.store.read(), null);
+});
+
+test('ready journal recovers both before-activation and after-activation crash points', async (t) => {
+  for (const alreadyApplied of [false, true]) {
+    const value = fixture(t, { currentReceipt: alreadyApplied ? receipt(2) : receipt(1) });
+    const prepared = createPreparedActiveContextSwitch(switchRequest());
+    const ready = markActiveContextSwitchReady(prepared, { now: () => 1_700_000_000_100 });
+    value.store.prepare(prepared);
+    value.store.markReady(ready);
+    const result = await value.coordinator.recover();
+    assert.equal(result.status, 'activated');
+    assert.equal(
+      value.calls.filter(([name]) => name === 'applyActivation').length,
+      alreadyApplied ? 0 : 1,
+    );
+    assert.equal(value.calls.some(([name]) => name === 'gateBrowser'), false);
+    assert.equal(value.store.read(), null);
+  }
+});
+
+test('activation callback uncertainty remains ready and recovery proves the visible receipt', async (t) => {
+  const value = fixture(t, {
+    outcomes: {
+      applyActivation(journal, setReceipt) {
+        setReceipt(journal.activation.after);
+        throw new Error('synthetic crash after activation rename');
+      },
+    },
+  });
+  await assert.rejects(value.coordinator.begin(switchRequest()), (error) => (
+    error.code === 'ACTIVE_CONTEXT_SWITCH_ACTIVATION_FAILED'
+  ));
+  assert.equal(value.store.read().state, 'ready');
+  assert.deepEqual(value.receipt(), receipt(2));
+  assert.equal(value.calls.some(([name]) => name === 'activateRuntime'), false);
+  value.outcomes.applyActivation = true;
+  assert.equal((await value.coordinator.recover()).status, 'activated');
+});
+
+test('committed recovery requires new authority before clearing and runtime activation', async (t) => {
+  const value = fixture(t, { currentReceipt: receipt(2) });
+  const prepared = createPreparedActiveContextSwitch(switchRequest());
+  const ready = markActiveContextSwitchReady(prepared, { now: () => 1_700_000_000_100 });
+  const committed = commitActiveContextSwitch(ready, { now: () => 1_700_000_000_200 });
+  value.store.prepare(prepared);
+  value.store.markReady(ready);
+  value.store.commit(committed);
+  assert.equal((await value.coordinator.recover()).status, 'activated');
+  assert.deepEqual(value.calls.map(([name]) => name), ['activateRuntime']);
+  assert.equal(value.store.read(), null);
+});
+
+test('journal clear uncertainty keeps committed authority gated until recovery', async (t) => {
+  const value = fixture(t);
+  const clearCommitted = value.store.clearCommitted.bind(value.store);
+  value.store.clearCommitted = () => { throw new Error('synthetic clear failure'); };
+  await assert.rejects(value.coordinator.begin(switchRequest()), (error) => (
+    error.code === 'ACTIVE_CONTEXT_SWITCH_CLEAR_FAILED'
+  ));
+  assert.equal(value.store.read().state, 'committed');
+  assert.equal(value.calls.some(([name]) => name === 'activateRuntime'), false);
+  value.store.clearCommitted = clearCommitted;
+  assert.equal((await value.coordinator.recover()).status, 'activated');
+});
+
+test('ambiguous authority gates Browser but never cleans or activates either context', async (t) => {
+  const value = fixture(t, { currentReceipt: receipt(99) });
+  const prepared = createPreparedActiveContextSwitch(switchRequest());
+  value.store.prepare(prepared);
+  await assert.rejects(value.coordinator.recover(), (error) => (
+    error.code === 'ACTIVE_CONTEXT_SWITCH_AUTHORITY_MISMATCH'
+  ));
+  assert.deepEqual(value.calls.map(([name]) => name), ['gateBrowser']);
+  assert.equal(value.store.read().state, 'prepared');
+});
+
+test('single-flight rejects a concurrent switch while the old Browser gate is pending', async (t) => {
+  let release;
+  const waiting = new Promise((resolve) => { release = resolve; });
+  const value = fixture(t, {
+    outcomes: { gateBrowser: async () => { await waiting; return true; } },
+  });
+  const first = value.coordinator.begin(switchRequest());
+  await new Promise((resolve) => setImmediate(resolve));
+  await assert.rejects(value.coordinator.recover(), (error) => (
+    error.code === 'ACTIVE_CONTEXT_SWITCH_ALREADY_RUNNING'
+  ));
+  release();
+  assert.equal((await first).status, 'activated');
+});
+
+test('100 alternating synthetic Profile switches retain one authority and no journal residue', async (t) => {
+  const value = fixture(t);
+  let active = context('school-a', '1', '2', '3', 1);
+  const stored = {
+    'school-a': active,
+    'school-b': context('school-b', '4', '5', '6', 1),
+  };
+  let receiptSeed = 1;
+  value.setReceipt(receipt(receiptSeed));
+  value.outcomes.activateRuntime = (journal) => {
+    active = { ...journal.to, activeContextEpoch: journal.nextActiveContextEpoch };
+    stored[active.profileId] = active;
+    return true;
+  };
+  for (let index = 0; index < 100; index++) {
+    const destinationId = active.profileId === 'school-a' ? 'school-b' : 'school-a';
+    const nextReceipt = receipt(++receiptSeed);
+    const result = await value.coordinator.begin({
+      from: active,
+      to: stored[destinationId],
+      nextActiveContextEpoch: index + 2,
+      engineGeneration: index % 2 === 0 ? index + 1 : null,
+      activation: { before: value.receipt(), after: nextReceipt },
+    });
+    assert.equal(result.activeContextEpoch, index + 2);
+    assert.equal(active.profileId, destinationId);
+    assert.equal(value.store.read(), null);
+  }
+  assert.equal(active.activeContextEpoch, 101);
+  assert.equal(value.calls.filter(([name]) => name === 'activateRuntime').length, 100);
+  assert.equal(value.calls.filter(([name]) => name === 'applyActivation').length, 100);
+});


### PR DESCRIPTION
## 目标

在 #28 的持久 switch journal 之上实现异步、single-flight、crash-recoverable 的 ActiveContextSwitchCoordinator。生产仍只选择 HKUST/primary；本 PR 不添加第二学校或切换 UI。

## 顺序与不变量

```text
prepare durable journal
→ gate old Browser
→ prove source GlobalSettings receipt and source context
→ cancel continuations
→ close old Browser workspace
→ confirm old Engine stop
→ revoke proxy/helper access
→ clear old server state
→ validate destination
→ persist ready
→ atomically apply active Profile/Account pair
→ persist committed
→ clear committed journal
→ activate destination runtime
```

- 每一步必须显式返回 `true`，异常或不确定结果都保持 fail closed。
- `prepared + before receipt` 可幂等恢复清理；其他 source authority 组合只关闭 Browser，不触发清理/激活。
- `ready + before receipt` 重做 activation；`ready + after receipt` 证明 rename 后崩溃并继续 commit。
- `committed + after receipt` 才能清 journal 并激活 runtime。
- receipt 不匹配、journal 不可读、清理未确认或 journal 清理失败均不会启动 destination runtime。
- 并发 begin/recover 被 single-flight 拒绝。

## 验证

- 新增 9 个 coordinator 测试。
- 覆盖 Engine cleanup 失败恢复、activation rename 后崩溃、journal clear 失败、ambiguous authority、single-flight。
- 100 次 A/B synthetic Profile 交替：每次只有一个 activation authority，journal residue 为 0。
- Desktop 全量：763 passed，0 failed，1 Windows-only skipped。
- Architecture 与全部 JS syntax：通过；Main 无增长。

## 后续

P4c 将增加 Main-owned active-context lease，把 profile/account/context epoch 与 connection intent、Engine generation 共同绑定，并接入 Engine、health、route、Browser 与 MFA 的 stale callback rejection。
