### PR TITLE
2.0 P4h: enforce active-context cleanup barrier

### DIFF
--- a/desktop/lib/active-context-switch-barrier.js
+++ b/desktop/lib/active-context-switch-barrier.js
@@ -1,0 +1,105 @@
+'use strict';
+
+function requiredFunction(value, name) {
+  if (typeof value !== 'function') throw new TypeError(`${name} must be a function`);
+  return value;
+}
+
+class ActiveContextSwitchBarrier {
+  constructor({
+    invalidateContext,
+    suspendBrowser,
+    browserBoundaryClosed,
+    cancelAuth,
+    cancelConnectivity,
+    cancelMutations,
+    closeBrowser,
+    browserClosed,
+    stopEngine,
+    revokeProxyAccess,
+    clearServerState,
+  } = {}) {
+    for (const [name, value] of Object.entries({
+      invalidateContext,
+      suspendBrowser,
+      browserBoundaryClosed,
+      cancelAuth,
+      cancelConnectivity,
+      cancelMutations,
+      closeBrowser,
+      browserClosed,
+      stopEngine,
+      revokeProxyAccess,
+      clearServerState,
+    })) requiredFunction(value, name);
+    Object.assign(this, {
+      invalidateContext,
+      suspendBrowser,
+      browserBoundaryClosed,
+      cancelAuth,
+      cancelConnectivity,
+      cancelMutations,
+      closeBrowser,
+      browserClosed,
+      stopEngine,
+      revokeProxyAccess,
+      clearServerState,
+    });
+  }
+
+  async gateBrowser() {
+    // Token invalidation is synchronous and precedes every await. Even if PAC
+    // suspension fails, old Engine/health/MFA/mutation callbacks are stale.
+    this.invalidateContext();
+    try { await this.suspendBrowser(); }
+    catch { return false; }
+    return this.browserBoundaryClosed() === true;
+  }
+
+  async cancelContinuations() {
+    try {
+      this.cancelAuth();
+      this.cancelConnectivity();
+      return await this.cancelMutations() === true;
+    } catch {
+      return false;
+    }
+  }
+
+  async closeBrowserWorkspace() {
+    try { await this.closeBrowser(); }
+    catch { return false; }
+    return this.browserClosed() === true;
+  }
+
+  async confirmEngineStop(journal) {
+    if (journal?.engineGeneration === null) return true;
+    let result;
+    try { result = await this.stopEngine(journal?.engineGeneration); }
+    catch { return false; }
+    return result?.ok === true && result.cleanExit !== false;
+  }
+
+  async revokeProxy() {
+    try { return await this.revokeProxyAccess() === true; }
+    catch { return false; }
+  }
+
+  async clearServer() {
+    try { return await this.clearServerState() === true; }
+    catch { return false; }
+  }
+
+  hooks() {
+    return Object.freeze({
+      gateBrowser: () => this.gateBrowser(),
+      cancelContinuations: () => this.cancelContinuations(),
+      closeBrowserWorkspace: () => this.closeBrowserWorkspace(),
+      stopEngine: (journal) => this.confirmEngineStop(journal),
+      revokeProxyAccess: () => this.revokeProxy(),
+      clearServerState: () => this.clearServer(),
+    });
+  }
+}
+
+module.exports = { ActiveContextSwitchBarrier };

