### PR TITLE
2.0 P4e: bind authentication challenges to active context

### DIFF
--- a/desktop/lib/active-context-lease.js
+++ b/desktop/lib/active-context-lease.js
@@ -93,14 +93,19 @@ class ActiveContextLease {
   }
 
   isCurrent(token, lifecycleValue) {
-    if (this.#current === null || !token || typeof token !== 'object') return false;
+    if (!this.isContextCurrent(token)) return false;
     const observed = this.#tokens.get(token);
-    if (!observed || !sameContext(observed.context, this.#current)) return false;
     let currentLifecycle;
     try { currentLifecycle = lifecycle(lifecycleValue); }
     catch { return false; }
     return observed.lifecycle.connectionIntent === currentLifecycle.connectionIntent &&
       observed.lifecycle.engineGeneration === currentLifecycle.engineGeneration;
+  }
+
+  isContextCurrent(token) {
+    if (this.#current === null || !token || typeof token !== 'object') return false;
+    const observed = this.#tokens.get(token);
+    return Boolean(observed && sameContext(observed.context, this.#current));
   }
 
   invalidate() {

--- a/desktop/lib/auth-challenge-coordinator.js
+++ b/desktop/lib/auth-challenge-coordinator.js
@@ -28,24 +28,29 @@ function rendererChallengeView(challenge) {
 
 class AuthChallengeCoordinator {
   constructor({ publish = () => {}, now = Date.now, setTimeoutFn = setTimeout,
-    clearTimeoutFn = clearTimeout } = {}) {
+    clearTimeoutFn = clearTimeout, isContextCurrent = () => true } = {}) {
+    if (typeof isContextCurrent !== 'function') {
+      throw new TypeError('authentication context guard is required');
+    }
     this.publish = publish;
     this.now = now;
     this.setTimeoutFn = setTimeoutFn;
     this.clearTimeoutFn = clearTimeoutFn;
+    this.isContextCurrent = isContextCurrent;
     this.binding = null;
     this.publicView = null;
     this.expiryTimer = null;
     this.inFlight = false;
   }
 
-  bind(generation, control) {
+  bind(generation, control, contextToken) {
     if (!Number.isSafeInteger(generation) || generation <= 0 || !control ||
-        typeof control.setAuthHandlers !== 'function') {
+        typeof control.setAuthHandlers !== 'function' || !contextToken ||
+        typeof contextToken !== 'object') {
       throw new TypeError('a generation-bound auth control suite is required');
     }
     this.detach();
-    this.binding = { generation, control };
+    this.binding = { generation, control, contextToken };
     control.setAuthHandlers({
       onChallenge: (challenge) => this.#activate(generation, control, challenge),
       onCleared: () => this.#clear(generation, control),
@@ -67,6 +72,7 @@ class AuthChallengeCoordinator {
   }
 
   snapshot() {
+    if (this.binding && !this.#contextCurrent()) this.detach();
     return this.publicView ? { ...this.publicView } : null;
   }
 
@@ -128,6 +134,12 @@ class AuthChallengeCoordinator {
     if (!this.binding || !this.publicView) {
       return Promise.reject(new Error('no active authentication challenge'));
     }
+    if (!this.#contextCurrent()) {
+      this.detach();
+      const error = new Error('authentication challenge belongs to a stale context');
+      error.code = 'stale_context';
+      return Promise.reject(error);
+    }
     if (this.inFlight) return Promise.reject(new Error('authentication action is in progress'));
     this.inFlight = true;
     let operation;
@@ -154,7 +166,7 @@ class AuthChallengeCoordinator {
 
   #activate(generation, control, challenge) {
     if (!this.binding || this.binding.generation !== generation ||
-        this.binding.control !== control) return;
+        this.binding.control !== control || !this.#contextCurrent()) return;
     this.publicView = rendererChallengeView(challenge);
     this.publish(this.snapshot());
     this.#scheduleExpiry(generation, control);
@@ -162,7 +174,7 @@ class AuthChallengeCoordinator {
 
   #clear(generation, control) {
     if (!this.binding || this.binding.generation !== generation ||
-        this.binding.control !== control) return;
+        this.binding.control !== control || !this.#contextCurrent()) return;
     this.#clearExpiryTimer();
     if (!this.publicView) return;
     this.publicView = null;
@@ -175,7 +187,8 @@ class AuthChallengeCoordinator {
     if (expiresAt == null) return;
     const schedule = () => {
       if (!this.binding || this.binding.generation !== generation ||
-          this.binding.control !== control || this.publicView?.expiresAtUnixMs !== expiresAt) return;
+          this.binding.control !== control || !this.#contextCurrent() ||
+          this.publicView?.expiresAtUnixMs !== expiresAt) return;
       const remaining = expiresAt - this.now();
       if (remaining > 0) {
         this.expiryTimer = this.setTimeoutFn(schedule, Math.min(remaining, MAX_TIMER_DELAY_MS));
@@ -192,6 +205,10 @@ class AuthChallengeCoordinator {
   #clearExpiryTimer() {
     if (this.expiryTimer) this.clearTimeoutFn(this.expiryTimer);
     this.expiryTimer = null;
+  }
+
+  #contextCurrent() {
+    return Boolean(this.binding && this.isContextCurrent(this.binding.contextToken));
   }
 }
 

--- a/desktop/lib/engine-connection-runtime.js
+++ b/desktop/lib/engine-connection-runtime.js
@@ -11,6 +11,7 @@ const NOOP = () => {};
 class EngineConnectionRuntime {
   constructor({
     generation,
+    contextToken,
     expectedPort,
     stdin,
     controlRegistry,
@@ -22,6 +23,9 @@ class EngineConnectionRuntime {
   } = {}) {
     if (!Number.isSafeInteger(generation) || generation <= 0) {
       throw new TypeError('a positive Engine generation is required');
+    }
+    if (!contextToken || typeof contextToken !== 'object') {
+      throw new TypeError('an active context token is required');
     }
     if (!Number.isInteger(expectedPort) || expectedPort < 1025 || expectedPort > 65535) {
       throw new TypeError('a valid expected listener port is required');
@@ -35,6 +39,7 @@ class EngineConnectionRuntime {
       throw new TypeError('Engine runtime lifecycle dependencies are invalid');
     }
     this.generation = generation;
+    this.contextToken = contextToken;
     this.expectedPort = expectedPort;
     this.isCurrent = isCurrent;
     this.handlers = {
@@ -60,7 +65,7 @@ class EngineConnectionRuntime {
     this.clearTimeoutFn = clearTimeoutFn;
     this.protocol = new EngineProtocolSession(generation);
     this.events = new EngineEventParser();
-    this.control = controlRegistry.bind(generation, stdin);
+    this.control = controlRegistry.bind(generation, stdin, contextToken);
     this.stdout = null;
     this.stdoutListener = null;
     this.helloTimer = null;

--- a/desktop/lib/engine-control-suite.js
+++ b/desktop/lib/engine-control-suite.js
@@ -46,11 +46,11 @@ class EngineControlRegistry {
     this.active = null;
   }
 
-  bind(generation, writable) {
+  bind(generation, writable, contextToken) {
     this.clear();
     const client = new EngineControlSuite({ writable, generation });
     this.active = { generation, client };
-    this.authChallenges.bind(generation, client);
+    this.authChallenges.bind(generation, client, contextToken);
     return client;
   }
 

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -191,6 +191,7 @@ let state = {
 function statusSnapshot() { return projectConnectionStatus(state, connectionState.presentation(), connectedAt); }
 function reportLogFailure() { if (!state.diagnosticNotice) { state.diagnosticNotice = t('error.logUnavailable'); emit(); } }
 const authChallengeCoordinator = new AuthChallengeCoordinator({
+  isContextCurrent: (token) => activeContextLease.isContextCurrent(token),
   publish: (challenge) => {
     desktopShell?.send('auth-challenge', challenge);
   },
@@ -510,7 +511,6 @@ function clearConnectionPresentation() {
   state.dnsMode = 'unknown'; activeSchoolProfile.clearCapabilitySnapshot();
   telemetryCoordinator?.stop();
 }
-
 function invalidateForConnectivity(reason, intent) {
   if (!connectionState.pauseForConnectivity(intent, {
     isQuitting: desktopShell?.isQuitting === true,
@@ -530,7 +530,6 @@ function invalidateForConnectivity(reason, intent) {
     emit();
   }).catch(() => {});
 }
-
 async function recoverConnectivity(intent, reason) {
   let autoReconnect;
   try {
@@ -999,6 +998,7 @@ async function connectOnce(isRetry, intent) {
   };
   engineRuntime = new EngineConnectionRuntime({
     generation: engineGeneration,
+    contextToken: engineContextToken,
     expectedPort: Number(s.port),
     stdin: child.stdin,
     controlRegistry: engineControlRegistry,

--- a/desktop/test/active-context-lease.test.js
+++ b/desktop/test/active-context-lease.test.js
@@ -21,6 +21,7 @@ function binding({
 test('token requires the exact active context intent and Engine generation', () => {
   const lease = new ActiveContextLease(binding());
   const token = lease.capture({ connectionIntent: 3, engineGeneration: 7 });
+  assert.equal(lease.isContextCurrent(token), true);
   assert.equal(lease.isCurrent(token, { connectionIntent: 3, engineGeneration: 7 }), true);
   assert.equal(lease.isCurrent(token, { connectionIntent: 4, engineGeneration: 7 }), false);
   assert.equal(lease.isCurrent(token, { connectionIntent: 3, engineGeneration: 8 }), false);
@@ -37,6 +38,7 @@ test('gating invalidates every borrowed token until a higher epoch activates', (
   assert.equal(lease.invalidate(), false);
   assert.equal(lease.snapshot(), null);
   assert.equal(lease.isCurrent(old, { connectionIntent: 1, engineGeneration: 1 }), false);
+  assert.equal(lease.isContextCurrent(old), false);
   assert.throws(() => lease.capture({ connectionIntent: 1, engineGeneration: 1 }), /gated/u);
   assert.throws(() => lease.activate(binding()), /increase monotonically/u);
 

--- a/desktop/test/auth-challenge-coordinator.test.js
+++ b/desktop/test/auth-challenge-coordinator.test.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 const { AuthChallengeCoordinator } = require('../lib/auth-challenge-coordinator');
+const CONTEXT_TOKEN = Object.freeze({});
 
 function internalChallenge(overrides = {}) {
   return {
@@ -43,7 +44,7 @@ test('renderer view omits Engine correlation and protocol context', () => {
   const published = [];
   const control = new FakeControl();
   const coordinator = new AuthChallengeCoordinator({ publish: (view) => published.push(view) });
-  coordinator.bind(9, control);
+  coordinator.bind(9, control, CONTEXT_TOKEN);
   control.handlers.onChallenge(internalChallenge());
 
   assert.deepEqual(Object.keys(published[0]).sort(), [
@@ -64,7 +65,7 @@ test('renderer view omits Engine correlation and protocol context', () => {
 test('response is removed from IPC payload and its Main-process Buffer is zeroized immediately', async () => {
   const control = new FakeControl();
   const coordinator = new AuthChallengeCoordinator();
-  coordinator.bind(9, control);
+  coordinator.bind(9, control, CONTEXT_TOKEN);
   control.handlers.onChallenge(internalChallenge());
   const payload = { response: 'synthetic-accepted' };
   const operation = coordinator.respond(payload);
@@ -79,7 +80,7 @@ test('unknown fields, empty responses, duplicate actions and cooldown resend fai
   const control = new FakeControl();
   control.respond = () => new Promise((resolve) => { resolveResponse = resolve; });
   const coordinator = new AuthChallengeCoordinator({ now: () => 1_000 });
-  coordinator.bind(9, control);
+  coordinator.bind(9, control, CONTEXT_TOKEN);
   control.handlers.onChallenge(internalChallenge({ resendAfterUnixMs: 2_000 }));
 
   await assert.rejects(coordinator.respond({ response: 'x', extra: true }), /invalid/);
@@ -106,7 +107,7 @@ test('expiry cancels the bound transaction, clears UI, and stale generations can
     setTimeoutFn: (callback) => { timerCallback = callback; return { unref() {} }; },
     clearTimeoutFn: () => {},
   });
-  coordinator.bind(4, control);
+  coordinator.bind(4, control, CONTEXT_TOKEN);
   control.handlers.onChallenge(internalChallenge({ expiresAtUnixMs: 1_500 }));
   assert.equal(timerCallback, undefined, 'already-expired challenge clears synchronously');
   await new Promise((done) => setImmediate(done));
@@ -126,7 +127,7 @@ test('expiry cleanup remains fail-closed when the control client throws synchron
     publish: (view) => published.push(view),
     now: () => 2_000,
   });
-  coordinator.bind(4, control);
+  coordinator.bind(4, control, CONTEXT_TOKEN);
   assert.doesNotThrow(() => {
     control.handlers.onChallenge(internalChallenge({ expiresAtUnixMs: 1_500 }));
   });
@@ -144,7 +145,7 @@ test('renderer lifecycle loss cancels through Main even while a submit is in fli
     return new Promise((resolve) => { resolveResponse = resolve; });
   };
   const coordinator = new AuthChallengeCoordinator({ publish: (view) => published.push(view) });
-  coordinator.bind(9, control);
+  coordinator.bind(9, control, CONTEXT_TOKEN);
   control.handlers.onChallenge(internalChallenge());
   const response = coordinator.respond({ response: 'synthetic-in-flight' });
   assert.equal(coordinator.cancelForLifecycle(), true);
@@ -157,4 +158,26 @@ test('renderer lifecycle loss cancels through Main even while a submit is in fli
   await response;
   control.handlers.onChallenge?.(internalChallenge());
   assert.equal(coordinator.snapshot(), null, 'late provider output cannot revive the renderer');
+});
+
+test('context invalidation clears the prompt and rejects old renderer actions as stale', async () => {
+  let current = true;
+  const published = [];
+  const control = new FakeControl();
+  const coordinator = new AuthChallengeCoordinator({
+    publish: (view) => published.push(view),
+    isContextCurrent: (token) => current && token === CONTEXT_TOKEN,
+  });
+  assert.throws(() => coordinator.bind(9, control), /control suite/u);
+  coordinator.bind(9, control, CONTEXT_TOKEN);
+  control.handlers.onChallenge(internalChallenge());
+  current = false;
+  const payload = { response: 'synthetic-stale-response' };
+  const result = await coordinator.ipcHandlers()['respond-auth-challenge']({}, payload);
+  assert.deepEqual(result, { ok: false, code: 'stale_context' });
+  assert.equal(payload.response, '');
+  assert.equal(coordinator.snapshot(), null);
+  assert.equal(published.at(-1), null);
+  assert.deepEqual(control.handlers, {});
+  assert.deepEqual(control.actions, []);
 });

--- a/desktop/test/engine-connection-runtime.test.js
+++ b/desktop/test/engine-connection-runtime.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const { EventEmitter } = require('node:events');
 const test = require('node:test');
 const { EngineConnectionRuntime } = require('../lib/engine-connection-runtime');
+const CONTEXT_TOKEN = Object.freeze({});
 
 class FakeControl {
   constructor() {
@@ -49,11 +50,12 @@ function fixture(overrides = {}) {
   ].map((name) => [name, (...args) => calls.push([name, ...args])]));
   const runtime = new EngineConnectionRuntime({
     generation: 7,
+    contextToken: CONTEXT_TOKEN,
     expectedPort: 6180,
     stdin: { write() {} },
     controlRegistry: {
-      bind(generation, stdin) {
-        binds.push([generation, stdin]);
+      bind(generation, stdin, contextToken) {
+        binds.push([generation, stdin, contextToken]);
         return control;
       },
     },
@@ -85,6 +87,7 @@ function lines(...events) {
 test('runtime binds one generation, negotiates before readiness, and dispatches typed events', async () => {
   const f = fixture();
   assert.equal(f.binds.length, 1);
+  assert.equal(f.binds[0][2], CONTEXT_TOKEN);
   assert.equal(f.runtime.start(f.stdout), true);
   assert.equal(f.runtime.start(f.stdout), false);
   assert.equal(f.control.handshakes, 1);
@@ -215,12 +218,14 @@ test('constructor rejects unbound generations, ports, controls and handlers', ()
   assert.throws(() => new EngineConnectionRuntime(), /generation/);
   assert.throws(() => new EngineConnectionRuntime({
     generation: 1,
+    contextToken: CONTEXT_TOKEN,
     expectedPort: 80,
     controlRegistry: { bind() {} },
     isCurrent() {},
   }), /port/);
   assert.throws(() => new EngineConnectionRuntime({
     generation: 1,
+    contextToken: CONTEXT_TOKEN,
     expectedPort: 6180,
     controlRegistry: {},
     isCurrent() {},

--- a/desktop/test/main-engine-protocol-contract.test.js
+++ b/desktop/test/main-engine-protocol-contract.test.js
@@ -34,7 +34,8 @@ test('desktop requires Engine API hello and has no English stdout readiness fall
 
 test('desktop opts into the private Control v2 stream and retains signal fallback', () => {
   assert.match(source, /controlRegistry: engineControlRegistry/);
-  assert.match(runtime, /controlRegistry\.bind\(generation, stdin\)/);
+  assert.match(runtime, /controlRegistry\.bind\(generation, stdin, contextToken\)/);
+  assert.match(source, /contextToken: engineContextToken/u);
   assert.match(runtime, /this\.control\.feed\(data\)/);
   assert.match(source, /'--control-api-v2-stdin'/);
   assert.match(source, /'--profile-binding-v1-stdin'/);


### PR DESCRIPTION
## 目标

把 Engine Control v3 challenge 的整个生命周期绑定到 active Profile/Account context，确保切换后旧 Renderer 无法 respond、resend、cancel 或复活旧 OTP/MFA prompt。

本 PR 堆叠在 #31 之上；不实现或猜测任何真实学校 MFA provider。

## 变化

- `ActiveContextLease` 增加 context-only validity check；仍不暴露 token 内容。
- EngineConnectionRuntime 必须接收 context token，并把它传入 EngineControlRegistry。
- AuthChallengeCoordinator binding 现在是 `generation + control + contextToken`。
- challenge activate/clear/expiry/respond/resend/cancel 每次都验证 active context。
- stale renderer action：
  - 立即 detach provider handlers；
  - 清除 prompt 和 expiry timer；
  - response Buffer 仍即时 zeroize；
  - IPC 只返回稳定 `stale_context`，不泄露 Profile、Account、transaction 或 token。
- lifecycle cancel 仍可在 submit in-flight 时优先清 UI 并 best-effort cancel Engine transaction。

## 验证

- 新增 context invalidation + stale renderer action 测试。
- Engine runtime/registry contract 强制 context token 从 Main 传到 auth coordinator。
- Desktop 全量：772 passed，0 failed，1 Windows-only skipped。
- 真实 synthetic Engine lifecycle、Campus MFA、popup/cross-origin MFA：全部通过。
- Architecture：mainDeps=35、mainLines=1644、0 cycles。
- 全部 JS syntax 与 staged secret gate：通过。

## 边界

这仍是通用、安全的 challenge framework；没有宣告 HKUST Gateway 已启用 MFA，也没有猜测 endpoint、字段、验证码长度或渠道映射。

## 后续

P4f 将为 RoutingPolicyTransactionQueue 增加 context-only token、cancel/drain barrier 和 stale rollback 规则；随后组合真实 Main ActiveContextSwitchCoordinator hooks。
