### PR TITLE
2.0 P5a: define the generation-bound Gateway connector

### DIFF
--- a/docs/adr/0016-gateway-connector-generation.md
+++ b/docs/adr/0016-gateway-connector-generation.md
@@ -1,0 +1,73 @@
+# ADR-0016: Generation-bound Gateway connector
+
+- Status: Accepted for 2.0 P5a
+- Production routing activation: deferred to P5b/P5c
+- Scope: reviewed Profile Gateway origin, resolution and peer policy
+
+## Decision
+
+Every credential-bearing Gateway operation will consume one immutable
+`GatewayConnectorGeneration`. A generation binds:
+
+- reviewed `profileId` and Profile revision;
+- a positive connector generation;
+- one normalized credential-free HTTPS root origin;
+- the origin host and effective port;
+- one bounded, deduplicated DNS result set;
+- the reviewed private-Gateway exception decision.
+
+The connector resolves once. HTTP clients receive the same addresses through
+Reqwest's explicit resolver override and disable implicit system/environment
+proxies. Direct sockets verify that the connected peer belongs to the exact
+generation set. A later network or Profile generation does not mutate an old
+connector or its authenticated Cookie/token state.
+
+## Address policy
+
+The default reviewed policy accepts only public peers. It rejects:
+
+- unspecified, loopback, link-local, multicast and broadcast addresses;
+- documentation, benchmarking and reserved ranges;
+- RFC1918, shared-address and IPv6 ULA results;
+- a DNS response that mixes public and private scopes;
+- a port different from the immutable Gateway origin;
+- an IP-literal origin whose exact address does not match the peer set.
+
+A reviewed built-in Profile may set `reviewedPrivateGatewayAllowed`. This
+permits an all-private RFC1918/shared/ULA set, but never permits local,
+link-local, multicast, unspecified, documentation or mixed-scope results.
+Custom/local Profiles do not inherit this exception.
+
+## Security boundary
+
+The connector contains no credentials, Cookie, authentication transaction,
+transport token or Browser data. It does not import authentication providers,
+Modern L3, special TLS, DNS inside the VPN, SOCKS, probes or Renderer code.
+
+Gateway TLS continues to use the reviewed hostname and standard PKI. P5a does
+not add certificate bypass, a user-controlled resolver, a public probe, TUN,
+system proxy mutation or a second transport route.
+
+## Migration order
+
+1. **P5a:** establish this contract and offline address/peer tests without
+   changing current HKUST traffic.
+2. **P5b:** construct one connector before authentication and route every
+   Gateway HTTP request through its Reqwest builder. Cookie/session state is
+   owned by the same generation.
+3. **P5c:** route Modern token, address-control, send and receive sockets
+   through the same connector; reject server-provided outer endpoints that do
+   not match the authenticated connector policy.
+4. **P6:** allow a second reviewed Profile only after cross-profile isolation
+   and real deployment evidence pass. Experimental custom onboarding remains
+   later and receives no private-Gateway exception by default.
+
+## Required evidence
+
+- exact origin normalization and endpoint binding;
+- empty, oversized, port-drift and IP-literal mismatch rejection;
+- public/private/mixed IPv4 and IPv6 address corpus;
+- no implicit proxy discovery;
+- exact peer membership;
+- Profile/revision/generation immutability;
+- HKUST password/Modern L3 behavior unchanged until P5b/P5c explicitly land.

