### PR TITLE
2.0 P4f: drain mutations across active-context switches

### DIFF
--- a/desktop/lib/active-context-lease.js
+++ b/desktop/lib/active-context-lease.js
@@ -84,10 +84,19 @@ class ActiveContextLease {
 
   capture(lifecycleValue) {
     if (this.#current === null) throw new Error('active context is gated');
+    return this.#issue(lifecycle(lifecycleValue));
+  }
+
+  captureContext() {
+    if (this.#current === null) throw new Error('active context is gated');
+    return this.#issue(null);
+  }
+
+  #issue(lifecycleBinding) {
     const token = redactedToken();
     this.#tokens.set(token, Object.freeze({
       context: this.#current,
-      lifecycle: lifecycle(lifecycleValue),
+      lifecycle: lifecycleBinding,
     }));
     return token;
   }
@@ -95,6 +104,7 @@ class ActiveContextLease {
   isCurrent(token, lifecycleValue) {
     if (!this.isContextCurrent(token)) return false;
     const observed = this.#tokens.get(token);
+    if (observed.lifecycle === null) return false;
     let currentLifecycle;
     try { currentLifecycle = lifecycle(lifecycleValue); }
     catch { return false; }

--- a/desktop/lib/routing-policy-transaction.js
+++ b/desktop/lib/routing-policy-transaction.js
@@ -13,6 +13,12 @@ function transactionError(primary, recoveryFailures) {
   return error;
 }
 
+function staleContextError() {
+  const error = new Error('active context changed during mutation');
+  error.code = 'stale_context';
+  return error;
+}
+
 // JSON is the source of truth and both PAC representations are derived data.
 // The browser is suspended before the source changes, then the source, external
 // PAC and live Session are committed as one observable operation. A failure
@@ -26,8 +32,11 @@ async function runRoutingPolicyTransaction({
   rollback,
   restoreExternal,
   restoreBrowser,
+  contextCurrent = () => true,
 } = {}) {
-  if (typeof commit !== 'function') throw new TypeError('路由策略事务缺少提交操作');
+  if (typeof commit !== 'function' || typeof contextCurrent !== 'function') {
+    throw new TypeError('路由策略事务缺少提交操作或上下文守卫');
+  }
   const suspendOperation = asOperation(suspend);
   const applyExternalOperation = asOperation(applyExternal);
   const applyBrowserOperation = asOperation(applyBrowser);
@@ -35,7 +44,12 @@ async function runRoutingPolicyTransaction({
   const restoreExternalOperation = asOperation(restoreExternal);
   const restoreBrowserOperation = asOperation(restoreBrowser);
 
+  const requireCurrent = () => {
+    if (contextCurrent() !== true) throw staleContextError();
+  };
+  requireCurrent();
   await suspendOperation();
+  requireCurrent();
   let committed = false;
   try {
     let value;
@@ -48,8 +62,11 @@ async function runRoutingPolicyTransaction({
       committed = error?.commitApplied === true;
       throw error;
     }
+    requireCurrent();
     await applyExternalOperation();
+    requireCurrent();
     await applyBrowserOperation();
+    requireCurrent();
     return value;
   } catch (primary) {
     const recoveryFailures = [];
@@ -61,28 +78,60 @@ async function runRoutingPolicyTransaction({
     // Resume only when the source and external PAC were both restored. If
     // either recovery step failed, keeping the Session suspended is safer than
     // guessing which policy is authoritative.
-    if (!recoveryFailures.length) {
+    if (!recoveryFailures.length && contextCurrent() === true) {
       try { await restoreBrowserOperation(); } catch (error) { recoveryFailures.push(error); }
+    }
+    if (contextCurrent() !== true) {
+      try { await suspendOperation(); } catch (error) { recoveryFailures.push(error); }
     }
     throw transactionError(primary, recoveryFailures);
   }
 }
 
 class RoutingPolicyTransactionQueue {
-  constructor() {
+  constructor({ isContextCurrent = () => true } = {}) {
+    if (typeof isContextCurrent !== 'function') {
+      throw new TypeError('mutation queue context guard is required');
+    }
+    this.isContextCurrent = isContextCurrent;
     this.chain = Promise.resolve();
+    this.tail = this.chain;
+    this.epoch = 1;
+    this.unsafe = false;
   }
 
-  run(options) {
-    const execute = () => runRoutingPolicyTransaction(
-      typeof options === 'function' ? options() : options,
-    );
+  run(contextToken, options) {
+    if (!contextToken || typeof contextToken !== 'object') {
+      return Promise.reject(new TypeError('mutation queue context token is required'));
+    }
+    const epoch = this.epoch;
+    const current = () => epoch === this.epoch && this.isContextCurrent(contextToken) === true;
+    const execute = () => {
+      if (!current()) return Promise.reject(staleContextError());
+      return runRoutingPolicyTransaction({
+        ...(typeof options === 'function' ? options() : options),
+        contextCurrent: current,
+      });
+    };
     const next = this.chain.then(
       execute,
       execute,
     );
-    this.chain = next.catch(() => {});
+    this.tail = next;
+    this.chain = next.catch((error) => {
+      if (error?.rollbackIncomplete === true) this.unsafe = true;
+    });
     return next;
+  }
+
+  async cancelAndDrain() {
+    this.epoch += 1;
+    while (true) {
+      const observed = this.tail;
+      try { await observed; } catch {}
+      if (this.tail === observed) break;
+    }
+    return !this.unsafe;
   }
 }
 

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -200,7 +200,8 @@ const engineControlRegistry = new EngineControlRegistry({ authChallenges: authCh
 const engineSupervisor = new EngineSupervisor({ spawnProcess: spawn });
 const activeEngineContextCurrent = (generation, token) => engineSupervisor.isCurrent(generation) &&
   activeContextLease.isCurrent(token, { connectionIntent: connectionState.snapshot().intent, engineGeneration: generation });
-const routingPolicyTransactions = new RoutingPolicyTransactionQueue();
+const routingPolicyTransactions = new RoutingPolicyTransactionQueue({ isContextCurrent: (token) => activeContextLease.isContextCurrent(token) });
+function runActiveContextTransaction(options) { return routingPolicyTransactions.run(activeContextLease.captureContext(), options); }
 let logWriter = null;
 function initializeLogWriter() {
   logWriter = new BufferedLogWriter(LOG, { onError: reportLogFailure, onRecovered: () => { if (state.diagnosticNotice) { state.diagnosticNotice = null; emit(); } } });
@@ -1212,9 +1213,8 @@ async function resumeOpenBrowserPolicyIfLive() {
   if (!connectionState.isConnected() || !engineSupervisor.hasActive) return null;
   return campusBrowserManager.resumeRoutingPolicy(socksPort());
 }
-
 function runDomainPolicyTransaction(buildOperations) {
-  return routingPolicyTransactions.run(() => {
+  return runActiveContextTransaction(() => {
     assertSettingsPersistenceAvailable();
     const { commit, rollback, resumeBrowser = true } = buildOperations();
     return {
@@ -1320,7 +1320,7 @@ async function runUpdateCheck() {
   if (result) {
     // The API answered, so the 24h throttle window starts here. Failures leave
     // the timestamp alone and are retried at the next launch.
-    await routingPolicyTransactions.run(() => {
+    await runActiveContextTransaction(() => {
       assertSettingsPersistenceAvailable();
       const settings = loadSettingsOrReport();
       return {
@@ -1396,7 +1396,7 @@ registerSettingsCredentialIpc({
   isCredentialBlocked: () => credentialTransactionBlocked,
   retryCredentialRecovery: retryCredentialTransactionRecovery,
   runPolicyTransaction: runDomainPolicyTransaction,
-  runSerialTransaction: (buildOperations) => routingPolicyTransactions.run(buildOperations),
+  runSerialTransaction: runActiveContextTransaction,
   assertPersistence: assertSettingsPersistenceAvailable,
   translate: (key) => t(key),
   onLanguageChanged: (language) => {
@@ -1475,7 +1475,7 @@ registerCoreControlIpc({
 });
 // ---------- window / tray composition ----------
 function rememberCloseAction(action) {
-  return routingPolicyTransactions.run(() => {
+  return runActiveContextTransaction(() => {
     assertSettingsPersistenceAvailable();
     const previous = loadSettingsOrReport();
     const next = { ...previous, closeAction: action };

--- a/desktop/test/active-context-lease.test.js
+++ b/desktop/test/active-context-lease.test.js
@@ -29,6 +29,11 @@ test('token requires the exact active context intent and Engine generation', () 
   assert.equal(JSON.stringify(token), '"[active context token]"');
   assert.equal(String(token), '[active context token]');
   assert.equal(JSON.stringify(token).includes('school-a'), false);
+  const contextToken = lease.captureContext();
+  assert.equal(lease.isContextCurrent(contextToken), true);
+  assert.equal(lease.isCurrent(contextToken, {
+    connectionIntent: 3, engineGeneration: 7,
+  }), false);
 });
 
 test('gating invalidates every borrowed token until a higher epoch activates', () => {

--- a/desktop/test/main-active-context-contract.test.js
+++ b/desktop/test/main-active-context-contract.test.js
@@ -41,3 +41,12 @@ test('Engine callbacks require context epoch connection intent and process gener
   assert.match(source, /reconnect: \(generation, token\) => activeEngineContextCurrent\(generation, token\)/u);
   assert.doesNotMatch(connect, /activeContextEpoch:\s*1/u);
 });
+
+test('all serialized settings routing and resource mutations capture active context', () => {
+  assert.match(source, /new RoutingPolicyTransactionQueue\(\{ isContextCurrent: \(token\) => activeContextLease\.isContextCurrent\(token\) \}\)/u);
+  assert.match(source, /routingPolicyTransactions\.run\(activeContextLease\.captureContext\(\), options\)/u);
+  assert.match(source, /function runDomainPolicyTransaction[\s\S]*return runActiveContextTransaction/u);
+  assert.match(source, /runSerialTransaction: runActiveContextTransaction/u);
+  const directRuns = source.match(/routingPolicyTransactions\.run\(/gu) || [];
+  assert.equal(directRuns.length, 1, 'every mutation must pass through the context-token helper');
+});

--- a/desktop/test/routing-policy-transaction.test.js
+++ b/desktop/test/routing-policy-transaction.test.js
@@ -106,7 +106,8 @@ test('a failure after an atomic rename is rolled back before browser restore', a
 });
 
 test('queued transaction factories run serially and observe the latest committed source', async () => {
-  const queue = new RoutingPolicyTransactionQueue();
+  const token = Object.freeze({});
+  const queue = new RoutingPolicyTransactionQueue({ isContextCurrent: (value) => value === token });
   const snapshots = [];
   let state = 0;
   let releaseFirst;
@@ -130,13 +131,79 @@ test('queued transaction factories run serially and observe the latest committed
     };
   };
 
-  const first = queue.run(makeTransaction(1, firstBlocked));
+  const first = queue.run(token, makeTransaction(1, firstBlocked));
   await firstStarted;
-  const second = queue.run(makeTransaction(2));
+  const second = queue.run(token, makeTransaction(2));
   await new Promise((resolve) => setImmediate(resolve));
   assert.deepEqual(snapshots, [0], 'the second snapshot must not be captured before its turn');
   releaseFirst();
   assert.deepEqual(await Promise.all([first, second]), [1, 2]);
   assert.deepEqual(snapshots, [0, 1]);
   assert.equal(state, 2);
+});
+
+test('cancelAndDrain rejects queued stale work before its factory observes state', async () => {
+  const token = Object.freeze({});
+  const queue = new RoutingPolicyTransactionQueue({ isContextCurrent: () => true });
+  let release;
+  const blocked = new Promise((resolve) => { release = resolve; });
+  let started;
+  const firstStarted = new Promise((resolve) => { started = resolve; });
+  let secondObserved = false;
+  const first = queue.run(token, () => ({
+    commit: async () => { started(); await blocked; },
+  }));
+  await firstStarted;
+  const second = queue.run(token, () => {
+    secondObserved = true;
+    return { commit: async () => {} };
+  });
+  const draining = queue.cancelAndDrain();
+  release();
+  await assert.rejects(first, (error) => error.code === 'stale_context');
+  await assert.rejects(second, (error) => error.code === 'stale_context');
+  assert.equal(await draining, true);
+  assert.equal(secondObserved, false);
+});
+
+test('stale in-flight commit rolls back old source and PAC then re-gates Browser', async () => {
+  const token = Object.freeze({});
+  let current = true;
+  let releaseExternal;
+  const externalBlocked = new Promise((resolve) => { releaseExternal = resolve; });
+  let externalStarted;
+  const externalStart = new Promise((resolve) => { externalStarted = resolve; });
+  const calls = [];
+  const queue = new RoutingPolicyTransactionQueue({ isContextCurrent: () => current });
+  const mutation = queue.run(token, {
+    suspend: async () => calls.push('suspend'),
+    commit: async () => calls.push('commit'),
+    applyExternal: async () => { calls.push('external'); externalStarted(); await externalBlocked; },
+    applyBrowser: async () => calls.push('browser'),
+    rollback: async () => calls.push('rollback'),
+    restoreExternal: async () => calls.push('restore-external'),
+    restoreBrowser: async () => calls.push('restore-browser'),
+  });
+  await externalStart;
+  current = false;
+  const draining = queue.cancelAndDrain();
+  releaseExternal();
+  await assert.rejects(mutation, (error) => error.code === 'stale_context');
+  assert.equal(await draining, true);
+  assert.deepEqual(calls, [
+    'suspend', 'commit', 'external', 'rollback', 'restore-external', 'suspend',
+  ]);
+});
+
+test('rollback uncertainty makes context drain fail closed permanently', async () => {
+  const token = Object.freeze({});
+  let current = true;
+  const queue = new RoutingPolicyTransactionQueue({ isContextCurrent: () => current });
+  const mutation = queue.run(token, {
+    commit: async () => { current = false; },
+    rollback: async () => { throw new Error('rollback failed'); },
+    restoreExternal: async () => {},
+  });
+  await assert.rejects(mutation, (error) => error.rollbackIncomplete === true);
+  assert.equal(await queue.cancelAndDrain(), false);
 });


### PR DESCRIPTION
## 目标

把设置、路由、PAC、资源和证书相关串行写入统一绑定 active-context token，并提供切换所需的 cancel/drain barrier，防止旧 Profile 的异步事务覆盖新 Profile。

本 PR 堆叠在 #32 之上；没有新增 Profile/Account UI。

## 设计

- `ActiveContextLease.captureContext()` 发行不含 Engine lifecycle 的 opaque token；token 仍不可序列化内部身份。
- RoutingPolicyTransactionQueue 每个提交记录 queue epoch + context token。
- factory 只在轮到执行且 token 仍 current 时才读取状态，排队中的旧事务不会观察新 Profile 数据。
- 每个不可逆阶段重新验证 context：suspend、commit、external PAC、Browser Session。
- stale 发生在 commit 后：
  - 回滚旧 workspace source；
  - 恢复旧 external PAC；
  - 不恢复旧 Browser；
  - 再次 suspend，消除 applyBrowser 与 switch gate 的竞态。
- `cancelAndDrain()`：
  - 递增 queue epoch，使排队/运行中的旧 token 全部 stale；
  - 等待当时及竞态追加的队列全部结束；
  - rollback 不完整时返回 false，使 Profile activation fail closed。
- Main 的 route/resource/settings/update/close-action mutations 全部经过同一个 context-token helper；禁止旁路直接调用 queue。

## 验证

- queued stale factory 不读取状态。
- in-flight external PAC 竞态按 source rollback → PAC restore → Browser re-gate 收敛。
- rollback uncertainty 使 drain 永久 fail closed。
- Main contract 强制所有 serialized mutations 捕获 context token。
- Desktop 全量：776 passed，0 failed，1 Windows-only skipped。
- 真实 Electron Main integration 与 routing restart：通过。
- Architecture：mainDeps=35、mainLines=1644、0 cycles。
- 全部 JS syntax 与 staged secret gate：通过。

## 后续

P4g 将把 ActiveContextSwitchCoordinator 组合到真实 Main：switch gate 将依次 invalidate lease、cancel MFA、关闭 Browser、cancelAndDrain mutations、确认 Engine stop、撤销 proxy sidecar，然后才允许 destination activation。生产选择器仍保持单 HKUST。
