### PR TITLE
2.0 P4c: bind Engine lifecycle to active-context leases

### DIFF
--- a/desktop/lib/active-context-lease.js
+++ b/desktop/lib/active-context-lease.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const util = require('node:util');
+const {
+  validateAccountHandle,
+  validateProfileId,
+} = require('./school-profile-schema');
+
+function plainObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+  return value;
+}
+
+function exactKeys(value, keys, name) {
+  const source = plainObject(value, name);
+  const actual = Object.keys(source).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length ||
+      actual.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${name} has an invalid schema`);
+  }
+  return source;
+}
+
+function positive(value, name) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function binding(value) {
+  const source = exactKeys(value, [
+    'profileId', 'profileRevision', 'accountHandle', 'activeContextEpoch',
+  ], 'active context binding');
+  return Object.freeze({
+    profileId: validateProfileId(source.profileId),
+    profileRevision: positive(source.profileRevision, 'profileRevision'),
+    accountHandle: validateAccountHandle(source.accountHandle),
+    activeContextEpoch: positive(source.activeContextEpoch, 'activeContextEpoch'),
+  });
+}
+
+function lifecycle(value) {
+  const source = exactKeys(value, [
+    'connectionIntent', 'engineGeneration',
+  ], 'active context lifecycle');
+  return Object.freeze({
+    connectionIntent: positive(source.connectionIntent, 'connectionIntent'),
+    engineGeneration: positive(source.engineGeneration, 'engineGeneration'),
+  });
+}
+
+function sameContext(left, right) {
+  return left.profileId === right.profileId &&
+    left.profileRevision === right.profileRevision &&
+    left.accountHandle === right.accountHandle &&
+    left.activeContextEpoch === right.activeContextEpoch;
+}
+
+function redactedToken() {
+  return Object.freeze({
+    toJSON: () => '[active context token]',
+    toString: () => '[active context token]',
+    [util.inspect.custom]: () => '[active context token]',
+  });
+}
+
+class ActiveContextLease {
+  #current = null;
+  #epochFloor = 0;
+  #tokens = new WeakMap();
+
+  constructor(initialBinding) {
+    this.activate(initialBinding);
+  }
+
+  snapshot() {
+    return this.#current;
+  }
+
+  capture(lifecycleValue) {
+    if (this.#current === null) throw new Error('active context is gated');
+    const token = redactedToken();
+    this.#tokens.set(token, Object.freeze({
+      context: this.#current,
+      lifecycle: lifecycle(lifecycleValue),
+    }));
+    return token;
+  }
+
+  isCurrent(token, lifecycleValue) {
+    if (this.#current === null || !token || typeof token !== 'object') return false;
+    const observed = this.#tokens.get(token);
+    if (!observed || !sameContext(observed.context, this.#current)) return false;
+    let currentLifecycle;
+    try { currentLifecycle = lifecycle(lifecycleValue); }
+    catch { return false; }
+    return observed.lifecycle.connectionIntent === currentLifecycle.connectionIntent &&
+      observed.lifecycle.engineGeneration === currentLifecycle.engineGeneration;
+  }
+
+  invalidate() {
+    if (this.#current === null) return false;
+    this.#epochFloor = Math.max(this.#epochFloor, this.#current.activeContextEpoch);
+    this.#current = null;
+    return true;
+  }
+
+  activate(value) {
+    const next = binding(value);
+    const floor = this.#current === null
+      ? this.#epochFloor
+      : Math.max(this.#epochFloor, this.#current.activeContextEpoch);
+    if (next.activeContextEpoch <= floor) {
+      throw new TypeError('active context epoch must increase monotonically');
+    }
+    this.#epochFloor = next.activeContextEpoch;
+    this.#current = next;
+    return this.#current;
+  }
+}
+
+module.exports = { ActiveContextLease };

--- a/desktop/lib/connection-state-machine.js
+++ b/desktop/lib/connection-state-machine.js
@@ -2,6 +2,7 @@
 
 const { planReconnect } = require('./reconnect-policy');
 const { ConnectionWaitRegistry } = require('./connection-wait-registry');
+const { ActiveContextLease } = require('./active-context-lease');
 
 const CONNECTION_PHASE = Object.freeze({
   IDLE: 'idle',
@@ -325,6 +326,7 @@ class ConnectionStateMachine {
 }
 
 module.exports = {
+  ActiveContextLease,
   CONNECTION_PHASE,
   ConnectionWaitRegistry,
   ConnectionStateMachine,

--- a/desktop/lib/school-profile-controller.js
+++ b/desktop/lib/school-profile-controller.js
@@ -59,6 +59,12 @@ function createSchoolProfileController(options = {}) {
     browserHomeUrl: profile.browser.homeUrl,
     healthTargets: profile.browser.healthTargets,
     builtInResourceCount: builtInResources.length,
+    activeContextBinding: () => Object.freeze({
+      profileId: profile.profileId,
+      profileRevision: profile.profileRevision,
+      accountHandle,
+      activeContextEpoch,
+    }),
     withProfileDocument: (callback) => context.registry.withDefaultProfileDocument(callback),
     verifyEngineConfig: context.verifyEngineConfig,
     verifyEngineLaunchBinding() {

--- a/desktop/lib/school-profile-schema.js
+++ b/desktop/lib/school-profile-schema.js
@@ -567,6 +567,7 @@ module.exports = {
   createWorkspaceView,
   normalizeGatewayOrigin,
   validateOpaqueKey: opaqueKey,
+  validateAccountHandle: opaqueAccountHandle,
   validateProfileId,
   validateProtocolFamily,
   validateCampusAccountDocument,

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -76,7 +76,7 @@ const { createT, effectiveLocale } = require('./lib/i18n');
 const { registerTrustedIpcHandlers } = require('./lib/ipc-handlers');
 const { RoutingPolicyTransactionQueue } = require('./lib/routing-policy-transaction');
 const { stopEngineAfterBrowserSuspend } = require('./lib/browser-engine-barrier');
-const { ConnectionStateMachine, ConnectionWaitRegistry, projectConnectionStatus } = require('./lib/connection-state-machine');
+const { ActiveContextLease, ConnectionStateMachine, ConnectionWaitRegistry, projectConnectionStatus } = require('./lib/connection-state-machine');
 // The campus browser is intentionally constrained to the application's
 // proxy/PAC boundary. WebRTC data channels do not require camera or microphone
 // permission and Chromium may otherwise send ICE/STUN UDP directly, bypassing
@@ -104,7 +104,6 @@ if (!app.requestSingleInstanceLock()) {
   return;
 }
 app.setName('HKUST(GZ) Connect');
-
 // ---------- paths & state ----------
 const DATA = app.getPath('userData');
 const legacyRuntimeStoragePaths = createLegacyRuntimeStoragePaths(DATA);
@@ -115,6 +114,7 @@ const activeSchoolProfile = createSchoolProfileController({
   packageRoot: __dirname, isPackaged: app.isPackaged,
   resourcesPath: process.resourcesPath, desktopDir: __dirname,
 });
+const activeContextLease = new ActiveContextLease(activeSchoolProfile.activeContextBinding());
 const preReadyStorage = activeSchoolProfile.withProfileDocument((profile) => (
   selectProfileWorkspacePreReadyStorage({ userData: DATA, profile })
 ));
@@ -144,7 +144,6 @@ try { fs.unlinkSync(PROXY_HELPER_CREDENTIAL); } catch (error) {
 }
 const GATEWAY_HOST = syntheticEngineE2e ? '127.0.0.1' : activeSchoolProfile.gatewayHost;
 const GATEWAY_PORT = activeSchoolProfile.gatewayPort;
-
 const credentialTransactionPaths = Object.freeze({
   settings: SETTINGS,
   settingsBackup: `${SETTINGS}.bak`,
@@ -157,7 +156,6 @@ let credentialTransactionRecovery = preReadyStorage.mode === 'legacy-flat'
   ? recoverCredentialSettingsTransaction(CREDENTIAL_TRANSACTION, credentialTransactionPaths)
   : { ok: true, status: 'none' };
 let credentialTransactionBlocked = credentialTransactionRecovery.status === 'blocked';
-
 for (const privateFile of [
   SETTINGS, CRED, LOG, PAC_FILE, CAMPUS_BROWSER_PAC_FILE, ROUTING_RULES,
   CAMPUS_CREDENTIALS, CAMPUS_CERTIFICATE_TRUST, ENGINE_OWNER,
@@ -628,10 +626,11 @@ async function connect(isRetry = false, expectedIntent = null) {
 }
 
 function handleEngineClose({ code, generation }, diagnosticTail,
-  structuredFatalCode = null, structuredStopReason = null, stoppedSocksPort = 1080) {
+  structuredFatalCode = null, structuredStopReason = null, stoppedSocksPort = 1080,
+  isCurrentContext = () => true) {
   // A delayed close from an already invalidated generation must not suspend a
   // newer listener that is now serving the browser.
-  const supervisorGenerationCurrent = engineSupervisor.isCurrent(generation);
+  const supervisorGenerationCurrent = engineSupervisor.isCurrent(generation) && isCurrentContext(generation);
   clearActiveEngineControl(generation);
   if (!cleanupProxyAccessForEngineClose({ generation, supervisorGenerationCurrent,
     connectionGenerationCurrent: connectionState.isCurrentGeneration(generation),
@@ -645,7 +644,6 @@ function handleEngineClose({ code, generation }, diagnosticTail,
     state.browserNotice = t('error.browserRoutingAfterSave', { message: error.message });
     emit();
   });
-
   const closeSnapshot = connectionState.snapshot(); const wasConnected = closeSnapshot.phase === 'connected' || closeSnapshot.wasConnectedBeforeStop;
   const uptime = Math.max(connectedAt ? Date.now() - connectedAt : 0, closeSnapshot.connectedUptimeBeforeStop);
   clearConnectionPresentation();
@@ -712,9 +710,9 @@ function handleEngineClose({ code, generation }, diagnosticTail,
   }
   emit();
 }
-function revokeEngineServing(generation) {
+function revokeEngineServing(generation, isCurrentContext = () => true) {
   const uptimeMs = connectedAt ? Date.now() - connectedAt : 0;
-  if (!engineSupervisor.isCurrent(generation) ||
+  if (!isCurrentContext(generation) || !engineSupervisor.isCurrent(generation) ||
       !connectionState.markEngineStopping(generation, { uptimeMs })) return false;
   // Its epoch and request gate synchronously defeat an awaiting activation.
   suspendOpenBrowserPolicy().catch((error) => {
@@ -723,10 +721,10 @@ function revokeEngineServing(generation) {
   });
   clearConnectionPresentation(); return true;
 }
-function handleEngineExitBoundary({ generation }) {
+function handleEngineExitBoundary({ generation }, isCurrentContext = () => true) {
   // `exit` can precede stdio close; revoke serving synchronously but retain the
   // generation so the terminal-only drain can classify fatal/stopped output.
-  if (!revokeEngineServing(generation)) return;
+  if (!revokeEngineServing(generation, isCurrentContext)) return;
   clearActiveEngineControl(generation);
   clearActiveProxyCredential(generation);
   removeExternalProxySidecar();
@@ -878,6 +876,9 @@ async function connectOnce(isRetry, intent) {
   let ownedEngine = null;
   let structuredFatalCode = null;
   let engineRuntime = null;
+  let engineContextToken = null;
+  const isCurrentEngineContext = (generation) => engineSupervisor.isCurrent(generation) &&
+    activeContextLease.isCurrent(engineContextToken, { connectionIntent: connectionState.snapshot().intent, engineGeneration: generation });
   connectionState.invalidateEngineGeneration();
   const expectedEngineGeneration = engineSupervisor.currentGeneration + 1;
   const engineArgs = [
@@ -895,12 +896,12 @@ async function connectOnce(isRetry, intent) {
     args: [...launch.argsPrefix, ...engineArgs],
     options: { stdio: ['pipe', 'pipe', 'pipe'], ...launch.options },
     onError: ({ error, generation }) => {
-      if (!engineSupervisor.isCurrent(generation)) return;
+      if (!isCurrentEngineContext(generation)) return;
       structuredFatalCode = 'EVENT_OUTPUT_FAILED';
       state.lastError = t('error.engineStart', { message: error.message });
       emit();
     },
-    onExit: (result) => { engineRuntime?.beginExitDrain(); handleEngineExitBoundary(result); },
+    onExit: (result) => { engineRuntime?.beginExitDrain(); handleEngineExitBoundary(result, isCurrentEngineContext); },
     onClose: (result) => {
       const structuredStopReason = engineRuntime?.stoppedReason || null;
       engineRuntime?.dispose();
@@ -910,7 +911,7 @@ async function connectOnce(isRetry, intent) {
         diagnosticTail,
         structuredFatalCode,
         structuredStopReason,
-        Number(s.port),
+        Number(s.port), isCurrentEngineContext,
       );
     },
   });
@@ -927,6 +928,7 @@ async function connectOnce(isRetry, intent) {
   const child = started.child;
   engineGeneration = started.generation;
   connectionState.bindEngineGeneration(engineGeneration);
+  engineContextToken = activeContextLease.capture({ connectionIntent: intent, engineGeneration });
   if (engineGeneration !== expectedEngineGeneration) {
     proxyCredential?.destroy();
     removeExternalProxySidecar();
@@ -954,10 +956,9 @@ async function connectOnce(isRetry, intent) {
     try { writeEngineOwnerRecord(ENGINE_OWNER, ownedEngine); } catch {}
   }
   let browserActivationInFlight = null;
-
   const finishConnected = () => {
     const wasConnected = connectionState.isConnected();
-    if (!engineSupervisor.isCurrent(engineGeneration) ||
+    if (!isCurrentEngineContext(engineGeneration) ||
         !connectionState.markConnected(engineGeneration)) return;
     state.lastError = null;
     if (!wasConnected) {
@@ -967,7 +968,7 @@ async function connectOnce(isRetry, intent) {
     emit();
   };
   const markConnected = () => {
-    if (!engineSupervisor.isCurrent(engineGeneration) ||
+    if (!isCurrentEngineContext(engineGeneration) ||
         !connectionState.isReadyToConnect(engineGeneration)) return;
     if (!campusBrowserManager.routingSuspended) {
       finishConnected();
@@ -981,7 +982,7 @@ async function connectOnce(isRetry, intent) {
       finishConnected();
     }).catch((error) => {
       if (browserActivationInFlight === activation) browserActivationInFlight = null;
-      if (!engineSupervisor.isCurrent(engineGeneration)) return;
+      if (!isCurrentEngineContext(engineGeneration)) return;
       // The engine is usable by authenticated external clients, while the
       // built-in browser deliberately remains behind its request gate.
       finishConnected();
@@ -989,10 +990,9 @@ async function connectOnce(isRetry, intent) {
       emit();
     });
   };
-
   const applyHumanDiagnostic = (chunk) => {
     diagnosticTail = (diagnosticTail + chunk).slice(-512);
-    if (!engineSupervisor.isCurrent(engineGeneration)) return;
+    if (!isCurrentEngineContext(engineGeneration)) return;
     const classifiedError = classifyEngineOutput(diagnosticTail, s.port, t);
     if (classifiedError) {
       state.lastError = classifiedError;
@@ -1004,14 +1004,14 @@ async function connectOnce(isRetry, intent) {
     expectedPort: Number(s.port),
     stdin: child.stdin,
     controlRegistry: engineControlRegistry,
-    isCurrent: (generation) => engineSupervisor.isCurrent(generation),
+    isCurrent: isCurrentEngineContext,
     handlers: {
       onDiagnostic: (event) => logWriter.append(formatEngineEventDiagnostic(event, { ...connectionState.snapshot(), generation: engineGeneration })),
       onConnecting: (engineState) => {
         if (!connectionState.markEnginePhase(engineGeneration, engineState)) return;
         emit();
       },
-      onStopping: () => { if (revokeEngineServing(engineGeneration)) emit(); },
+      onStopping: () => { if (revokeEngineServing(engineGeneration, isCurrentEngineContext)) emit(); },
       onConnectionCandidate: () => {
         connectionState.recordEngineConnectedCandidate(engineGeneration);
         markConnected();
@@ -1021,7 +1021,7 @@ async function connectOnce(isRetry, intent) {
         markConnected();
       },
       onListenerMismatch: () => {
-        revokeEngineServing(engineGeneration); structuredFatalCode = 'LOCAL_LISTENER_FAILED';
+        revokeEngineServing(engineGeneration, isCurrentEngineContext); structuredFatalCode = 'LOCAL_LISTENER_FAILED';
         state.lastError = classifyEngineCode(structuredFatalCode, s.port, t); emit();
         engineSupervisor.stop({ graceMs: 1000, forceWaitMs: STOP_FORCE_WAIT_MS }).catch(() => {});
       },
@@ -1035,14 +1035,14 @@ async function connectOnce(isRetry, intent) {
         emit();
       },
       onNetworkUnhealthy: () => {
-        revokeEngineServing(engineGeneration); state.lastError = t('error.tunnelRecovering'); emit();
+        revokeEngineServing(engineGeneration, isCurrentEngineContext); state.lastError = t('error.tunnelRecovering'); emit();
       },
       onFatalError: (code, secondaryCode) => {
-        revokeEngineServing(engineGeneration); structuredFatalCode = code;
+        revokeEngineServing(engineGeneration, isCurrentEngineContext); structuredFatalCode = code;
         state.lastError = classifyEngineCode(code, s.port, t, secondaryCode); emit();
       },
       onProtocolTimeout: () => {
-        revokeEngineServing(engineGeneration);
+        revokeEngineServing(engineGeneration, isCurrentEngineContext);
         structuredFatalCode = 'EVENT_OUTPUT_FAILED';
         state.lastError = classifyEngineCode(structuredFatalCode, s.port, t);
         emit();

--- a/desktop/test/active-context-lease.test.js
+++ b/desktop/test/active-context-lease.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { ActiveContextLease } = require('../lib/active-context-lease');
+
+function binding({
+  profileId = 'school-a',
+  profileRevision = 1,
+  accountSeed = 'a',
+  activeContextEpoch = 1,
+} = {}) {
+  return {
+    profileId,
+    profileRevision,
+    accountHandle: `account-${accountSeed.repeat(36)}`,
+    activeContextEpoch,
+  };
+}
+
+test('token requires the exact active context intent and Engine generation', () => {
+  const lease = new ActiveContextLease(binding());
+  const token = lease.capture({ connectionIntent: 3, engineGeneration: 7 });
+  assert.equal(lease.isCurrent(token, { connectionIntent: 3, engineGeneration: 7 }), true);
+  assert.equal(lease.isCurrent(token, { connectionIntent: 4, engineGeneration: 7 }), false);
+  assert.equal(lease.isCurrent(token, { connectionIntent: 3, engineGeneration: 8 }), false);
+  assert.equal(lease.isCurrent({}, { connectionIntent: 3, engineGeneration: 7 }), false);
+  assert.equal(JSON.stringify(token), '"[active context token]"');
+  assert.equal(String(token), '[active context token]');
+  assert.equal(JSON.stringify(token).includes('school-a'), false);
+});
+
+test('gating invalidates every borrowed token until a higher epoch activates', () => {
+  const lease = new ActiveContextLease(binding());
+  const old = lease.capture({ connectionIntent: 1, engineGeneration: 1 });
+  assert.equal(lease.invalidate(), true);
+  assert.equal(lease.invalidate(), false);
+  assert.equal(lease.snapshot(), null);
+  assert.equal(lease.isCurrent(old, { connectionIntent: 1, engineGeneration: 1 }), false);
+  assert.throws(() => lease.capture({ connectionIntent: 1, engineGeneration: 1 }), /gated/u);
+  assert.throws(() => lease.activate(binding()), /increase monotonically/u);
+
+  const current = lease.activate(binding({
+    profileId: 'school-b', accountSeed: 'b', activeContextEpoch: 2,
+  }));
+  assert.equal(current.profileId, 'school-b');
+  assert.equal(lease.isCurrent(old, { connectionIntent: 1, engineGeneration: 1 }), false);
+  const next = lease.capture({ connectionIntent: 2, engineGeneration: 2 });
+  assert.equal(lease.isCurrent(next, { connectionIntent: 2, engineGeneration: 2 }), true);
+});
+
+test('context binding is exact bounded and contains no persistent storage key', () => {
+  assert.throws(() => new ActiveContextLease({ ...binding(), accountKey: 'forbidden' }),
+    /invalid schema/u);
+  assert.throws(() => new ActiveContextLease(binding({ activeContextEpoch: 0 })), /positive/u);
+  assert.throws(() => new ActiveContextLease(binding({ accountSeed: '-' })), /opaque handle/u);
+  const lease = new ActiveContextLease(binding());
+  assert.throws(() => lease.capture({ connectionIntent: 0, engineGeneration: 1 }), /positive/u);
+});
+
+test('100 context activations reject every token from an older epoch', () => {
+  const lease = new ActiveContextLease(binding());
+  let token = lease.capture({ connectionIntent: 1, engineGeneration: 1 });
+  for (let epoch = 2; epoch <= 101; epoch++) {
+    const stale = token;
+    lease.invalidate();
+    lease.activate(binding({
+      profileId: epoch % 2 === 0 ? 'school-b' : 'school-a',
+      accountSeed: epoch % 2 === 0 ? 'b' : 'a',
+      activeContextEpoch: epoch,
+    }));
+    assert.equal(lease.isCurrent(stale, {
+      connectionIntent: epoch - 1,
+      engineGeneration: epoch - 1,
+    }), false);
+    token = lease.capture({ connectionIntent: epoch, engineGeneration: epoch });
+    assert.equal(lease.isCurrent(token, {
+      connectionIntent: epoch,
+      engineGeneration: epoch,
+    }), true);
+  }
+});

--- a/desktop/test/main-active-context-contract.test.js
+++ b/desktop/test/main-active-context-contract.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const source = fs.readFileSync(path.join(__dirname, '..', 'main.js'), 'utf8');
+
+function section(start, end) {
+  const from = source.indexOf(start);
+  const to = source.indexOf(end, from + start.length);
+  assert.ok(from >= 0 && to > from, `missing section ${start}`);
+  return source.slice(from, to);
+}
+
+test('Main creates one Profile-bound lease before persistence and connection services', () => {
+  const profile = source.indexOf('const activeSchoolProfile = createSchoolProfileController(');
+  const lease = source.indexOf(
+    'new ActiveContextLease(activeSchoolProfile.activeContextBinding())',
+  );
+  const storage = source.indexOf('const preReadyStorage =');
+  assert.ok(profile >= 0 && lease > profile && storage > lease);
+});
+
+test('Engine callbacks require context epoch connection intent and process generation', () => {
+  const connect = section('async function connectOnce(', '\nfunction ensureEngineStopped()');
+  assert.match(connect, /activeContextLease\.isCurrent\(engineContextToken, \{ connectionIntent: connectionState\.snapshot\(\)\.intent, engineGeneration: generation \}\)/u);
+  const capture = connect.indexOf('activeContextLease.capture({ connectionIntent: intent, engineGeneration })');
+  const bind = connect.indexOf('connectionState.bindEngineGeneration(engineGeneration)');
+  const runtime = connect.indexOf('new EngineConnectionRuntime({');
+  assert.ok(capture > bind && runtime > capture);
+  assert.match(connect, /isCurrent: isCurrentEngineContext/u);
+  assert.match(connect, /if \(!isCurrentEngineContext\(engineGeneration\)/u);
+  assert.match(connect, /handleEngineExitBoundary\(result, isCurrentEngineContext\)/u);
+  assert.match(connect, /Number\(s\.port\), isCurrentEngineContext,/u);
+  assert.match(connect, /revokeEngineServing\(engineGeneration, isCurrentEngineContext\)/u);
+  assert.doesNotMatch(connect, /activeContextEpoch:\s*1/u);
+});

--- a/desktop/test/main-engine-exit-boundary.test.js
+++ b/desktop/test/main-engine-exit-boundary.test.js
@@ -13,12 +13,13 @@ test('engine exit closes the browser request boundary before stdio close cleanup
   assert.ok(boundaryStart >= 0 && connectStart > boundaryStart);
   const boundary = source.slice(boundaryStart, connectStart);
   assert.match(boundary, /engineSupervisor\.isCurrent\(generation\)/);
+  assert.match(boundary, /isCurrentContext\(generation\)/);
   assert.match(boundary, /connectionState\.markEngineStopping\(generation, \{ uptimeMs \}\)/);
   assert.match(boundary, /clearActiveProxyCredential\(generation\)/);
   assert.match(boundary, /suspendOpenBrowserPolicy\(\)/);
 
   const startCall = source.slice(source.indexOf('const started = engineSupervisor.start({'));
-  assert.match(startCall, /onExit:\s*\(result\) => \{\s*engineRuntime\?\.beginExitDrain\(\);\s*handleEngineExitBoundary\(result\);\s*\},\s*onClose:/);
+  assert.match(startCall, /onExit:\s*\(result\) => \{\s*engineRuntime\?\.beginExitDrain\(\);\s*handleEngineExitBoundary\(result, isCurrentEngineContext\);\s*\},\s*onClose:/);
   assert.match(startCall, /const structuredStopReason = engineRuntime\?\.stoppedReason \|\| null;\s*engineRuntime\?\.dispose\(\)/);
 });
 
@@ -32,13 +33,14 @@ test('fatal, stopping, and exit boundaries revoke in-flight serving promotion', 
   assert.match(revoke, /clearConnectionPresentation\(\)/);
 
   const handlers = source.slice(source.indexOf('handlers: {', exitStart));
-  assert.match(handlers, /onStopping:.*revokeEngineServing\(engineGeneration\)/);
-  assert.match(handlers, /onListenerMismatch:[\s\S]*?revokeEngineServing\(engineGeneration\)[\s\S]*?engineSupervisor\.stop/);
-  assert.match(handlers, /onFatalError:[\s\S]*?revokeEngineServing\(engineGeneration\)/);
-  assert.match(handlers, /onProtocolTimeout:[\s\S]*?revokeEngineServing\(engineGeneration\)/);
+  assert.match(handlers, /onStopping:.*revokeEngineServing\(engineGeneration, isCurrentEngineContext\)/);
+  assert.match(handlers, /onListenerMismatch:[\s\S]*?revokeEngineServing\(engineGeneration, isCurrentEngineContext\)[\s\S]*?engineSupervisor\.stop/);
+  assert.match(handlers, /onFatalError:[\s\S]*?revokeEngineServing\(engineGeneration, isCurrentEngineContext\)/);
+  assert.match(handlers, /onProtocolTimeout:[\s\S]*?revokeEngineServing\(engineGeneration, isCurrentEngineContext\)/);
   const close = source.slice(source.indexOf('function handleEngineClose('), revokeStart);
   assert.match(close, /closeSnapshot\.wasConnectedBeforeStop/);
   assert.match(close, /closeSnapshot\.connectedUptimeBeforeStop/);
+  assert.match(close, /engineSupervisor\.isCurrent\(generation\) && isCurrentContext\(generation\)/);
   assert.match(close, /cleanupProxyAccessForEngineClose\(\{[\s\S]*generation,[\s\S]*supervisorGenerationCurrent,[\s\S]*connectionGenerationCurrent: connectionState\.isCurrentGeneration\(generation\),[\s\S]*clearCredential: clearActiveProxyCredential,[\s\S]*removeSidecar: removeExternalProxySidecar/);
   assert.match(close, /\}\)\) return;/);
 });

--- a/desktop/test/school-profile-controller.test.js
+++ b/desktop/test/school-profile-controller.test.js
@@ -52,6 +52,12 @@ test('composes the reviewed HKUST deployment without persistent account scope', 
     presentation.campusAccount.accountHandle,
   );
   assert.equal(presentation.workspace.persistentScope, false);
+  assert.deepEqual(profile.activeContextBinding(), {
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    accountHandle: presentation.campusAccount.accountHandle,
+    activeContextEpoch: 1,
+  });
   for (const forbidden of ['engineConfigRef', 'reviewedDnsFallback', 'accountKey', 'workspaceKey']) {
     assert.equal(JSON.stringify(presentation).includes(forbidden), false);
   }


### PR DESCRIPTION
## 目标

让生产 Engine 事件不再只依赖进程 generation，而是同时绑定 Main-owned Profile/Account context、activeContextEpoch、connection intent 和 Engine generation。

本 PR 堆叠在 #29 之上；仍只启用 HKUST/primary，不增加切换 UI。

## 设计

- 新增 `ActiveContextLease`：
  - context binding 只包含 reviewed profile identity、process-lifetime accountHandle 和 monotonic epoch；
  - 不接受 profileKey/accountKey/workspaceKey；
  - token 元数据保存在 WeakMap，不向日志/JSON暴露 Profile、Account、intent 或 generation；
  - gate 立即使所有 token 失效；新 context 必须使用更高 epoch。
- SchoolProfileController 提供当前受审 Profile 的 context binding。
- Main 为每个 Engine generation 捕获一个 token，并在每次判断时同时核对：
  - active Profile/Account/epoch；
  - 当前 connection intent；
  - EngineSupervisor generation。
- guard 覆盖 stdout/control、provider capabilities、readiness、fatal、network unhealthy、protocol timeout、Browser routing completion、process exit 与 close。
- stale close 仍可销毁其 generation-owned secret，但不能移除新 sidecar、修改新连接状态、重开 Browser 或安排重试。

## 验证

- ActiveContextLease：exact lifecycle、gate/activate、redacted token、schema rejection、100 epoch transitions。
- Main contract 强制 Engine start/exit/close/fatal paths携带 context guard。
- Desktop 全量：769 passed，0 failed，1 Windows-only skipped。
- 真实 Electron Main、Engine lifecycle、initially-offline、two-process migration：全部通过。
- Architecture：mainDeps=35、mainLines=1644、0 cycles；无 Main 债务增长。
- 全部 JS syntax 与 staged secret gate：通过。

## 后续

P4d 将把同一 lease 接入 health/telemetry/retry、routing transaction、Browser credential/certificate/navigation 和 MFA coordinator，并为 switch coordinator 组合真实 Main gate/invalidate hooks。