--- a/independent/src/gateway_connector.rs
+++ b/independent/src/gateway_connector.rs
@@ -1,0 +1,582 @@
+//! Generation-bound Gateway origin, DNS and peer policy.
+//!
+//! P5a does not change production routing. It defines the immutable contract
+//! consumed by later HTTP and special-TLS migrations: one reviewed Profile
+//! origin is resolved once, every address is classified before credentials are
+//! used, implicit proxies remain disabled, and connected peers must belong to
+//! that exact generation's resolution set.
+
+use crate::{Error, ErrorKind, Result};
+use reqwest::blocking::ClientBuilder;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
+use std::time::Duration;
+use url::{Host, Url};
+
+const MAX_PROFILE_ID_BYTES: usize = 64;
+const MAX_RESOLVED_ADDRESSES: usize = 16;
+
+fn configuration_error(message: impl Into<String>) -> Error {
+    Error::classified(ErrorKind::Configuration, message)
+}
+
+fn connector_error(message: impl Into<String>) -> Error {
+    Error::classified(ErrorKind::GatewayHttp, message)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AddressScope {
+    Public,
+    Private,
+    Forbidden,
+}
+
+fn ipv4_scope(address: Ipv4Addr) -> AddressScope {
+    let octets = address.octets();
+    if address.is_unspecified()
+        || address.is_loopback()
+        || address.is_link_local()
+        || address.is_multicast()
+        || address.is_broadcast()
+        || address.is_documentation()
+        || octets[0] == 0
+        || octets[0] >= 240
+        || (octets[0] == 198 && (18..=19).contains(&octets[1]))
+    {
+        return AddressScope::Forbidden;
+    }
+    if address.is_private() || (octets[0] == 100 && (64..=127).contains(&octets[1])) {
+        AddressScope::Private
+    } else {
+        AddressScope::Public
+    }
+}
+
+fn ipv6_scope(address: Ipv6Addr) -> AddressScope {
+    if let Some(mapped) = address.to_ipv4_mapped() {
+        return ipv4_scope(mapped);
+    }
+    let segments = address.segments();
+    if address.is_unspecified()
+        || address.is_loopback()
+        || address.is_multicast()
+        || (segments[0] & 0xffc0) == 0xfe80
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8)
+        || (segments[0] & 0xffc0) == 0xfec0
+    {
+        return AddressScope::Forbidden;
+    }
+    if (segments[0] & 0xfe00) == 0xfc00 {
+        AddressScope::Private
+    } else {
+        AddressScope::Public
+    }
+}
+
+fn address_scope(address: IpAddr) -> AddressScope {
+    match address {
+        IpAddr::V4(address) => ipv4_scope(address),
+        IpAddr::V6(address) => ipv6_scope(address),
+    }
+}
+
+fn valid_profile_id(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= MAX_PROFILE_ID_BYTES
+        && bytes.first().is_some_and(u8::is_ascii_alphanumeric)
+        && bytes.last().is_some_and(u8::is_ascii_alphanumeric)
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'-')
+}
+
+fn normalize_origin(value: &str) -> Result<(String, Host<String>, String, u16)> {
+    let url = Url::parse(value).map_err(|_| configuration_error("invalid Gateway origin"))?;
+    if url.scheme() != "https"
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.path() != "/"
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(configuration_error(
+            "Gateway origin must be a credential-free HTTPS root",
+        ));
+    }
+    let host = url
+        .host()
+        .ok_or_else(|| configuration_error("Gateway origin has no host"))?
+        .to_owned();
+    let host_text = url
+        .host_str()
+        .ok_or_else(|| configuration_error("Gateway origin has no host"))?
+        .to_owned();
+    let port = url
+        .port_or_known_default()
+        .ok_or_else(|| configuration_error("Gateway origin has no port"))?;
+    Ok((url.origin().ascii_serialization(), host, host_text, port))
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GatewayConnectorGeneration {
+    profile_id: String,
+    profile_revision: u64,
+    generation: u64,
+    origin: String,
+    host: String,
+    port: u16,
+    addresses: Vec<SocketAddr>,
+    reviewed_private_gateway_allowed: bool,
+}
+
+impl GatewayConnectorGeneration {
+    pub fn resolve_with<F>(
+        profile_id: &str,
+        profile_revision: u64,
+        generation: u64,
+        origin: &str,
+        reviewed_private_gateway_allowed: bool,
+        resolver: F,
+    ) -> Result<Self>
+    where
+        F: FnOnce(&str, u16) -> std::io::Result<Vec<SocketAddr>>,
+    {
+        if !valid_profile_id(profile_id) || profile_revision == 0 || generation == 0 {
+            return Err(configuration_error(
+                "Gateway connector Profile or generation is invalid",
+            ));
+        }
+        let (origin, parsed_host, host, port) = normalize_origin(origin)?;
+        let resolved = match parsed_host {
+            Host::Ipv4(address) => vec![SocketAddr::new(IpAddr::V4(address), port)],
+            Host::Ipv6(address) => vec![SocketAddr::new(IpAddr::V6(address), port)],
+            Host::Domain(_) => resolver(&host, port).map_err(|error| {
+                connector_error(format!("Gateway DNS resolution failed: {error}"))
+            })?,
+        };
+        Self::from_resolved(
+            profile_id,
+            profile_revision,
+            generation,
+            &origin,
+            reviewed_private_gateway_allowed,
+            resolved,
+        )
+    }
+
+    pub fn resolve_system(
+        profile_id: &str,
+        profile_revision: u64,
+        generation: u64,
+        origin: &str,
+        reviewed_private_gateway_allowed: bool,
+    ) -> Result<Self> {
+        Self::resolve_with(
+            profile_id,
+            profile_revision,
+            generation,
+            origin,
+            reviewed_private_gateway_allowed,
+            |host, port| {
+                (host, port)
+                    .to_socket_addrs()
+                    .map(|values| values.collect())
+            },
+        )
+    }
+
+    pub fn from_resolved(
+        profile_id: &str,
+        profile_revision: u64,
+        generation: u64,
+        origin: &str,
+        reviewed_private_gateway_allowed: bool,
+        resolved: Vec<SocketAddr>,
+    ) -> Result<Self> {
+        if !valid_profile_id(profile_id) || profile_revision == 0 || generation == 0 {
+            return Err(configuration_error(
+                "Gateway connector Profile or generation is invalid",
+            ));
+        }
+        let (origin, parsed_host, host, port) = normalize_origin(origin)?;
+        if resolved.is_empty() || resolved.len() > MAX_RESOLVED_ADDRESSES {
+            return Err(configuration_error(
+                "Gateway resolution set has an invalid size",
+            ));
+        }
+        let mut addresses = Vec::with_capacity(resolved.len());
+        let mut selected_scope = None;
+        for address in resolved {
+            if address.port() != port {
+                return Err(configuration_error(
+                    "Gateway resolution returned an unexpected port",
+                ));
+            }
+            let scope = address_scope(address.ip());
+            if scope == AddressScope::Forbidden
+                || (scope == AddressScope::Private && !reviewed_private_gateway_allowed)
+            {
+                return Err(configuration_error(
+                    "Gateway resolution returned a forbidden address",
+                ));
+            }
+            if selected_scope.is_some_and(|selected| selected != scope) {
+                return Err(configuration_error(
+                    "Gateway resolution mixed public and private addresses",
+                ));
+            }
+            selected_scope = Some(scope);
+            if !addresses.contains(&address) {
+                addresses.push(address);
+            }
+        }
+        match parsed_host {
+            Host::Ipv4(expected) => {
+                if addresses.len() != 1 || addresses[0].ip() != IpAddr::V4(expected) {
+                    return Err(configuration_error(
+                        "Gateway IP literal does not match its peer address",
+                    ));
+                }
+            }
+            Host::Ipv6(expected) => {
+                if addresses.len() != 1 || addresses[0].ip() != IpAddr::V6(expected) {
+                    return Err(configuration_error(
+                        "Gateway IP literal does not match its peer address",
+                    ));
+                }
+            }
+            Host::Domain(_) => {}
+        }
+        Ok(Self {
+            profile_id: profile_id.to_owned(),
+            profile_revision,
+            generation,
+            origin,
+            host,
+            port,
+            addresses,
+            reviewed_private_gateway_allowed,
+        })
+    }
+
+    pub fn profile_id(&self) -> &str {
+        &self.profile_id
+    }
+
+    pub const fn profile_revision(&self) -> u64 {
+        self.profile_revision
+    }
+
+    pub const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn origin(&self) -> &str {
+        &self.origin
+    }
+
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    pub const fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn resolved_addresses(&self) -> &[SocketAddr] {
+        &self.addresses
+    }
+
+    pub const fn reviewed_private_gateway_allowed(&self) -> bool {
+        self.reviewed_private_gateway_allowed
+    }
+
+    pub fn peer_allowed(&self, peer: SocketAddr) -> bool {
+        self.addresses.contains(&peer)
+    }
+
+    pub fn apply_to_reqwest_builder(&self, builder: ClientBuilder) -> ClientBuilder {
+        builder
+            .no_proxy()
+            .resolve_to_addrs(&self.host, &self.addresses)
+    }
+
+    pub fn connect_tcp(&self, timeout: Duration) -> Result<TcpStream> {
+        if timeout.is_zero() {
+            return Err(configuration_error(
+                "Gateway connector timeout must be nonzero",
+            ));
+        }
+        let mut last_error = None;
+        for address in &self.addresses {
+            match TcpStream::connect_timeout(address, timeout) {
+                Ok(stream) => {
+                    let peer = stream.peer_addr().map_err(|error| {
+                        connector_error(format!("cannot inspect Gateway peer: {error}"))
+                    })?;
+                    if !self.peer_allowed(peer) {
+                        return Err(Error::classified(
+                            ErrorKind::GatewayProtocolInvalid,
+                            "connected Gateway peer is outside the connector generation",
+                        ));
+                    }
+                    return Ok(stream);
+                }
+                Err(error) => last_error = Some(error),
+            }
+        }
+        Err(connector_error(format!(
+            "cannot connect to any Gateway peer: {}",
+            last_error
+                .map(|error| error.to_string())
+                .unwrap_or_else(|| "no address".to_owned())
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::blocking::Client;
+
+    fn public(address: &str) -> SocketAddr {
+        if address.contains(':') {
+            format!("[{address}]:443").parse().unwrap()
+        } else {
+            format!("{address}:443").parse().unwrap()
+        }
+    }
+
+    #[test]
+    fn connector_binds_reviewed_profile_origin_generation_and_dns_set() {
+        let connector = GatewayConnectorGeneration::from_resolved(
+            "school-a",
+            7,
+            11,
+            "https://vpn.example.edu",
+            false,
+            vec![public("8.8.8.8"), public("1.1.1.1"), public("8.8.8.8")],
+        )
+        .unwrap();
+        assert_eq!(connector.profile_id(), "school-a");
+        assert_eq!(connector.profile_revision(), 7);
+        assert_eq!(connector.generation(), 11);
+        assert_eq!(connector.origin(), "https://vpn.example.edu");
+        assert_eq!(connector.host(), "vpn.example.edu");
+        assert_eq!(connector.port(), 443);
+        assert_eq!(connector.resolved_addresses().len(), 2);
+        assert!(connector.peer_allowed(public("8.8.8.8")));
+        assert!(!connector.peer_allowed(public("9.9.9.9")));
+        connector
+            .apply_to_reqwest_builder(Client::builder())
+            .build()
+            .unwrap();
+    }
+
+    #[test]
+    fn origin_is_an_exact_credential_free_https_root() {
+        for origin in [
+            "http://vpn.example.edu",
+            "https://user@vpn.example.edu",
+            "https://vpn.example.edu/path",
+            "https://vpn.example.edu/?query=1",
+            "https://vpn.example.edu/#fragment",
+        ] {
+            assert!(
+                GatewayConnectorGeneration::from_resolved(
+                    "school-a",
+                    1,
+                    1,
+                    origin,
+                    false,
+                    vec![public("8.8.8.8")],
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn default_policy_rejects_private_and_always_forbidden_results() {
+        for address in [
+            "10.0.0.1",
+            "100.64.0.1",
+            "127.0.0.1",
+            "169.254.1.1",
+            "224.0.0.1",
+            "0.0.0.0",
+            "192.0.2.1",
+            "198.18.0.1",
+        ] {
+            assert!(
+                GatewayConnectorGeneration::from_resolved(
+                    "school-a",
+                    1,
+                    1,
+                    "https://vpn.example.edu",
+                    false,
+                    vec![public(address)],
+                )
+                .is_err(),
+                "{address}"
+            );
+        }
+    }
+
+    #[test]
+    fn reviewed_private_exception_never_allows_local_or_mixed_scope() {
+        let private = GatewayConnectorGeneration::from_resolved(
+            "school-a",
+            1,
+            1,
+            "https://vpn.example.edu",
+            true,
+            vec![public("10.0.0.1"), public("10.0.0.2")],
+        )
+        .unwrap();
+        assert!(private.reviewed_private_gateway_allowed());
+        for address in ["127.0.0.1", "169.254.1.1", "224.0.0.1"] {
+            assert!(
+                GatewayConnectorGeneration::from_resolved(
+                    "school-a",
+                    1,
+                    1,
+                    "https://vpn.example.edu",
+                    true,
+                    vec![public(address)],
+                )
+                .is_err()
+            );
+        }
+        assert!(
+            GatewayConnectorGeneration::from_resolved(
+                "school-a",
+                1,
+                1,
+                "https://vpn.example.edu",
+                true,
+                vec![public("10.0.0.1"), public("8.8.8.8")],
+            )
+            .is_err()
+        );
+        let private_v6 = GatewayConnectorGeneration::from_resolved(
+            "school-a",
+            1,
+            1,
+            "https://vpn.example.edu",
+            true,
+            vec![public("fd00::1")],
+        )
+        .unwrap();
+        assert!(private_v6.peer_allowed(public("fd00::1")));
+        for address in ["::1", "fe80::1", "ff02::1", "2001:db8::1"] {
+            assert!(
+                GatewayConnectorGeneration::from_resolved(
+                    "school-a",
+                    1,
+                    1,
+                    "https://vpn.example.edu",
+                    true,
+                    vec![public(address)],
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn ip_literal_skips_dns_and_must_match_exact_peer() {
+        let mut resolutions = 0;
+        let connector = GatewayConnectorGeneration::resolve_with(
+            "school-a",
+            1,
+            1,
+            "https://8.8.8.8",
+            false,
+            |_host, _port| {
+                resolutions += 1;
+                Ok(vec![])
+            },
+        )
+        .unwrap();
+        assert_eq!(resolutions, 0);
+        assert!(connector.peer_allowed(public("8.8.8.8")));
+        assert!(
+            GatewayConnectorGeneration::from_resolved(
+                "school-a",
+                1,
+                1,
+                "https://8.8.8.8",
+                false,
+                vec![public("1.1.1.1")],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn resolver_failure_bounds_and_port_drift_fail_closed() {
+        let error = GatewayConnectorGeneration::resolve_with(
+            "school-a",
+            1,
+            1,
+            "https://vpn.example.edu:8443",
+            false,
+            |_host, _port| Err(std::io::Error::other("fixture")),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::GatewayHttp);
+        assert!(
+            GatewayConnectorGeneration::from_resolved(
+                "school-a",
+                1,
+                1,
+                "https://vpn.example.edu:8443",
+                false,
+                vec![public("8.8.8.8")],
+            )
+            .is_err()
+        );
+        assert!(
+            GatewayConnectorGeneration::from_resolved(
+                "school-a",
+                1,
+                1,
+                "https://vpn.example.edu",
+                false,
+                (0..=MAX_RESOLVED_ADDRESSES)
+                    .map(|index| SocketAddr::new(
+                        IpAddr::V4(Ipv4Addr::new(8, 8, 4, index as u8)),
+                        443
+                    ))
+                    .collect(),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn invalid_profile_generation_and_timeout_are_rejected() {
+        assert!(
+            GatewayConnectorGeneration::from_resolved(
+                "School A",
+                1,
+                1,
+                "https://vpn.example.edu",
+                false,
+                vec![public("8.8.8.8")],
+            )
+            .is_err()
+        );
+        let connector = GatewayConnectorGeneration::from_resolved(
+            "school-a",
+            1,
+            1,
+            "https://vpn.example.edu",
+            false,
+            vec![public("8.8.8.8")],
+        )
+        .unwrap();
+        assert!(connector.connect_tcp(Duration::ZERO).is_err());
+    }
+}

--- a/independent/src/lib.rs
+++ b/independent/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod credentials;
 pub mod engine;
 pub mod gateway_auth;
+pub mod gateway_connector;
 pub mod gateway_http;
 pub mod modern;
 pub mod probe;

--- a/independent/tests/module_boundaries.rs
+++ b/independent/tests/module_boundaries.rs
@@ -74,6 +74,29 @@ fn gateway_http_is_neutral_to_probe_transport_and_local_frontends() {
 }
 
 #[test]
+fn gateway_connector_is_profile_bound_but_credential_and_transport_neutral() {
+    let connector = source("src/gateway_connector.rs");
+    for forbidden in [
+        "crate::credentials",
+        "crate::gateway_auth",
+        "crate::probe",
+        "crate::modern",
+        "crate::special_tls11",
+        "crate::engine::socks",
+        "crate::engine::dns",
+        "std::env",
+    ] {
+        assert!(
+            !connector.contains(forbidden),
+            "Gateway connector imports {forbidden}"
+        );
+    }
+    assert!(connector.contains(".no_proxy()"));
+    assert!(connector.contains(".resolve_to_addrs("));
+    assert!(connector.contains("peer_allowed"));
+}
+
+#[test]
 fn credential_input_is_neutral_to_gateway_and_protocol_layers() {
     let credentials = source("src/credentials.rs");
     for forbidden in [


### PR DESCRIPTION
## 目标

建立一个 credential-neutral、Profile-bound、generation-bound 的 GatewayConnector contract，供 P5b HTTP 与 P5c Modern/special-TLS 逐步接入。本 PR 不改变当前 HKUST 生产流量。

本 PR 堆叠在 #36 之上。

## Connector 绑定

- reviewed profileId + Profile revision；
- positive connector generation；
- credential-free HTTPS root origin；
- normalized host + effective port；
- 一次解析、最多 16 个、去重的 peer addresses；
- reviewed private-Gateway exception decision。

## 地址与 peer 策略

默认拒绝：

- unspecified、loopback、link-local、multicast、broadcast；
- documentation、benchmark、reserved；
- RFC1918、CGNAT/shared、IPv6 ULA；
- public/private mixed DNS results；
- origin port drift；
- IP literal 与 peer 不一致。

reviewed built-in Profile 可以显式允许 all-private RFC1918/shared/ULA 集合，但仍不能允许本机、链路、多播、未指定、文档/保留地址或公私混合。Custom Profile 默认没有该例外。

## 建连合同

- Reqwest builder 强制 `.no_proxy()`；
- DNS 使用 `.resolve_to_addrs()` 固定到本 generation；
- direct TCP 在连接后核对 `peer_addr()` 属于 exact generation set；
- connector 不包含 password、Cookie、token、CSRF、MFA transaction 或 Browser state；
- 模块禁止依赖 auth provider、Modern L3、special TLS、VPN DNS、SOCKS、probe 或 Renderer。

## 验证

- exact origin/Profile/revision/generation binding；
- resolver failure、empty/oversized set、port drift；
- IPv4/IPv6 public/private/local/documentation/mixed corpus；
- IP literal 跳过 DNS 且 exact peer；
- implicit proxy disabled；
- module-boundary architecture gate。
- Rust：208 passed、0 failed、1 explicit performance ignored。
- Engine 与所有 integration tests：通过。
- Clippy `-D warnings`：通过。
- fmt：通过。
- staged secret gate：通过。

## 激活边界

P5b 才会让 GatewaySession 的全部 HTTP 请求消费 connector；P5c 才会迁移 Modern token/address/send/receive sockets。两阶段完成前，现有 HKUST system-default route、standard PKI、HTTPS leaf binding 与数据面行为保持不变。
