### PR TITLE
2.0 P4g: bind switch activation across workspace authority

### DIFF
--- a/desktop/lib/active-context-activation-store.js
+++ b/desktop/lib/active-context-activation-store.js
@@ -1,0 +1,251 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { atomicWritePrivateFile } = require('./credential-store');
+const {
+  validateActiveContextSwitchJournal,
+} = require('./active-context-switch-journal');
+const { readPrivateFileBounded } = require('./private-file');
+const {
+  createProfileAccountWorkspaceLayout,
+  validateUserDataRoot,
+} = require('./profile-workspace-layout');
+const {
+  validateGlobalSettingsDocument,
+} = require('./profile-workspace-documents');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+const MAX_TARGET_BYTES = 512 * 1024;
+const WORKSPACE_KEYS = Object.freeze([
+  'schemaVersion', 'profileId', 'profileRevision', 'accountKey', 'accountRevision',
+  'workspaceKey', 'activeContextEpoch',
+]);
+
+function receipt(data) {
+  if (!Buffer.isBuffer(data) || data.length < 2 || data.length > MAX_TARGET_BYTES) {
+    throw new TypeError('active context activation target is invalid');
+  }
+  return Object.freeze({
+    present: true,
+    bytes: data.length,
+    sha256: crypto.createHash('sha256').update(data).digest('hex'),
+  });
+}
+
+function sameReceipt(left, right) {
+  return left.present === right.present && left.bytes === right.bytes &&
+    left.sha256 === right.sha256;
+}
+
+function exactWorkspace(value, expected, epoch) {
+  if (!expected || typeof expected !== 'object' || !value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype ||
+      JSON.stringify(Object.keys(value).sort()) !== JSON.stringify([...WORKSPACE_KEYS].sort()) ||
+      value.schemaVersion !== 1 || value.profileId !== expected.profileId ||
+      value.profileRevision !== expected.profileRevision ||
+      value.accountKey !== expected.accountKey || value.accountRevision !== expected.accountRevision ||
+      value.workspaceKey !== expected.workspaceKey || value.activeContextEpoch !== epoch) {
+    throw new Error('destination Workspace state does not match switch authority');
+  }
+  return Object.freeze({ ...value });
+}
+
+function serialized(value) {
+  return Buffer.from(`${JSON.stringify(value)}\n`, 'utf8');
+}
+
+function storageOptions(platform, windowsAcl) {
+  return platform === 'win32' ? {
+    protectTemporary: (file) => windowsAcl.protect(file) === true,
+    verifyCommitted: (file) => windowsAcl.verify(file) === true,
+    removeCommittedOnFailure: true,
+  } : {};
+}
+
+class ActiveContextActivationStore {
+  constructor({
+    userData,
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+  } = {}) {
+    if (!fileSystem || typeof fileSystem.openSync !== 'function' ||
+        !['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' &&
+          (typeof windowsAcl?.protect !== 'function' || typeof windowsAcl?.verify !== 'function'))) {
+      throw new TypeError('active context activation store dependencies are invalid');
+    }
+    this.userData = validateUserDataRoot(userData);
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+    this.globalSettings = path.join(this.userData, 'global', 'settings.json');
+  }
+
+  plan({ from, to, nextActiveContextEpoch } = {}) {
+    const global = this.#readDocument(this.globalSettings, 'GlobalSettings');
+    const workspacePath = this.#workspaceStatePath(to);
+    const workspace = this.#readDocument(workspacePath, 'destination Workspace');
+    try {
+      const globalDocument = validateGlobalSettingsDocument(global.value);
+      if (globalDocument.activeProfileKey !== from?.profileKey ||
+          globalDocument.activeAccountKey !== from?.accountKey) {
+        throw new Error('GlobalSettings does not match switch source authority');
+      }
+      exactWorkspace(workspace.value, to, to?.activeContextEpoch);
+      const nextGlobal = validateGlobalSettingsDocument({
+        ...globalDocument,
+        activeProfileKey: to.profileKey,
+        activeAccountKey: to.accountKey,
+      });
+      const nextWorkspace = exactWorkspace({
+        ...workspace.value,
+        activeContextEpoch: nextActiveContextEpoch,
+      }, to, nextActiveContextEpoch);
+      const globalAfter = serialized(nextGlobal);
+      const workspaceAfter = serialized(nextWorkspace);
+      try {
+        return Object.freeze({
+          globalSettings: Object.freeze({
+            before: receipt(global.data),
+            after: receipt(globalAfter),
+          }),
+          destinationWorkspace: Object.freeze({
+            before: receipt(workspace.data),
+            after: receipt(workspaceAfter),
+          }),
+        });
+      } finally {
+        globalAfter.fill(0);
+        workspaceAfter.fill(0);
+      }
+    } finally {
+      global.data.fill(0);
+      workspace.data.fill(0);
+    }
+  }
+
+  readState(journalValue) {
+    const journal = validateActiveContextSwitchJournal(journalValue);
+    return Object.freeze({
+      globalSettings: this.#readReceipt(this.globalSettings, 'GlobalSettings'),
+      destinationWorkspace: this.#readReceipt(
+        this.#workspaceStatePath(journal.to),
+        'destination Workspace',
+      ),
+    });
+  }
+
+  apply(journalValue) {
+    const journal = validateActiveContextSwitchJournal(journalValue);
+    if (journal.state !== 'ready') {
+      throw new TypeError('active context activation requires a ready switch journal');
+    }
+    const targets = [
+      {
+        name: 'destinationWorkspace',
+        path: this.#workspaceStatePath(journal.to),
+        build: (current) => serialized(exactWorkspace({
+          ...current,
+          activeContextEpoch: journal.nextActiveContextEpoch,
+        }, journal.to, journal.nextActiveContextEpoch)),
+      },
+      {
+        name: 'globalSettings',
+        path: this.globalSettings,
+        build: (current) => serialized(validateGlobalSettingsDocument({
+          ...current,
+          activeProfileKey: journal.to.profileKey,
+          activeAccountKey: journal.to.accountKey,
+        })),
+      },
+    ];
+    for (const target of targets) this.#applyTarget(target, journal.activation[target.name]);
+    const observed = this.readState(journal);
+    if (!sameReceipt(observed.globalSettings, journal.activation.globalSettings.after) ||
+        !sameReceipt(
+          observed.destinationWorkspace,
+          journal.activation.destinationWorkspace.after,
+        )) {
+      throw new Error('active context activation did not reach its after receipts');
+    }
+    return true;
+  }
+
+  #applyTarget(target, transition) {
+    const current = this.#readDocument(target.path, target.name);
+    try {
+      const currentReceipt = receipt(current.data);
+      if (sameReceipt(currentReceipt, transition.after)) return;
+      if (!sameReceipt(currentReceipt, transition.before)) {
+        throw new Error(`active context activation target changed: ${target.name}`);
+      }
+      const next = target.build(current.value);
+      try {
+        if (!sameReceipt(receipt(next), transition.after)) {
+          throw new Error(`active context activation plan drifted: ${target.name}`);
+        }
+        if (!atomicWritePrivateFile(
+          target.path,
+          next,
+          this.fileSystem,
+          storageOptions(this.platform, this.windowsAcl),
+        )) {
+          throw new Error(`active context activation write failed: ${target.name}`);
+        }
+      } finally {
+        next.fill(0);
+      }
+    } finally {
+      current.data.fill(0);
+    }
+  }
+
+  #readReceipt(file, name) {
+    const current = this.#readDocument(file, name);
+    try { return receipt(current.data); }
+    finally { current.data.fill(0); }
+  }
+
+  #readDocument(file, name) {
+    if (this.platform === 'win32' && !this.windowsAcl.verify(file)) {
+      throw new Error(`${name} ACL is invalid`);
+    }
+    let data;
+    try {
+      ({ data } = readPrivateFileBounded(file, {
+        maxBytes: MAX_TARGET_BYTES,
+        minBytes: 2,
+        platform: this.platform,
+        fileSystem: this.fileSystem,
+      }));
+    } catch (error) {
+      throw new Error(`${name} is unavailable`, { cause: error });
+    }
+    try {
+      return { data, value: JSON.parse(data.toString('utf8')) };
+    } catch (error) {
+      data.fill(0);
+      throw new Error(`${name} is invalid`, { cause: error });
+    }
+  }
+
+  #workspaceStatePath(context) {
+    return createProfileAccountWorkspaceLayout({
+      userData: this.userData,
+      profileKey: context?.profileKey,
+      accountKey: context?.accountKey,
+      workspaceKey: context?.workspaceKey,
+    }).workspace.state;
+  }
+}
+
+module.exports = { ActiveContextActivationStore };

