### PR TITLE
2.0 P4d: bind health and recovery to active context

### DIFF
--- a/desktop/lib/connection-telemetry-coordinator.js
+++ b/desktop/lib/connection-telemetry-coordinator.js
@@ -100,6 +100,7 @@ class ConnectionTelemetryCoordinator {
       enumerator, runHealthRound, probe, ping,
     });
     this.generation = null;
+    this.contextToken = null;
     this.probeFailures = 0;
     this.recoveryInFlight = null;
     this.service = new TelemetryServiceClass({
@@ -122,17 +123,22 @@ class ConnectionTelemetryCoordinator {
 
   current(generation) {
     return this.generation === generation && this.isConnected() &&
-      this.isEngineCurrent(generation);
+      this.isEngineCurrent(generation, this.contextToken);
   }
 
-  start(generation) {
+  start(generation, contextToken) {
+    if (!contextToken || typeof contextToken !== 'object') {
+      throw new TypeError('telemetry active context token is required');
+    }
     this.stop();
     this.generation = generation;
+    this.contextToken = contextToken;
     this.service.start(generation);
   }
 
   stop() {
     this.generation = null;
+    this.contextToken = null;
     this.service.stop();
     this.probeFailures = 0;
     this.recoveryInFlight = null;
@@ -166,11 +172,15 @@ class ConnectionTelemetryCoordinator {
     if (!this.current(generation) || !this.isDesiredConnected()) {
       return { ...result, kind: 'stale' };
     }
-    const recovery = { generation };
+    const recovery = { generation, contextToken: this.contextToken };
     this.recoveryInFlight = recovery;
-    this.onRecovering();
+    if (!this.current(generation)) {
+      this.recoveryInFlight = null;
+      return { ...result, kind: 'stale' };
+    }
+    this.onRecovering(generation, recovery.contextToken);
     try {
-      await this.reconnect(generation);
+      await this.reconnect(generation, recovery.contextToken);
     } finally {
       if (this.recoveryInFlight === recovery) {
         this.probeFailures = 0;

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -197,6 +197,8 @@ const authChallengeCoordinator = new AuthChallengeCoordinator({
 });
 const engineControlRegistry = new EngineControlRegistry({ authChallenges: authChallengeCoordinator });
 const engineSupervisor = new EngineSupervisor({ spawnProcess: spawn });
+const activeEngineContextCurrent = (generation, token) => engineSupervisor.isCurrent(generation) &&
+  activeContextLease.isCurrent(token, { connectionIntent: connectionState.snapshot().intent, engineGeneration: generation });
 const routingPolicyTransactions = new RoutingPolicyTransactionQueue();
 let logWriter = null;
 function initializeLogWriter() {
@@ -624,7 +626,6 @@ async function connect(isRetry = false, expectedIntent = null) {
   try { return await operation; }
   finally { if (connectInFlight === record) connectInFlight = null; }
 }
-
 function handleEngineClose({ code, generation }, diagnosticTail,
   structuredFatalCode = null, structuredStopReason = null, stoppedSocksPort = 1080,
   isCurrentContext = () => true) {
@@ -680,12 +681,10 @@ function handleEngineClose({ code, generation }, diagnosticTail,
     uptimeMs: uptime,
     failureKind,
   });
-
   if (decision.action === 'settled' || decision.action === 'terminal') {
     emit();
     return;
   }
-
   // Only a genuinely stable session earns a fresh retry budget. Merely
   // opening SOCKS and then losing the data plane must keep counting, or a
   // rejecting gateway can drive the app into an infinite login loop.
@@ -877,8 +876,7 @@ async function connectOnce(isRetry, intent) {
   let structuredFatalCode = null;
   let engineRuntime = null;
   let engineContextToken = null;
-  const isCurrentEngineContext = (generation) => engineSupervisor.isCurrent(generation) &&
-    activeContextLease.isCurrent(engineContextToken, { connectionIntent: connectionState.snapshot().intent, engineGeneration: generation });
+  const isCurrentEngineContext = (generation) => activeEngineContextCurrent(generation, engineContextToken);
   connectionState.invalidateEngineGeneration();
   const expectedEngineGeneration = engineSupervisor.currentGeneration + 1;
   const engineArgs = [
@@ -963,7 +961,7 @@ async function connectOnce(isRetry, intent) {
     state.lastError = null;
     if (!wasConnected) {
       connectedAt = Date.now();
-      telemetryCoordinator.start(engineGeneration);
+      telemetryCoordinator.start(engineGeneration, engineContextToken);
     }
     emit();
   };
@@ -1522,7 +1520,6 @@ desktopShell = new DesktopShell({
     emit();
   },
 });
-
 telemetryCoordinator = new ConnectionTelemetryCoordinator({
   appPid: process.pid,
   gatewayHost: GATEWAY_HOST,
@@ -1534,14 +1531,17 @@ telemetryCoordinator = new ConnectionTelemetryCoordinator({
     activeProxyCredential?.socksAuthentication(generation) || null
   ),
   isConnected: () => connectionState.isConnected(),
-  isEngineCurrent: (generation) => engineSupervisor.isCurrent(generation),
+  isEngineCurrent: activeEngineContextCurrent,
   isVisible: () => desktopShell.isVisible(),
   getConnectedAt: () => connectedAt,
   send: (snapshot) => desktopShell.send('telemetry', snapshot),
   getAutoReconnect: () => loadSettingsOrReport().autoReconnect,
   isDesiredConnected: () => connectionState.snapshot().desiredConnected,
-  reconnect: (generation) => reconnect(generation),
-  onRecovering: () => {
+  reconnect: (generation, token) => activeEngineContextCurrent(generation, token)
+    ? reconnect(generation)
+    : Promise.resolve({ ok: false, stale: true }),
+  onRecovering: (generation, token) => {
+    if (!activeEngineContextCurrent(generation, token)) return;
     state.lastError = t('error.tunnelRecovering');
     emit();
   },

--- a/desktop/test/connection-telemetry-coordinator.test.js
+++ b/desktop/test/connection-telemetry-coordinator.test.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 const { ConnectionTelemetryCoordinator } = require('../lib/connection-telemetry-coordinator');
+const CONTEXT_TOKEN = Object.freeze({});
 
 class FakeTelemetryService {
   constructor(options) { this.options = options; this.starts = []; this.stops = 0; }
@@ -26,8 +27,8 @@ function fixture(overrides = {}) {
     send: (snapshot) => calls.push(['send', snapshot]),
     getAutoReconnect: () => true,
     isDesiredConnected: () => true,
-    reconnect: async (generation) => calls.push(['reconnect', generation]),
-    onRecovering: () => calls.push(['recovering']),
+    reconnect: async (generation, token) => calls.push(['reconnect', generation, token]),
+    onRecovering: (generation, token) => calls.push(['recovering', generation, token]),
     enumerator: { list: async () => ({ connCount: 0, apps: [] }) },
     runHealthRound: async () => health,
     probe: async () => true,
@@ -40,7 +41,7 @@ function fixture(overrides = {}) {
 
 test('start/stop bind all telemetry to one current Engine generation', () => {
   const f = fixture();
-  f.coordinator.start(7);
+  f.coordinator.start(7, CONTEXT_TOKEN);
   assert.equal(f.coordinator.current(7), true);
   assert.deepEqual(f.coordinator.service.starts, [7]);
   f.coordinator.service.options.emit({
@@ -75,7 +76,7 @@ test('profile Gateway port and health targets drive telemetry without global def
       return { kind: 'healthy', failedTargets: [] };
     },
   });
-  f.coordinator.start(7);
+  f.coordinator.start(7, CONTEXT_TOKEN);
   await f.coordinator.service.options.collectLatency();
   await f.coordinator.checkHealth(7);
   assert.deepEqual(calls, [
@@ -86,14 +87,14 @@ test('profile Gateway port and health targets drive telemetry without global def
 
 test('healthy evidence resets failures while three total failures trigger one reconnect', async () => {
   const f = fixture();
-  f.coordinator.start(7);
+  f.coordinator.start(7, CONTEXT_TOKEN);
   f.setHealth({ kind: 'failed', failedTargets: ['a', 'b'] });
   await f.coordinator.checkHealth(7);
   await f.coordinator.checkHealth(7);
   assert.equal(f.calls.some(([name]) => name === 'reconnect'), false);
   await f.coordinator.checkHealth(7);
   assert.deepEqual(f.calls.filter(([name]) => name === 'recovering' || name === 'reconnect'), [
-    ['recovering'], ['reconnect', 7],
+    ['recovering', 7, CONTEXT_TOKEN], ['reconnect', 7, CONTEXT_TOKEN],
   ]);
   assert.equal(f.coordinator.probeFailures, 0);
   f.setHealth({ kind: 'healthy', failedTargets: [] });
@@ -103,7 +104,7 @@ test('healthy evidence resets failures while three total failures trigger one re
 
 test('disabled recovery and stale generations never restart the Engine', async () => {
   const disabled = fixture({ getAutoReconnect: () => false });
-  disabled.coordinator.start(7);
+  disabled.coordinator.start(7, CONTEXT_TOKEN);
   disabled.setHealth({ kind: 'failed', failedTargets: [] });
   await disabled.coordinator.checkHealth(7);
   await disabled.coordinator.checkHealth(7);
@@ -111,6 +112,39 @@ test('disabled recovery and stale generations never restart the Engine', async (
   assert.equal(disabled.calls.length, 0);
 
   const stale = fixture({ isEngineCurrent: () => false });
-  stale.coordinator.start(7);
+  stale.coordinator.start(7, CONTEXT_TOKEN);
   assert.equal(await stale.coordinator.checkHealth(7), undefined);
+});
+
+test('telemetry requires and forwards the exact active context token', async () => {
+  const observed = [];
+  const f = fixture({
+    isEngineCurrent: (generation, token) => {
+      observed.push([generation, token]);
+      return token === CONTEXT_TOKEN;
+    },
+  });
+  assert.throws(() => f.coordinator.start(7), /context token/u);
+  f.coordinator.start(7, CONTEXT_TOKEN);
+  assert.equal(f.coordinator.current(7), true);
+  f.setHealth({ kind: 'failed', failedTargets: [] });
+  await f.coordinator.checkHealth(7);
+  assert.equal(observed.every(([, token]) => token === CONTEXT_TOKEN), true);
+  f.coordinator.stop();
+  assert.equal(f.coordinator.contextToken, null);
+});
+
+test('context invalidation during a health round cannot surface recovery or reconnect', async () => {
+  let current = true;
+  const f = fixture({
+    isEngineCurrent: (_generation, token) => current && token === CONTEXT_TOKEN,
+    runHealthRound: async () => {
+      current = false;
+      return { kind: 'failed', failedTargets: [] };
+    },
+  });
+  f.coordinator.start(7, CONTEXT_TOKEN);
+  f.coordinator.probeFailures = 2;
+  assert.equal((await f.coordinator.checkHealth(7)).kind, 'stale');
+  assert.equal(f.calls.some(([name]) => name === 'recovering' || name === 'reconnect'), false);
 });

--- a/desktop/test/main-active-context-contract.test.js
+++ b/desktop/test/main-active-context-contract.test.js
@@ -25,7 +25,8 @@ test('Main creates one Profile-bound lease before persistence and connection ser
 
 test('Engine callbacks require context epoch connection intent and process generation', () => {
   const connect = section('async function connectOnce(', '\nfunction ensureEngineStopped()');
-  assert.match(connect, /activeContextLease\.isCurrent\(engineContextToken, \{ connectionIntent: connectionState\.snapshot\(\)\.intent, engineGeneration: generation \}\)/u);
+  assert.match(source, /activeContextLease\.isCurrent\(token, \{ connectionIntent: connectionState\.snapshot\(\)\.intent, engineGeneration: generation \}\)/u);
+  assert.match(connect, /activeEngineContextCurrent\(generation, engineContextToken\)/u);
   const capture = connect.indexOf('activeContextLease.capture({ connectionIntent: intent, engineGeneration })');
   const bind = connect.indexOf('connectionState.bindEngineGeneration(engineGeneration)');
   const runtime = connect.indexOf('new EngineConnectionRuntime({');
@@ -35,5 +36,8 @@ test('Engine callbacks require context epoch connection intent and process gener
   assert.match(connect, /handleEngineExitBoundary\(result, isCurrentEngineContext\)/u);
   assert.match(connect, /Number\(s\.port\), isCurrentEngineContext,/u);
   assert.match(connect, /revokeEngineServing\(engineGeneration, isCurrentEngineContext\)/u);
+  assert.match(connect, /telemetryCoordinator\.start\(engineGeneration, engineContextToken\)/u);
+  assert.match(source, /isEngineCurrent: activeEngineContextCurrent/u);
+  assert.match(source, /reconnect: \(generation, token\) => activeEngineContextCurrent\(generation, token\)/u);
   assert.doesNotMatch(connect, /activeContextEpoch:\s*1/u);
 });


### PR DESCRIPTION
## 目标

把 #30 的 active-context token 延伸到 telemetry、health probes 和 automatic reconnect，阻止旧 Profile/Account 的异步健康结果影响新上下文。

本 PR 堆叠在 #30 之上；没有新增学校、账号或 UI。

## 变化

- Telemetry start 现在必须携带 opaque context token；缺失 token 直接拒绝。
- generation current 判断同时验证 token 内的 Profile/Account/epoch/connection intent。
- renderer telemetry emit、health round continuation、failure accumulation和恢复决策均使用同一 token。
- `onRecovering` 和 `reconnect` 接收并再次验证 token；context 在 health await 期间失效时返回 stale，不显示“恢复中”，也不触发 reconnect。
- stop 同时清除 generation 与 context token。

## 验证

- 新增 token required/forwarded、health await 中 context invalidation 测试。
- Desktop 全量：771 passed，0 failed，1 Windows-only skipped。
- 真实 synthetic Engine lifecycle：通过。
- Architecture：mainDeps=35、mainLines=1644、0 cycles。
- 全部 JS syntax 与 staged secret gate：通过。

## 后续

P4e 继续把 context lease 接到 RoutingPolicyTransactionQueue、Campus Browser navigation/credential/certificate lifecycle 和 AuthChallengeCoordinator；P4f 再组合真实 Main switch hooks。