--- a/desktop/lib/campus-browser-manager.js
+++ b/desktop/lib/campus-browser-manager.js
@@ -59,6 +59,8 @@ class CampusBrowserManager {
 
   get routingRequestsBlocked() { return this.browser?.routingRequestsBlocked; }
 
+  get hasBrowser() { return this.browser !== null; }
+
   getOrCreate() {
     if (this.browser) return this.browser;
     const credentialVault = new this.CredentialVaultClass({
@@ -131,7 +133,9 @@ class CampusBrowserManager {
   }
 
   close() {
-    return this.browser?.close() ?? null;
+    const browser = this.browser;
+    this.browser = null;
+    return browser?.close() ?? null;
   }
 
   ownsWebContents(contents) {

--- a/desktop/lib/external-proxy-credential-store.js
+++ b/desktop/lib/external-proxy-credential-store.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
 const util = require('node:util');
 const {
   atomicWritePrivateFile,
@@ -8,6 +10,10 @@ const {
 } = require('./credential-store');
 const { readPrivateFileBounded } = require('./private-file');
 const { RANDOM_SECRET_BYTES } = require('./proxy-credential');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
 
 const DOCUMENT_VERSION = 1;
 const MAX_ENCRYPTED_PROXY_CREDENTIAL_BYTES = 64 * 1024;
@@ -34,6 +40,21 @@ function generateSecret(randomBytes) {
     throw storageError('secure proxy credential generation failed');
   }
   return bytes.toString('base64url');
+}
+
+function fsyncDirectory(directory, fileSystem, platform) {
+  let descriptor = null;
+  try {
+    descriptor = fileSystem.openSync(directory, 'r');
+    fileSystem.fsyncSync?.(descriptor);
+    return true;
+  } catch {
+    return platform === 'win32';
+  } finally {
+    if (descriptor !== null) {
+      try { fileSystem.closeSync(descriptor); } catch {}
+    }
+  }
 }
 
 class StableProxyCredential {
@@ -87,10 +108,17 @@ class ExternalProxyCredentialStore {
     safeStorage,
     platform = process.platform,
     randomBytes = crypto.randomBytes,
-    fileSystem,
+    fileSystem = fs,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
   } = {}) {
     if (typeof filePath !== 'string' || !filePath ||
-        !safeStorage || typeof randomBytes !== 'function') {
+        !safeStorage || typeof randomBytes !== 'function' || !fileSystem ||
+        typeof fileSystem.openSync !== 'function' ||
+        (platform === 'win32' &&
+          (typeof windowsAcl?.protect !== 'function' || typeof windowsAcl?.verify !== 'function'))) {
       throw new TypeError('external proxy credential store options are invalid');
     }
     this.filePath = filePath;
@@ -98,6 +126,7 @@ class ExternalProxyCredentialStore {
     this.platform = platform;
     this.randomBytes = randomBytes;
     this.fileSystem = fileSystem;
+    this.windowsAcl = windowsAcl;
   }
 
   encryptionAvailable() {
@@ -114,6 +143,11 @@ class ExternalProxyCredentialStore {
     }
     let encrypted;
     try {
+      if (this.platform === 'win32' && !this.windowsAcl.verify(this.filePath)) {
+        try { this.fileSystem.lstatSync(this.filePath); }
+        catch (error) { if (error?.code === 'ENOENT') return null; throw error; }
+        throw new Error('saved proxy credential ACL is invalid');
+      }
       encrypted = readPrivateFileBounded(this.filePath, {
         maxBytes: MAX_ENCRYPTED_PROXY_CREDENTIAL_BYTES,
         platform: this.platform,
@@ -160,7 +194,12 @@ class ExternalProxyCredentialStore {
           encrypted.length > MAX_ENCRYPTED_PROXY_CREDENTIAL_BYTES) {
         throw new Error('invalid encrypted proxy credential');
       }
-      if (!atomicWritePrivateFile(this.filePath, encrypted, this.fileSystem)) {
+      const options = this.platform === 'win32' ? {
+        protectTemporary: (file) => this.windowsAcl.protect(file) === true,
+        verifyCommitted: (file) => this.windowsAcl.verify(file) === true,
+        removeCommittedOnFailure: true,
+      } : {};
+      if (!atomicWritePrivateFile(this.filePath, encrypted, this.fileSystem, options)) {
         throw new Error('could not persist proxy credential');
       }
       return credential;
@@ -175,6 +214,39 @@ class ExternalProxyCredentialStore {
   loadOrCreate() {
     const existing = this.load();
     return existing || this.create();
+  }
+
+  clear() {
+    if (this.platform === 'win32') {
+      try {
+        this.fileSystem.lstatSync(this.filePath);
+      } catch (error) {
+        if (error?.code === 'ENOENT') return true;
+        throw storageError('saved proxy credential cannot be inspected', error);
+      }
+      if (!this.windowsAcl.verify(this.filePath)) {
+        throw storageError('saved proxy credential ACL is invalid');
+      }
+    }
+    let data;
+    try {
+      ({ data } = readPrivateFileBounded(this.filePath, {
+        maxBytes: MAX_ENCRYPTED_PROXY_CREDENTIAL_BYTES,
+        platform: this.platform,
+        fileSystem: this.fileSystem,
+      }));
+    } catch (error) {
+      if (error?.code === 'ENOENT') return true;
+      throw storageError('saved proxy credential cannot be removed safely', error);
+    } finally {
+      data?.fill?.(0);
+    }
+    try { this.fileSystem.unlinkSync(this.filePath); }
+    catch (error) { throw storageError('saved proxy credential removal failed', error); }
+    if (!fsyncDirectory(path.dirname(this.filePath), this.fileSystem, this.platform)) {
+      throw storageError('saved proxy credential removal was not durable');
+    }
+    return true;
   }
 }
 

--- a/desktop/test/active-context-switch-barrier.test.js
+++ b/desktop/test/active-context-switch-barrier.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { ActiveContextLease } = require('../lib/active-context-lease');
+const { ActiveContextSwitchBarrier } = require('../lib/active-context-switch-barrier');
+
+function lease() {
+  return new ActiveContextLease({
+    profileId: 'school-a',
+    profileRevision: 1,
+    accountHandle: `account-${'a'.repeat(36)}`,
+    activeContextEpoch: 1,
+  });
+}
+
+function fixture(overrides = {}) {
+  const calls = [];
+  let boundaryClosed = false;
+  let browserPresent = true;
+  const activeLease = lease();
+  const barrier = new ActiveContextSwitchBarrier({
+    invalidateContext: () => { calls.push('invalidate'); return activeLease.invalidate(); },
+    suspendBrowser: async () => { calls.push('suspend'); boundaryClosed = true; },
+    browserBoundaryClosed: () => boundaryClosed,
+    cancelAuth: () => calls.push('cancel-auth'),
+    cancelConnectivity: () => calls.push('cancel-connectivity'),
+    cancelMutations: async () => { calls.push('drain-mutations'); return true; },
+    closeBrowser: async () => { calls.push('close-browser'); browserPresent = false; },
+    browserClosed: () => !browserPresent,
+    stopEngine: async (generation) => {
+      calls.push(['stop-engine', generation]);
+      return { ok: true, cleanExit: true };
+    },
+    revokeProxyAccess: async () => { calls.push('revoke-proxy'); return true; },
+    clearServerState: async () => { calls.push('clear-server'); return true; },
+    ...overrides,
+  });
+  return { activeLease, barrier, calls };
+}
+
+test('Browser gate invalidates every context token before its first await', async () => {
+  const value = fixture({
+    suspendBrowser: async () => {
+      value.calls.push('suspend');
+      assert.equal(value.activeLease.snapshot(), null);
+    },
+    browserBoundaryClosed: () => true,
+  });
+  const token = value.activeLease.captureContext();
+  assert.equal(await value.barrier.gateBrowser(), true);
+  assert.equal(value.activeLease.isContextCurrent(token), false);
+  assert.deepEqual(value.calls, ['invalidate', 'suspend']);
+});
+
+test('continuation cancellation drains mutations after auth and connectivity cancellation', async () => {
+  const value = fixture();
+  assert.equal(await value.barrier.cancelContinuations(), true);
+  assert.deepEqual(value.calls, [
+    'cancel-auth', 'cancel-connectivity', 'drain-mutations',
+  ]);
+  const blocked = fixture({ cancelMutations: async () => false });
+  assert.equal(await blocked.barrier.cancelContinuations(), false);
+});
+
+test('Browser retirement Engine cleanup proxy revocation and server clearing require proof', async () => {
+  const value = fixture();
+  assert.equal(await value.barrier.closeBrowserWorkspace(), true);
+  assert.equal(await value.barrier.confirmEngineStop({ engineGeneration: 7 }), true);
+  assert.equal(await value.barrier.confirmEngineStop({ engineGeneration: null }), true);
+  assert.equal(await value.barrier.revokeProxy(), true);
+  assert.equal(await value.barrier.clearServer(), true);
+  assert.deepEqual(value.calls, [
+    'close-browser', ['stop-engine', 7], 'revoke-proxy', 'clear-server',
+  ]);
+});
+
+test('unconfirmed Browser Engine or proxy cleanup remains fail closed', async () => {
+  const browser = fixture({ browserClosed: () => false });
+  assert.equal(await browser.barrier.closeBrowserWorkspace(), false);
+  const engine = fixture({ stopEngine: async () => ({ ok: true, cleanExit: false }) });
+  assert.equal(await engine.barrier.confirmEngineStop({ engineGeneration: 9 }), false);
+  const proxy = fixture({ revokeProxyAccess: async () => false });
+  assert.equal(await proxy.barrier.revokeProxy(), false);
+});
+
+test('hooks expose the exact coordinator lifecycle surface', () => {
+  assert.deepEqual(Object.keys(fixture().barrier.hooks()).sort(), [
+    'cancelContinuations', 'clearServerState', 'closeBrowserWorkspace', 'gateBrowser',
+    'revokeProxyAccess', 'stopEngine',
+  ]);
+});

--- a/desktop/test/campus-browser-manager.test.js
+++ b/desktop/test/campus-browser-manager.test.js
@@ -98,5 +98,8 @@ test('lifecycle and certificate wrappers are inert before creation and delegate 
   assert.deepEqual(f.manager.handleCertificateError({ origin: 'fixture' }), { origin: 'fixture' });
   f.manager.setLocale('en', () => {});
   assert.equal(f.manager.browser.locale[0], 'en');
+  const retired = f.manager.browser;
   assert.equal(f.manager.close(), 'closed');
+  assert.equal(f.manager.hasBrowser, false);
+  assert.notEqual(f.manager.getOrCreate(), retired);
 });

--- a/desktop/test/external-proxy-credential-store.test.js
+++ b/desktop/test/external-proxy-credential-store.test.js
@@ -108,3 +108,64 @@ test('unavailable secure storage creates no plaintext fallback', (t) => {
   assert.throws(() => store.loadOrCreate(), /secure storage is unavailable/);
   assert.equal(fs.existsSync(temporary.file), false);
 });
+
+test('clear durably revokes the encrypted credential without decrypting it', (t) => {
+  const temporary = temporaryFile();
+  t.after(temporary.cleanup);
+  const safeStorage = fakeSafeStorage();
+  let entropy = 7;
+  const store = new ExternalProxyCredentialStore({
+    filePath: temporary.file,
+    safeStorage,
+    platform: HOST_PRIVATE_FILE_PLATFORM,
+    randomBytes: (length) => Buffer.alloc(length, entropy++),
+  });
+  store.create().destroy();
+  assert.equal(store.clear(), true);
+  assert.equal(fs.existsSync(temporary.file), false);
+  assert.equal(store.clear(), true);
+  assert.equal(safeStorage.calls.decrypt, 0);
+});
+
+test('clear never follows a symbolic or hard-linked credential', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const temporary = temporaryFile();
+  t.after(temporary.cleanup);
+  const unrelated = path.join(temporary.directory, 'unrelated');
+  fs.writeFileSync(unrelated, 'unrelated', { mode: 0o600 });
+  const store = new ExternalProxyCredentialStore({
+    filePath: temporary.file,
+    safeStorage: fakeSafeStorage(),
+    platform: 'darwin',
+  });
+  fs.symlinkSync(unrelated, temporary.file);
+  assert.throws(() => store.clear(), /cannot be removed safely/u);
+  fs.unlinkSync(temporary.file);
+  fs.linkSync(unrelated, temporary.file);
+  assert.throws(() => store.clear(), /cannot be removed safely/u);
+  assert.equal(fs.readFileSync(unrelated, 'utf8'), 'unrelated');
+});
+
+test('simulated Windows create protects and clear verifies the encrypted file ACL', (t) => {
+  const temporary = temporaryFile();
+  t.after(temporary.cleanup);
+  const protectedPaths = [];
+  const verifiedPaths = [];
+  const windowsAcl = {
+    protect(file) { protectedPaths.push(file); return true; },
+    verify(file) { verifiedPaths.push(file); return fs.existsSync(file); },
+  };
+  let entropy = 8;
+  const store = new ExternalProxyCredentialStore({
+    filePath: temporary.file,
+    safeStorage: fakeSafeStorage(),
+    platform: 'win32',
+    windowsAcl,
+    randomBytes: (length) => Buffer.alloc(length, entropy++),
+  });
+  store.create().destroy();
+  assert.equal(store.clear(), true);
+  assert.equal(protectedPaths.some((file) => file.endsWith('.tmp')), true);
+  assert.equal(verifiedPaths.includes(temporary.file), true);
+});


### PR DESCRIPTION
## 目标

提供可直接交给 #29 ActiveContextSwitchCoordinator 的 Main cleanup barrier，确保 destination activation 之前，旧 context 的 Browser、MFA、mutations、Engine 和本地代理权限都得到明确清理证明。

本 PR 堆叠在 #34 之上；暂不暴露第二学校或 switch IPC。

## Barrier 顺序

```text
invalidate active-context lease (synchronous, before first await)
→ suspend and prove Browser request gate
→ cancel MFA + connectivity continuations
→ cancelAndDrain serialized mutations
→ retire CampusBrowser instance
→ stop exact old Engine generation and confirm clean exit
→ revoke encrypted proxy credential + helper sidecar/generation secret
→ clear server resources/notices/capabilities
```

任何回调异常、false、Browser 未退休、mutation rollback 不完整或 Engine cleanExit=false 都返回 false，由 coordinator 阻止 destination activation。

## 配套完善

- CampusBrowserManager.close() 现在退休整个 Browser 实例，不复用旧 credential vault、certificate controller、tabs/views 或 workspace path。
- ExternalProxyCredentialStore.clear()：
  - 不解密即可撤销 encrypted local proxy credential；
  - owner-only bounded read；
  - 拒绝 symlink/hardlink；
  - durable unlink + directory fsync；
  - Windows create/clear 均验证并保护 DACL。

## 验证

- token 在 Browser suspend 的第一个 await 前已失效。
- MFA/connectivity/mutation drain 顺序固定。
- Browser/Engine/proxy/server 每一步均要求证明。
- unclean Engine、Browser 未关闭或 proxy revoke 失败均 fail closed。
- proxy clear 幂等、不解密、拒绝 link substitution、覆盖 Windows ACL。
- Desktop 全量：796 passed，0 failed，1 Windows-only skipped。
- Main integration、synthetic Engine lifecycle、browser performance/20-tab soak：全部通过。
- Architecture：mainDeps=35、mainLines=1644、0 cycles。
- 全部 JS syntax 与 staged secret gate：通过。

## 后续

P4i 将把 barrier hooks 与 switch coordinator 在 synthetic Main composition 中连通，并验证 100 次完整 lifecycle switch 的 PID/port/timer/view/sidecar residue；P6 registry 支持 destination Profile 后再启用真实 switch command/recovery。