--- a/desktop/lib/active-context-switch-coordinator.js
+++ b/desktop/lib/active-context-switch-coordinator.js
@@ -21,6 +21,21 @@ function sameReceipt(value, expected) {
     value.bytes === expected.bytes && value.sha256 === expected.sha256);
 }
 
+const ACTIVATION_TARGETS = Object.freeze(['globalSettings', 'destinationWorkspace']);
+
+function activationStatus(value, activation) {
+  if (!value || typeof value !== 'object') return 'unknown';
+  const states = ACTIVATION_TARGETS.map((target) => {
+    if (sameReceipt(value[target], activation[target].before)) return 'before';
+    if (sameReceipt(value[target], activation[target].after)) return 'after';
+    return 'unknown';
+  });
+  if (states.includes('unknown')) return 'unknown';
+  if (states.every((state) => state === 'before')) return 'before';
+  if (states.every((state) => state === 'after')) return 'after';
+  return 'mixed';
+}
+
 function sameDocument(left, right) {
   return JSON.stringify(left) === JSON.stringify(right);
 }
@@ -138,7 +153,7 @@ class ActiveContextSwitchCoordinator {
 
   async #resumePrepared(journal) {
     await this.#requireStep('browser-gate', this.gateBrowser, journal);
-    this.#requireActivationReceipt(journal.activation.before, 'source-authority');
+    this.#requireActivationState(journal, 'before', 'source-authority');
     await this.#requireStep('source-validation', this.validateSource, journal);
     await this.#requireStep('continuation-cancel', this.cancelContinuations, journal);
     await this.#requireStep('browser-close', this.closeBrowserWorkspace, journal);
@@ -167,8 +182,9 @@ class ActiveContextSwitchCoordinator {
   }
 
   async #activateReady(journal) {
-    const observed = this.#activationReceipt();
-    if (sameReceipt(observed, journal.activation.before)) {
+    const observed = this.#activationState(journal);
+    const status = activationStatus(observed, journal.activation);
+    if (status === 'before' || status === 'mixed') {
       try {
         if (await this.applyActivation(journal) !== true) {
           throw new Error('activation callback did not confirm its commit');
@@ -180,8 +196,8 @@ class ActiveContextSwitchCoordinator {
           error,
         );
       }
-      this.#requireActivationReceipt(journal.activation.after, 'activation');
-    } else if (!sameReceipt(observed, journal.activation.after)) {
+      this.#requireActivationState(journal, 'after', 'activation');
+    } else if (status !== 'after') {
       throw new ActiveContextSwitchError(
         'ACTIVE_CONTEXT_SWITCH_ACTIVATION_AMBIGUOUS',
         'activation',
@@ -209,7 +225,7 @@ class ActiveContextSwitchCoordinator {
   }
 
   async #finishCommitted(journal) {
-    this.#requireActivationReceipt(journal.activation.after, 'committed-authority');
+    this.#requireActivationState(journal, 'after', 'committed-authority');
     try {
       if (this.journalStore.clearCommitted() !== true) {
         throw new Error('committed journal was not cleared');
@@ -231,8 +247,8 @@ class ActiveContextSwitchCoordinator {
     });
   }
 
-  #activationReceipt() {
-    try { return this.readActivationReceipt(); }
+  #activationState(journal) {
+    try { return this.readActivationReceipt(journal); }
     catch (error) {
       throw new ActiveContextSwitchError(
         'ACTIVE_CONTEXT_SWITCH_AUTHORITY_UNREADABLE',
@@ -242,8 +258,8 @@ class ActiveContextSwitchCoordinator {
     }
   }
 
-  #requireActivationReceipt(expected, stage) {
-    if (!sameReceipt(this.#activationReceipt(), expected)) {
+  #requireActivationState(journal, expected, stage) {
+    if (activationStatus(this.#activationState(journal), journal.activation) !== expected) {
       throw new ActiveContextSwitchError(
         'ACTIVE_CONTEXT_SWITCH_AUTHORITY_MISMATCH',
         stage,

--- a/desktop/lib/active-context-switch-journal.js
+++ b/desktop/lib/active-context-switch-journal.js
@@ -111,14 +111,30 @@ function receipt(value, name) {
   return Object.freeze({ present: true, bytes: source.bytes, sha256: source.sha256 });
 }
 
-function activation(value) {
-  const source = exactKeys(value, ['before', 'after'], 'active context activation');
-  const before = receipt(source.before, 'active context activation before receipt');
-  const after = receipt(source.after, 'active context activation after receipt');
+function receiptTransition(value, name) {
+  const source = exactKeys(value, ['before', 'after'], name);
+  const before = receipt(source.before, `${name} before receipt`);
+  const after = receipt(source.after, `${name} after receipt`);
   if (before.bytes === after.bytes && before.sha256 === after.sha256) {
-    throw new TypeError('active context activation must change GlobalSettings');
+    throw new TypeError(`${name} must change its target`);
   }
   return Object.freeze({ before, after });
+}
+
+function activation(value) {
+  const source = exactKeys(value, [
+    'globalSettings', 'destinationWorkspace',
+  ], 'active context activation');
+  return Object.freeze({
+    globalSettings: receiptTransition(
+      source.globalSettings,
+      'active context GlobalSettings activation',
+    ),
+    destinationWorkspace: receiptTransition(
+      source.destinationWorkspace,
+      'active context destination Workspace activation',
+    ),
+  });
 }
 
 function expectedOutcomes(state, engineGeneration) {

--- a/desktop/lib/active-context-switch-startup.js
+++ b/desktop/lib/active-context-switch-startup.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const {
+  ActiveContextSwitchJournalStore,
+} = require('./active-context-switch-store');
+
+function assertActiveContextSwitchStartupClear({
+  mode,
+  filePath,
+  createStore = (options) => new ActiveContextSwitchJournalStore(options),
+} = {}) {
+  if (!['legacy-flat', 'profile-workspace'].includes(mode) ||
+      typeof filePath !== 'string' || !filePath || typeof createStore !== 'function') {
+    throw new TypeError('active context startup guard inputs are invalid');
+  }
+  if (mode === 'legacy-flat') return Object.freeze({ clear: true, mode });
+  let journal;
+  try { journal = createStore({ filePath }).read(); }
+  catch (cause) {
+    const error = new Error('active context switch authority is unreadable', { cause });
+    error.code = 'ACTIVE_CONTEXT_SWITCH_UNREADABLE';
+    throw error;
+  }
+  if (journal !== null) {
+    const error = new Error('active context switch recovery is required');
+    error.code = 'ACTIVE_CONTEXT_SWITCH_RECOVERY_REQUIRED';
+    error.switchState = journal.state;
+    throw error;
+  }
+  return Object.freeze({ clear: true, mode });
+}
+
+module.exports = { assertActiveContextSwitchStartupClear };

--- a/desktop/lib/app-data-dir.js
+++ b/desktop/lib/app-data-dir.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const { assertActiveContextSwitchStartupClear } = require('./active-context-switch-startup');
 const { DesktopPersistenceRuntime } = require('./desktop-persistence-runtime');
 const { LegacyMigrationCredentialOwner } = require('./legacy-migration-inputs');
 const { selectProfileWorkspacePreReadyStorage } =
@@ -20,6 +21,7 @@ function resolveUserDataOverride(rawValue) {
 }
 
 module.exports = {
+  assertActiveContextSwitchStartupClear,
   createLegacyRuntimeStoragePaths,
   DesktopPersistenceRuntime,
   LegacyMigrationCredentialOwner,

--- a/desktop/lib/legacy-flat-source-receipts.js
+++ b/desktop/lib/legacy-flat-source-receipts.js
@@ -21,6 +21,7 @@ const LEGACY_SOURCE_MAX_BYTES = Object.freeze({
   certificateTrust: 2 * 1024 * 1024,
   engineOwner: 64 * 1024,
   credentialTransaction: 2 * 1024 * 1024,
+  activeContextSwitch: 256 * 1024,
   proxyCredential: 64 * 1024,
   proxyHelperCredential: 1024,
   engineLog: 16 * 1024 * 1024,

--- a/desktop/lib/profile-workspace-layout.js
+++ b/desktop/lib/profile-workspace-layout.js
@@ -46,6 +46,7 @@ function createLegacyFlatSourcePaths(userData) {
     certificateTrust: path.join(root, 'campus-certificate-trust.json'),
     engineOwner: path.join(root, 'engine-owner.json'),
     credentialTransaction: path.join(root, 'credential-settings-transaction.json'),
+    activeContextSwitch: path.join(root, 'active-context-switch.json'),
     proxyCredential: path.join(root, 'proxy-credential.bin'),
     proxyHelperCredential: path.join(root, 'proxy-helper-credential.txt'),
     engineLog: path.join(root, 'engine.log'),

--- a/desktop/lib/profile-workspace-migration-journal.js
+++ b/desktop/lib/profile-workspace-migration-journal.js
@@ -21,6 +21,7 @@ const LEGACY_SOURCE_IDS = Object.freeze([
   'certificateTrust',
   'engineOwner',
   'credentialTransaction',
+  'activeContextSwitch',
   'proxyCredential',
   'proxyHelperCredential',
   'engineLog',
@@ -30,6 +31,7 @@ const LEGACY_SOURCE_IDS = Object.freeze([
 const REQUIRED_ABSENT_LEGACY_SOURCE_IDS = Object.freeze([
   'engineOwner',
   'credentialTransaction',
+  'activeContextSwitch',
   'proxyHelperCredential',
 ]);
 const DESTINATION_RECEIPT_IDS = Object.freeze([

--- a/desktop/lib/runtime-storage-paths.js
+++ b/desktop/lib/runtime-storage-paths.js
@@ -20,6 +20,7 @@ const RUNTIME_PATH_KEYS = Object.freeze([
   'certificateTrust',
   'engineOwner',
   'credentialTransaction',
+  'activeContextSwitch',
   'proxyCredential',
   'proxyHelperCredential',
 ]);
@@ -61,6 +62,7 @@ function createLegacyRuntimeStoragePaths(userData) {
     certificateTrust: legacy.certificateTrust,
     engineOwner: legacy.engineOwner,
     credentialTransaction: legacy.credentialTransaction,
+    activeContextSwitch: legacy.activeContextSwitch,
     proxyCredential: legacy.proxyCredential,
     proxyHelperCredential: legacy.proxyHelperCredential,
   });
@@ -85,6 +87,7 @@ function createProfileWorkspaceRuntimeStoragePaths(authority) {
     certificateTrust: layout.workspace.certificateTrust,
     engineOwner: layout.global.engineOwner,
     credentialTransaction: layout.account.credentialTransaction,
+    activeContextSwitch: layout.global.activeContextSwitch,
     proxyCredential: layout.global.proxyCredential,
     proxyHelperCredential: layout.global.proxyHelperCredential,
   });

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -20,7 +20,7 @@ const {
   recoverCredentialSettingsTransaction,
   runCredentialSettingsMutation,
 } = require('./lib/credential-settings-transaction');
-const { createLegacyRuntimeStoragePaths, DesktopPersistenceRuntime, LegacyMigrationCredentialOwner, ProfileWorkspaceStartupRuntime, relaunchAfterPersistenceMigration, resolveUserDataOverride, selectProfileWorkspacePreReadyStorage, writePersistenceE2EMarker } = require('./lib/app-data-dir');
+const { assertActiveContextSwitchStartupClear, createLegacyRuntimeStoragePaths, DesktopPersistenceRuntime, LegacyMigrationCredentialOwner, ProfileWorkspaceStartupRuntime, relaunchAfterPersistenceMigration, resolveUserDataOverride, selectProfileWorkspacePreReadyStorage, writePersistenceE2EMarker } = require('./lib/app-data-dir');
 const {
   classifyEngineCode,
   classifyEngineOutput,
@@ -129,6 +129,7 @@ const CAMPUS_CREDENTIALS = runtimeStoragePaths.siteCredentials;
 const CAMPUS_CERTIFICATE_TRUST = runtimeStoragePaths.certificateTrust;
 const ENGINE_OWNER = runtimeStoragePaths.engineOwner;
 const CREDENTIAL_TRANSACTION = runtimeStoragePaths.credentialTransaction;
+const ACTIVE_CONTEXT_SWITCH = runtimeStoragePaths.activeContextSwitch;
 const PROXY_CREDENTIAL = runtimeStoragePaths.proxyCredential;
 const PROXY_HELPER_CREDENTIAL = runtimeStoragePaths.proxyHelperCredential;
 const syntheticEngineE2e = !app.isPackaged && process.env[SYNTHETIC_ENGINE_E2E_ENV] === '1';
@@ -1204,11 +1205,9 @@ function browserPolicyProxyConfig(port) {
     proxyBypassRules: '<-loopback>',
   };
 }
-
 async function suspendOpenBrowserPolicy() {
   return campusBrowserManager.suspendRoutingPolicy();
 }
-
 async function resumeOpenBrowserPolicyIfLive() {
   if (!connectionState.isConnected() || !engineSupervisor.hasActive) return null;
   return campusBrowserManager.resumeRoutingPolicy(socksPort());
@@ -1576,6 +1575,7 @@ app.on('login', (event, webContents, _details, authInfo, callback) => {
   activeProxyCredential.answerProxyChallenge(authInfo, generation, callback);
 });
 app.whenReady().then(() => {
+  assertActiveContextSwitchStartupClear({ mode: preReadyStorage.mode, filePath: ACTIVE_CONTEXT_SWITCH });
   const persistence = persistenceRuntime.initialize();
   if (persistence.relaunchRequired) {
     relaunchAfterPersistenceMigration({ application: app, argv: process.argv,

--- a/desktop/test/active-context-activation-store.test.js
+++ b/desktop/test/active-context-activation-store.test.js
@@ -1,0 +1,188 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { ActiveContextActivationStore } = require('../lib/active-context-activation-store');
+const {
+  createPreparedActiveContextSwitch,
+  markActiveContextSwitchReady,
+} = require('../lib/active-context-switch-journal');
+const {
+  createProfileAccountWorkspaceLayout,
+} = require('../lib/profile-workspace-layout');
+
+function key(name, seed) { return `${name}-${String(seed).repeat(32)}`; }
+
+function context(profileId, profileSeed, accountSeed, workspaceSeed, epoch) {
+  return {
+    profileId,
+    profileKey: key('profile', profileSeed),
+    profileRevision: 1,
+    profileCredentialBindingRevision: 1,
+    accountKey: key('account', accountSeed),
+    accountRevision: 1,
+    accountCredentialRevision: 1,
+    workspaceKey: key('workspace', workspaceSeed),
+    activeContextEpoch: epoch,
+  };
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+}
+
+function fixture(t) {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'active-context-activation-'));
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const from = context('school-a', '1', '2', '3', 5);
+  const to = context('school-b', '4', '5', '6', 2);
+  const toLayout = createProfileAccountWorkspaceLayout({
+    userData,
+    profileKey: to.profileKey,
+    accountKey: to.accountKey,
+    workspaceKey: to.workspaceKey,
+  });
+  const globalSettings = path.join(userData, 'global', 'settings.json');
+  writeJson(globalSettings, {
+    schemaVersion: 1,
+    activeProfileKey: from.profileKey,
+    activeAccountKey: from.accountKey,
+    port: 6180,
+    strictProxyAuth: true,
+    proxySecurityVersion: 3,
+    proxyAuthMigrationPending: false,
+    closeAction: 'ask',
+    language: 'auto',
+    startAtLogin: false,
+  });
+  writeJson(toLayout.workspace.state, {
+    schemaVersion: 1,
+    profileId: to.profileId,
+    profileRevision: to.profileRevision,
+    accountKey: to.accountKey,
+    accountRevision: to.accountRevision,
+    workspaceKey: to.workspaceKey,
+    activeContextEpoch: to.activeContextEpoch,
+  });
+  return {
+    userData,
+    from,
+    to,
+    toLayout,
+    globalSettings,
+    store: new ActiveContextActivationStore({ userData }),
+  };
+}
+
+function ready(value) {
+  const activation = value.store.plan({
+    from: value.from,
+    to: value.to,
+    nextActiveContextEpoch: 6,
+  });
+  const prepared = createPreparedActiveContextSwitch({
+    from: value.from,
+    to: value.to,
+    nextActiveContextEpoch: 6,
+    engineGeneration: 7,
+    activation,
+    randomBytes: () => Buffer.alloc(16, 0xaa),
+    now: () => 1_800_000_000_000,
+  });
+  return markActiveContextSwitchReady(prepared, { now: () => 1_800_000_000_100 });
+}
+
+test('plan binds and apply commits destination epoch before active GlobalSettings pair', (t) => {
+  const value = fixture(t);
+  const journal = ready(value);
+  const before = value.store.readState(journal);
+  assert.deepEqual(before, {
+    globalSettings: journal.activation.globalSettings.before,
+    destinationWorkspace: journal.activation.destinationWorkspace.before,
+  });
+  assert.equal(value.store.apply(journal), true);
+  assert.deepEqual(value.store.readState(journal), {
+    globalSettings: journal.activation.globalSettings.after,
+    destinationWorkspace: journal.activation.destinationWorkspace.after,
+  });
+  const global = JSON.parse(fs.readFileSync(value.globalSettings, 'utf8'));
+  const workspace = JSON.parse(fs.readFileSync(value.toLayout.workspace.state, 'utf8'));
+  assert.equal(global.activeProfileKey, value.to.profileKey);
+  assert.equal(global.activeAccountKey, value.to.accountKey);
+  assert.equal(workspace.activeContextEpoch, 6);
+});
+
+test('crash between Workspace and GlobalSettings writes resumes mixed activation', (t) => {
+  const value = fixture(t);
+  const journal = ready(value);
+  const injected = Object.create(fs);
+  injected.renameSync = (source, destination) => {
+    if (destination === value.globalSettings) throw new Error('synthetic activation crash');
+    return fs.renameSync(source, destination);
+  };
+  const crashing = new ActiveContextActivationStore({
+    userData: value.userData,
+    fileSystem: injected,
+  });
+  assert.throws(() => crashing.apply(journal), /write failed: globalSettings/u);
+  assert.deepEqual(value.store.readState(journal), {
+    globalSettings: journal.activation.globalSettings.before,
+    destinationWorkspace: journal.activation.destinationWorkspace.after,
+  });
+  assert.equal(value.store.apply(journal), true);
+  assert.deepEqual(value.store.readState(journal), {
+    globalSettings: journal.activation.globalSettings.after,
+    destinationWorkspace: journal.activation.destinationWorkspace.after,
+  });
+});
+
+test('out-of-band target mutation blocks before activation can overwrite it', (t) => {
+  const value = fixture(t);
+  const journal = ready(value);
+  const workspace = JSON.parse(fs.readFileSync(value.toLayout.workspace.state, 'utf8'));
+  writeJson(value.toLayout.workspace.state, { ...workspace, accountRevision: 2 });
+  assert.throws(() => value.store.apply(journal), /target changed: destinationWorkspace/u);
+  const global = JSON.parse(fs.readFileSync(value.globalSettings, 'utf8'));
+  assert.equal(global.activeProfileKey, value.from.profileKey);
+});
+
+test('planning rejects source authority or destination Workspace drift', (t) => {
+  const value = fixture(t);
+  assert.throws(() => value.store.plan({
+    from: { ...value.from, accountKey: key('account', '9') },
+    to: value.to,
+    nextActiveContextEpoch: 6,
+  }), /source authority/u);
+  const workspace = JSON.parse(fs.readFileSync(value.toLayout.workspace.state, 'utf8'));
+  writeJson(value.toLayout.workspace.state, { ...workspace, profileId: 'other-school' });
+  assert.throws(() => value.store.plan({
+    from: value.from,
+    to: value.to,
+    nextActiveContextEpoch: 6,
+  }), /destination Workspace state/u);
+});
+
+test('simulated Windows verifies source ACLs and protects both committed targets', (t) => {
+  const value = fixture(t);
+  const protectedPaths = [];
+  const verifiedPaths = [];
+  const windowsAcl = {
+    protect(file) { protectedPaths.push(file); return true; },
+    verify(file) { verifiedPaths.push(file); return fs.existsSync(file); },
+  };
+  const store = new ActiveContextActivationStore({
+    userData: value.userData,
+    platform: 'win32',
+    windowsAcl,
+  });
+  value.store = store;
+  const journal = ready(value);
+  assert.equal(store.apply(journal), true);
+  assert.equal(verifiedPaths.includes(value.globalSettings), true);
+  assert.equal(verifiedPaths.includes(value.toLayout.workspace.state), true);
+  assert.equal(protectedPaths.filter((file) => file.endsWith('.tmp')).length, 2);
+});

--- a/desktop/test/active-context-switch-coordinator.test.js
+++ b/desktop/test/active-context-switch-coordinator.test.js
@@ -37,12 +37,36 @@ function receipt(seed) {
   return { present: true, bytes: seed + 100, sha256: seed.toString(16).padStart(64, '0') };
 }
 
+function activation(seed) {
+  return {
+    globalSettings: { before: receipt(seed), after: receipt(seed + 1) },
+    destinationWorkspace: { before: receipt(seed + 2), after: receipt(seed + 3) },
+  };
+}
+
+function activationState(value, state) {
+  return {
+    globalSettings: value.globalSettings[state],
+    destinationWorkspace: value.destinationWorkspace[state],
+  };
+}
+
+function activationFromStates(before, after) {
+  return {
+    globalSettings: { before: before.globalSettings, after: after.globalSettings },
+    destinationWorkspace: {
+      before: before.destinationWorkspace,
+      after: after.destinationWorkspace,
+    },
+  };
+}
+
 function switchRequest(overrides = {}) {
   return {
     from: context('school-a', '1', '2', '3', 3),
     to: context('school-b', '4', '5', '6', 1),
     engineGeneration: 8,
-    activation: { before: receipt(1), after: receipt(2) },
+    activation: activation(1),
     randomBytes: () => Buffer.alloc(16, 0xaa),
     now: () => 1_700_000_000_000,
     ...overrides,
@@ -55,7 +79,7 @@ function fixture(t, overrides = {}) {
   const store = new ActiveContextSwitchJournalStore({
     filePath: path.join(root, 'global', 'active-context-switch.json'),
   });
-  let currentReceipt = overrides.currentReceipt || receipt(1);
+  let currentReceipt = overrides.currentReceipt || activationState(activation(1), 'before');
   const calls = [];
   const outcomes = {
     gateBrowser: true,
@@ -82,7 +106,7 @@ function fixture(t, overrides = {}) {
       const value = outcomes.applyActivation;
       if (typeof value === 'function') return value(journal, (next) => { currentReceipt = next; });
       if (value === false) return false;
-      currentReceipt = journal.activation.after;
+      currentReceipt = activationState(journal.activation, 'after');
       return true;
     },
     gateBrowser: operation('gateBrowser'),
@@ -133,7 +157,7 @@ test('clean switch gates old context before one activation and clears its journa
     'applyActivation',
     'activateRuntime',
   ]);
-  assert.deepEqual(value.receipt(), receipt(2));
+  assert.deepEqual(value.receipt(), activationState(activation(1), 'after'));
   assert.equal(value.store.read(), null);
 });
 
@@ -143,7 +167,7 @@ test('failed cleanup leaves prepared authority gated and a later recovery resume
     error.code === 'ACTIVE_CONTEXT_SWITCH_ENGINE_STOP_FAILED'
   ));
   assert.equal(value.store.read().state, 'prepared');
-  assert.deepEqual(value.receipt(), receipt(1));
+  assert.deepEqual(value.receipt(), activationState(activation(1), 'before'));
   assert.equal(value.calls.some(([name]) => name === 'applyActivation'), false);
 
   value.outcomes.stopEngine = true;
@@ -155,7 +179,13 @@ test('failed cleanup leaves prepared authority gated and a later recovery resume
 
 test('ready journal recovers both before-activation and after-activation crash points', async (t) => {
   for (const alreadyApplied of [false, true]) {
-    const value = fixture(t, { currentReceipt: alreadyApplied ? receipt(2) : receipt(1) });
+    const requestedActivation = activation(1);
+    const value = fixture(t, {
+      currentReceipt: activationState(
+        requestedActivation,
+        alreadyApplied ? 'after' : 'before',
+      ),
+    });
     const prepared = createPreparedActiveContextSwitch(switchRequest());
     const ready = markActiveContextSwitchReady(prepared, { now: () => 1_700_000_000_100 });
     value.store.prepare(prepared);
@@ -171,11 +201,28 @@ test('ready journal recovers both before-activation and after-activation crash p
   }
 });
 
+test('mixed two-file activation is resumed as redo instead of becoming ambiguous', async (t) => {
+  const requestedActivation = activation(1);
+  const value = fixture(t, {
+    currentReceipt: {
+      globalSettings: requestedActivation.globalSettings.after,
+      destinationWorkspace: requestedActivation.destinationWorkspace.before,
+    },
+  });
+  const prepared = createPreparedActiveContextSwitch(switchRequest());
+  const ready = markActiveContextSwitchReady(prepared, { now: () => 1_700_000_000_100 });
+  value.store.prepare(prepared);
+  value.store.markReady(ready);
+  assert.equal((await value.coordinator.recover()).status, 'activated');
+  assert.equal(value.calls.filter(([name]) => name === 'applyActivation').length, 1);
+  assert.deepEqual(value.receipt(), activationState(requestedActivation, 'after'));
+});
+
 test('activation callback uncertainty remains ready and recovery proves the visible receipt', async (t) => {
   const value = fixture(t, {
     outcomes: {
       applyActivation(journal, setReceipt) {
-        setReceipt(journal.activation.after);
+        setReceipt(activationState(journal.activation, 'after'));
         throw new Error('synthetic crash after activation rename');
       },
     },
@@ -184,14 +231,14 @@ test('activation callback uncertainty remains ready and recovery proves the visi
     error.code === 'ACTIVE_CONTEXT_SWITCH_ACTIVATION_FAILED'
   ));
   assert.equal(value.store.read().state, 'ready');
-  assert.deepEqual(value.receipt(), receipt(2));
+  assert.deepEqual(value.receipt(), activationState(activation(1), 'after'));
   assert.equal(value.calls.some(([name]) => name === 'activateRuntime'), false);
   value.outcomes.applyActivation = true;
   assert.equal((await value.coordinator.recover()).status, 'activated');
 });
 
 test('committed recovery requires new authority before clearing and runtime activation', async (t) => {
-  const value = fixture(t, { currentReceipt: receipt(2) });
+  const value = fixture(t, { currentReceipt: activationState(activation(1), 'after') });
   const prepared = createPreparedActiveContextSwitch(switchRequest());
   const ready = markActiveContextSwitchReady(prepared, { now: () => 1_700_000_000_100 });
   const committed = commitActiveContextSwitch(ready, { now: () => 1_700_000_000_200 });
@@ -217,7 +264,9 @@ test('journal clear uncertainty keeps committed authority gated until recovery',
 });
 
 test('ambiguous authority gates Browser but never cleans or activates either context', async (t) => {
-  const value = fixture(t, { currentReceipt: receipt(99) });
+  const value = fixture(t, {
+    currentReceipt: { globalSettings: receipt(99), destinationWorkspace: receipt(100) },
+  });
   const prepared = createPreparedActiveContextSwitch(switchRequest());
   value.store.prepare(prepared);
   await assert.rejects(value.coordinator.recover(), (error) => (
@@ -249,8 +298,11 @@ test('100 alternating synthetic Profile switches retain one authority and no jou
     'school-a': active,
     'school-b': context('school-b', '4', '5', '6', 1),
   };
-  let receiptSeed = 1;
-  value.setReceipt(receipt(receiptSeed));
+  let receiptSeed = 10;
+  value.setReceipt({
+    globalSettings: receipt(receiptSeed++),
+    destinationWorkspace: receipt(receiptSeed++),
+  });
   value.outcomes.activateRuntime = (journal) => {
     active = { ...journal.to, activeContextEpoch: journal.nextActiveContextEpoch };
     stored[active.profileId] = active;
@@ -258,13 +310,16 @@ test('100 alternating synthetic Profile switches retain one authority and no jou
   };
   for (let index = 0; index < 100; index++) {
     const destinationId = active.profileId === 'school-a' ? 'school-b' : 'school-a';
-    const nextReceipt = receipt(++receiptSeed);
+    const nextReceipt = {
+      globalSettings: receipt(receiptSeed++),
+      destinationWorkspace: receipt(receiptSeed++),
+    };
     const result = await value.coordinator.begin({
       from: active,
       to: stored[destinationId],
       nextActiveContextEpoch: index + 2,
       engineGeneration: index % 2 === 0 ? index + 1 : null,
-      activation: { before: value.receipt(), after: nextReceipt },
+      activation: activationFromStates(value.receipt(), nextReceipt),
     });
     assert.equal(result.activeContextEpoch, index + 2);
     assert.equal(active.profileId, destinationId);

--- a/desktop/test/active-context-switch-journal.test.js
+++ b/desktop/test/active-context-switch-journal.test.js
@@ -35,6 +35,13 @@ function receipt(seed) {
   return { present: true, bytes: seed + 20, sha256: seed.toString(16).padStart(64, '0') };
 }
 
+function activation(seed) {
+  return {
+    globalSettings: { before: receipt(seed), after: receipt(seed + 1) },
+    destinationWorkspace: { before: receipt(seed + 2), after: receipt(seed + 3) },
+  };
+}
+
 function profileSwitch(overrides = {}) {
   return {
     from: context(),
@@ -43,7 +50,7 @@ function profileSwitch(overrides = {}) {
       activeContextEpoch: 3,
     }),
     engineGeneration: 7,
-    activation: { before: receipt(1), after: receipt(2) },
+    activation: activation(1),
     randomBytes: () => Buffer.alloc(16, 0xab),
     now: () => 1_800_000_000_000,
     ...overrides,
@@ -86,7 +93,7 @@ test('an Engine-free account switch records not_required and keeps Profile autho
     to: context({ accountSeed: '7', workspaceSeed: '8', activeContextEpoch: 2 }),
     nextActiveContextEpoch: 9,
     engineGeneration: null,
-    activation: { before: receipt(3), after: receipt(4) },
+    activation: activation(3),
     randomBytes: () => Buffer.alloc(16, 0xcd),
     now: () => 1_800_000_001_000,
   });
@@ -116,8 +123,11 @@ test('switch journal rejects no-op, key reuse, Profile drift and stale epochs', 
 
 test('activation receipts and exact journal schema fail closed', () => {
   assert.throws(() => createPreparedActiveContextSwitch(profileSwitch({
-    activation: { before: receipt(1), after: receipt(1) },
-  })), /must change GlobalSettings/u);
+    activation: {
+      ...activation(1),
+      globalSettings: { before: receipt(1), after: receipt(1) },
+    },
+  })), /must change its target/u);
   const prepared = createPreparedActiveContextSwitch(profileSwitch());
   assert.throws(() => validateActiveContextSwitchJournal({ ...prepared, extra: true }),
     /invalid schema/u);
@@ -125,7 +135,13 @@ test('activation receipts and exact journal schema fail closed', () => {
     ...prepared,
     activation: {
       ...prepared.activation,
-      after: { ...prepared.activation.after, sha256: 'A'.repeat(64) },
+      globalSettings: {
+        ...prepared.activation.globalSettings,
+        after: {
+          ...prepared.activation.globalSettings.after,
+          sha256: 'A'.repeat(64),
+        },
+      },
     },
   }), /receipt is invalid/u);
   assert.throws(() => validateActiveContextSwitchJournal({

--- a/desktop/test/active-context-switch-startup.test.js
+++ b/desktop/test/active-context-switch-startup.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  assertActiveContextSwitchStartupClear,
+} = require('../lib/active-context-switch-startup');
+
+const FILE = path.resolve('/tmp/campus-active-context-switch.json');
+
+test('legacy mode defers to migration preconditions without opening a switch journal', () => {
+  let stores = 0;
+  assert.deepEqual(assertActiveContextSwitchStartupClear({
+    mode: 'legacy-flat',
+    filePath: FILE,
+    createStore: () => { stores += 1; throw new Error('must not open'); },
+  }), { clear: true, mode: 'legacy-flat' });
+  assert.equal(stores, 0);
+});
+
+test('Profile Workspace starts only when the exact switch path is absent', () => {
+  let observedPath = null;
+  assert.deepEqual(assertActiveContextSwitchStartupClear({
+    mode: 'profile-workspace',
+    filePath: FILE,
+    createStore: ({ filePath }) => ({
+      read() { observedPath = filePath; return null; },
+    }),
+  }), { clear: true, mode: 'profile-workspace' });
+  assert.equal(observedPath, FILE);
+});
+
+for (const state of ['prepared', 'ready', 'committed']) {
+  test(`${state} switch authority blocks startup before credentials or Browser`, () => {
+    assert.throws(() => assertActiveContextSwitchStartupClear({
+      mode: 'profile-workspace',
+      filePath: FILE,
+      createStore: () => ({ read: () => ({ state }) }),
+    }), (error) => error.code === 'ACTIVE_CONTEXT_SWITCH_RECOVERY_REQUIRED' &&
+      error.switchState === state);
+  });
+}
+
+test('unreadable or corrupt switch authority is distinct and fail closed', () => {
+  assert.throws(() => assertActiveContextSwitchStartupClear({
+    mode: 'profile-workspace',
+    filePath: FILE,
+    createStore: () => ({ read() { throw new Error('synthetic corruption'); } }),
+  }), (error) => error.code === 'ACTIVE_CONTEXT_SWITCH_UNREADABLE' &&
+    error.cause?.message === 'synthetic corruption');
+});

--- a/desktop/test/active-context-switch-store.test.js
+++ b/desktop/test/active-context-switch-store.test.js
@@ -34,12 +34,19 @@ function receipt(seed) {
   return { present: true, bytes: seed + 50, sha256: seed.toString(16).padStart(64, '0') };
 }
 
+function activation(seed) {
+  return {
+    globalSettings: { before: receipt(seed), after: receipt(seed + 1) },
+    destinationWorkspace: { before: receipt(seed + 2), after: receipt(seed + 3) },
+  };
+}
+
 function prepared(seed = 1) {
   return createPreparedActiveContextSwitch({
     from: context('school-a', '1', '2', '3', 4),
     to: context('school-b', '4', '5', '6', 2),
     engineGeneration: 9,
-    activation: { before: receipt(seed), after: receipt(seed + 1) },
+    activation: activation(seed),
     randomBytes: () => Buffer.alloc(16, seed),
     now: () => 1_800_000_000_000 + seed,
   });

--- a/desktop/test/legacy-flat-source-receipts.test.js
+++ b/desktop/test/legacy-flat-source-receipts.test.js
@@ -38,6 +38,7 @@ test('legacy source paths are the exact current flat userData authorities', () =
     certificateTrust: path.join(userData, 'campus-certificate-trust.json'),
     engineOwner: path.join(userData, 'engine-owner.json'),
     credentialTransaction: path.join(userData, 'credential-settings-transaction.json'),
+    activeContextSwitch: path.join(userData, 'active-context-switch.json'),
     proxyCredential: path.join(userData, 'proxy-credential.bin'),
     proxyHelperCredential: path.join(userData, 'proxy-helper-credential.txt'),
     engineLog: path.join(userData, 'engine.log'),

--- a/desktop/test/main-persistence-activation-contract.test.js
+++ b/desktop/test/main-persistence-activation-contract.test.js
@@ -27,12 +27,14 @@ test('pre-ready selection binds every service path before recovery or constructi
 
 test('after-ready migration uses the bounded relaunch owner before services can start', () => {
   const startup = section('app.whenReady().then(() => {', "app.on('window-all-closed'");
+  const switchGuard = startup.indexOf('assertActiveContextSwitchStartupClear(');
   const initialize = startup.indexOf('persistenceRuntime.initialize()');
   const relaunch = startup.indexOf('relaunchAfterPersistenceMigration(');
   const log = startup.indexOf('initializeLogWriter()');
   const tray = startup.indexOf('desktopShell.createTray()');
   const network = startup.indexOf('networkStartupCoordinator.start()');
-  assert.ok(initialize >= 0 && relaunch > initialize && log > relaunch && tray > log && network > tray);
+  assert.ok(switchGuard >= 0 && initialize > switchGuard && relaunch > initialize &&
+    log > relaunch && tray > log && network > tray);
   assert.match(startup, /if \(persistence\.relaunchRequired\) \{[\s\S]*relaunchAfterPersistenceMigration\(\{[\s\S]*developmentEntry: __dirname \}\);\s*return;/u);
   assert.match(source, /let logWriter = null;[\s\S]*function initializeLogWriter\(\)/u);
 });

--- a/desktop/test/runtime-storage-paths.test.js
+++ b/desktop/test/runtime-storage-paths.test.js
@@ -21,6 +21,7 @@ test('legacy path seam is an exact behavior-preserving projection', () => {
   assert.equal(paths.vpnCredential, path.join(USER_DATA, 'cred.bin'));
   assert.equal(paths.externalPac, path.join(USER_DATA, 'routing.pac'));
   assert.equal(paths.browserPac, path.join(USER_DATA, 'campus-browser-routing.pac'));
+  assert.equal(paths.activeContextSwitch, path.join(USER_DATA, 'active-context-switch.json'));
   assert.deepEqual(
     Object.keys(paths).filter((key) => !['mode', 'root'].includes(key)),
     [...RUNTIME_PATH_KEYS],
@@ -43,6 +44,7 @@ test('Profile Workspace path seam assigns every service to its owner scope', () 
   assert.equal(paths.routingRules, layout.workspace.routingRules);
   assert.equal(paths.siteCredentials, layout.workspace.siteCredentials);
   assert.equal(paths.settingsBackup, layout.global.settingsTransaction);
+  assert.equal(paths.activeContextSwitch, layout.global.activeContextSwitch);
   for (const sensitive of ['student001', 'remote.hkust-gz.edu.cn']) {
     assert.equal(JSON.stringify(paths).includes(sensitive), false);
   }


### PR DESCRIPTION
## 目标

补齐 ActiveContext switch 的真实持久化激活边界：Profile/Account pair 位于 GlobalSettings，但 monotonic activeContextEpoch 位于 destination Workspace state，两者必须由同一 journal 绑定并可从 mixed crash 状态恢复。

本 PR 堆叠在 #33 之上。生产 registry 仍只允许 HKUST/primary，因此暂不开放切换操作；pending switch 在 credential/Browser/Engine 启动前 fail closed。

## 核心变化

- `activeContextSwitch` 正式进入 runtime storage path seam：
  - legacy：`userData/active-context-switch.json`，迁移要求其必须不存在；
  - Profile Workspace：`global/active-context-switch.json`。
- journal activation 从单个 GlobalSettings receipt 升级为两个 target：
  - GlobalSettings before/after；
  - destination Workspace state before/after。
- coordinator recovery 分类：
  - all-before：执行 activation；
  - mixed：按 redo 恢复缺失 target；
  - all-after：提交 journal；
  - 任一 unknown receipt：fail closed。
- 新增 ActiveContextActivationStore：
  - 验证 source active Profile/Account；
  - 验证 destination Profile/Account/Workspace authority；
  - 先提交 destination epoch，再提交 GlobalSettings active pair；
  - 每个 target 仅接受 before 或 after receipt，拒绝外部漂移；
  - owner-only atomic write、POSIX private-file 检查、Windows ACL。
- Main 启动 guard：
  - legacy 状态由迁移 required-absent gate 处理；
  - Profile Workspace 若存在 prepared/ready/committed 或损坏 journal，在 persistence.initialize/credential decrypt、Browser、Engine 之前停止。

## 为什么暂不自动恢复生产 journal

当前 packaged registry 强制只有 HKUST/primary，尚不能解析 journal 指向的 destination reviewed Profile。此时自动“恢复”会绕过 Profile/config/Gateway 验证。P6 增加第二 reviewed Profile 后，才能把本 PR 的 activation store 与 #29 coordinator 接入 Main recovery。

## 验证

- 两 target clean activation。
- Workspace 已写、GlobalSettings 未写的 mixed crash redo。
- out-of-band target mutation fail closed。
- source/destination authority drift rejection。
- Windows read ACL + temporary/committed DACL。
- Main startup ordering contract：switch guard 早于 persistence.initialize。
- Desktop 全量：788 passed，0 failed，1 Windows-only skipped。
- Main integration、Engine lifecycle、initially-offline、two-process migration：全部通过。
- Architecture：mainDeps=35、mainLines=1644、0 cycles。
- 全部 JS syntax 与 staged secret gate：通过。
