### PR TITLE
2.0 P5b: bind Gateway HTTP to connector generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,7 @@ jobs:
         working-directory: desktop
         run: |
           npm run test:main-integration
+          npm run test:control-renderer-recovery
           npm run test:main-engine-lifecycle
           npm run test:main-network-startup
           ./node_modules/.bin/electron e2e/campus-browser-toolbar.electron.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,8 @@ jobs:
         run: npm ci
       - name: Exercise the real Electron main process
         run: npm run test:main-integration
+      - name: Exercise control renderer crash-loop recovery
+        run: npm run test:control-renderer-recovery
       - name: Exercise Main with a synthetic Engine lifecycle
         run: npm run test:main-engine-lifecycle
       - name: Exercise initially-offline Main startup recovery

--- a/desktop/assets/profiles/hkustgz/engine-config.json
+++ b/desktop/assets/profiles/hkustgz/engine-config.json
@@ -12,6 +12,9 @@
     "windows_modules": "/com/WindowsModule.xml"
   },
   "hash_windows_installer": true,
+  "gateway_connector": {
+    "reviewed_private_gateway_allowed": false
+  },
   "max_artifact_bytes": 536870912,
   "proxy": {
     "allow_system_dns_fallback": false,

--- a/desktop/assets/profiles/manifest.json
+++ b/desktop/assets/profiles/manifest.json
@@ -13,7 +13,7 @@
           "key": "hkustgz-engine-config",
           "kind": "engine-config",
           "path": "assets/profiles/hkustgz/engine-config.json",
-          "sha256": "2a25086478bc751a686a0479a55cd3165deb9da2742b8cd20d646c94581c910a"
+          "sha256": "ed7d9d3dee309124b35f9b9921c83df4947d9c919fc009ab2b8b9b3b0457e1db"
         },
         {
           "key": "hkustgz-logo",

--- a/desktop/e2e/control-renderer-recovery.electron.js
+++ b/desktop/e2e/control-renderer-recovery.electron.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { app, BrowserWindow, Menu, nativeImage } = require('electron');
+const { DesktopShell } = require('../lib/desktop-shell');
+
+const TIMEOUT_MS = 15_000;
+
+// Match production: losing the control renderer must not terminate the tray
+// owner while the recovery policy decides whether another window is safe.
+app.on('window-all-closed', () => {});
+
+function delay(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
+
+async function waitFor(predicate, message) {
+  const deadline = Date.now() + TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await delay(25);
+  }
+  throw new Error(message);
+}
+
+async function run() {
+  await app.whenReady();
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'control-renderer-recovery-'));
+  const renderer = path.join(directory, 'index.html');
+  const preload = path.join(directory, 'preload.js');
+  fs.writeFileSync(renderer, '<!doctype html><meta charset="utf-8"><title>fixture</title>');
+  fs.writeFileSync(preload, "'use strict';\n");
+  const errors = [];
+  const shell = new DesktopShell({
+    app,
+    BrowserWindow,
+    Tray: class {},
+    Menu,
+    nativeImage,
+    dialog: { showMessageBox: async () => ({ response: 2, checkboxChecked: false }) },
+    baseDirectory: path.join(__dirname, '..'),
+    controlRendererFile: renderer,
+    preloadFile: preload,
+    platform: process.platform,
+    translate: (key) => key,
+    getConnectionState: () => ({ connected: false, connecting: false }),
+    getCloseAction: () => 'minimize',
+    connect: async () => ({ ok: true }),
+    disconnect: async () => ({ ok: true }),
+    openCampusBrowser: async () => ({ ok: true }),
+    rememberCloseAction: async () => {},
+    disposeLifecycle: () => {},
+    cleanupQuit: async () => {},
+    onControlRendererUnavailable: () => {},
+    onWindowError: (error) => errors.push(error),
+  });
+
+  try {
+    const first = shell.createWindow();
+    await waitFor(() => !first.webContents.isLoading(), 'first control renderer did not load');
+    first.webContents.forcefullyCrashRenderer();
+    await waitFor(() => shell.window && shell.window !== first,
+      'the first renderer crash was not recovered');
+    const recovery = shell.window;
+    await waitFor(() => !recovery.webContents.isLoading(), 'recovery renderer did not load');
+    recovery.webContents.forcefullyCrashRenderer();
+    await waitFor(() => shell.window === null, 'the repeated crash kept restarting the renderer');
+
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].code, 'CONTROL_RENDERER_CRASH_LOOP_BLOCKED');
+    process.stdout.write('control renderer recovery: PASS\n');
+  } finally {
+    if (shell.window && !shell.window.isDestroyed()) shell.window.destroy();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+run().then(() => app.quit()).catch((error) => {
+  process.stderr.write(`${error.stack || error}\n`);
+  app.exit(1);
+});

--- a/desktop/lib/desktop-shell.js
+++ b/desktop/lib/desktop-shell.js
@@ -4,6 +4,12 @@ const path = require('node:path');
 const { loadTrayImage } = require('./tray-icon');
 const { CONTROL_WINDOW, clampWindowSize } = require('./window-layout');
 
+// A transient Chromium renderer failure may be recovered once, but a broken
+// preload/renderer must never turn into an unbounded create-crash-create loop.
+// Keep the main/tray process alive so the user can retry after the underlying
+// condition changes.
+const CONTROL_RENDERER_RECOVERY_WINDOW_MS = 30_000;
+
 class DesktopShell {
   constructor({
     app,
@@ -27,11 +33,12 @@ class DesktopShell {
     cleanupQuit,
     onControlRendererUnavailable,
     onWindowError,
+    now = Date.now,
   } = {}) {
     for (const dependency of [
       BrowserWindow, Tray, translate, getConnectionState, getCloseAction, connect, disconnect,
       openCampusBrowser, rememberCloseAction, disposeLifecycle, cleanupQuit,
-      onControlRendererUnavailable, onWindowError,
+      onControlRendererUnavailable, onWindowError, now,
     ]) {
       if (typeof dependency !== 'function') {
         throw new TypeError('desktop shell dependencies are incomplete');
@@ -63,6 +70,7 @@ class DesktopShell {
     this.cleanupQuit = cleanupQuit;
     this.onControlRendererUnavailable = onControlRendererUnavailable;
     this.onWindowError = onWindowError;
+    this.now = now;
     this.window = null;
     this.windowInvalid = false;
     this.tray = null;
@@ -70,6 +78,7 @@ class DesktopShell {
     this.quitAllowed = false;
     this.quitInFlight = null;
     this.closePromptOpen = false;
+    this.lastAutomaticRendererRecoveryAt = null;
   }
 
   get webContents() {
@@ -284,7 +293,17 @@ class DesktopShell {
       this.windowInvalid = true;
       this.window = null;
       try { window.destroy(); } catch {}
-      if (wasVisible && this.app.isReady()) this.createWindow();
+      if (!wasVisible || !this.app.isReady()) return;
+      const observedAt = this.now();
+      const previous = this.lastAutomaticRendererRecoveryAt;
+      if (previous === null || observedAt - previous >= CONTROL_RENDERER_RECOVERY_WINDOW_MS) {
+        this.lastAutomaticRendererRecoveryAt = observedAt;
+        this.createWindow();
+        return;
+      }
+      const error = new Error(this.translate('error.controlRendererCrashLoop'));
+      error.code = 'CONTROL_RENDERER_CRASH_LOOP_BLOCKED';
+      this.onWindowError(error);
     });
     contents.on('destroyed', () => {
       reportRendererUnavailable('destroyed');

--- a/desktop/lib/i18n.js
+++ b/desktop/lib/i18n.js
@@ -82,6 +82,7 @@ const dictionaries = {
     'error.settingsRestored': '检测到设置文件损坏，已从本机备份恢复；请检查端口和偏好设置',
     'error.settingsDefaults': '设置文件损坏且备份不可用，已恢复安全默认值；请重新检查端口和偏好设置',
     'error.startupTitle': 'HKUST(GZ) Connect 启动失败',
+    'error.controlRendererCrashLoop': '控制界面连续异常退出，已停止自动重启。校园连接和托盘仍会保留；请稍后从托盘重新打开窗口。',
 
     'engine.authFailed': '登录处理失败，无法确认是否为密码问题；已停止自动重试',
     'engine.authRejected': '登录未通过：账号或密码未被网关接受，已停止自动重试',
@@ -227,6 +228,7 @@ const dictionaries = {
     'error.settingsRestored': 'The settings file was damaged and restored from a local backup; review the port and preferences',
     'error.settingsDefaults': 'The settings file and backup were unusable; safe defaults were restored. Review the port and preferences',
     'error.startupTitle': 'HKUST(GZ) Connect failed to start',
+    'error.controlRendererCrashLoop': 'The control window exited repeatedly, so automatic restart was stopped. The campus connection and tray remain available; reopen the window from the tray later.',
 
     'engine.authFailed': 'Login processing failed and could not be attributed to the password. Automatic retries stopped.',
     'engine.authRejected': 'Login was rejected: the gateway did not accept the account or password; automatic retries stopped',

--- a/desktop/lib/school-profile-runtime.js
+++ b/desktop/lib/school-profile-runtime.js
@@ -98,6 +98,10 @@ function verifyEngineConfigBinding({
   if (normalizeGatewayOrigin(config.base_url).origin !== profile.gateway.origin.origin) {
     throw new Error('engine profile config Gateway origin does not match the active profile');
   }
+  if (config.gateway_connector?.reviewed_private_gateway_allowed !==
+      profile.policy.reviewedPrivateGatewayAllowed) {
+    throw new Error('engine profile config private Gateway policy does not match the active profile');
+  }
   return Object.freeze({ path: candidate, sha256: descriptor.sha256 });
 }
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -13,6 +13,7 @@
     "test:auth-control-e2e": "node e2e/auth-control-fixture.js",
     "test:campus-mfa-safety": "electron e2e/campus-mfa-safety.electron.js",
     "test:campus-popup-mfa-safety": "electron e2e/campus-popup-mfa-safety.electron.js",
+    "test:control-renderer-recovery": "electron e2e/control-renderer-recovery.electron.js",
     "test:idle-performance": "electron scripts/idle-performance-baseline.js",
     "test:routing-restart": "node e2e/routing-restart.electron.js",
     "test:renderer-layout": "electron e2e/resource-manager-layout.electron.js",

--- a/desktop/test/desktop-shell.test.js
+++ b/desktop/test/desktop-shell.test.js
@@ -139,6 +139,28 @@ test('a crashed visible control renderer is destroyed and recreated once', () =>
   assert.equal(f.calls.filter((entry) => entry[0] === 'renderer-lost').length, 1);
 });
 
+test('repeated control renderer crashes trip a recovery circuit breaker', () => {
+  let now = 100_000;
+  const f = fixture({ now: () => now });
+  const first = f.shell.createWindow();
+  first.webContents.emit('render-process-gone');
+  const recovery = f.shell.window;
+
+  recovery.webContents.emit('render-process-gone');
+  assert.equal(f.shell.window, null,
+    'a recovery renderer that also crashes must not be recreated indefinitely');
+  assert.deepEqual(f.calls.filter((entry) => entry[0] === 'error'), [
+    ['error', 'error.controlRendererCrashLoop'],
+  ]);
+
+  now += 30_000;
+  assert.equal(f.shell.showWindow(), true);
+  const later = f.shell.window;
+  later.webContents.emit('render-process-gone');
+  assert.notEqual(f.shell.window, later,
+    'a later isolated crash may receive one automatic recovery');
+});
+
 test('a crashed hidden renderer is recreated on the next show request', () => {
   const f = fixture();
   const first = f.shell.createWindow();

--- a/desktop/test/school-profile-controller.test.js
+++ b/desktop/test/school-profile-controller.test.js
@@ -35,7 +35,7 @@ test('composes the reviewed HKUST deployment without persistent account scope', 
   assert.deepEqual(JSON.parse(binding.stdinFrame), {
     type: 'engine_config_binding',
     apiVersion: 1,
-    configSha256: '2a25086478bc751a686a0479a55cd3165deb9da2742b8cd20d646c94581c910a',
+    configSha256: 'ed7d9d3dee309124b35f9b9921c83df4947d9c919fc009ab2b8b9b3b0457e1db',
     gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
     profileId: 'hkustgz',
     profileRevision: 1,

--- a/desktop/test/school-profile-registry.test.js
+++ b/desktop/test/school-profile-registry.test.js
@@ -134,7 +134,7 @@ test('manifest assets are exact, hashed, read-only copies and match current sour
     key: 'hkustgz-engine-config',
     kind: 'engine-config',
     path: 'assets/profiles/hkustgz/engine-config.json',
-    sha256: '2a25086478bc751a686a0479a55cd3165deb9da2742b8cd20d646c94581c910a',
+    sha256: 'ed7d9d3dee309124b35f9b9921c83df4947d9c919fc009ab2b8b9b3b0457e1db',
   });
   const first = registry.readAsset('hkustgz', 'hkustgz-engine-config', 'engine-config');
   assert.deepEqual(first, fs.readFileSync(path.join(desktopRoot, '..', 'independent', 'config', 'hkustgz.json')));

--- a/hkustgzconnect
+++ b/hkustgzconnect
@@ -6,7 +6,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
 ENGINE="$HERE/independent/target/release/ec-engine"
 PROXY_HELPER="$HERE/independent/target/release/ec-proxy-command"
 ENGINE_CONFIG="$HERE/independent/config/hkustgz.json"
-REVIEWED_ENGINE_CONFIG_SHA256="2a25086478bc751a686a0479a55cd3165deb9da2742b8cd20d646c94581c910a"
+REVIEWED_ENGINE_CONFIG_SHA256="ed7d9d3dee309124b35f9b9921c83df4947d9c919fc009ab2b8b9b3b0457e1db"
 CONF="$HERE/config.toml"
 
 RUNDIR="$HOME/.hkustgzconnect"
@@ -102,6 +102,7 @@ run_engine(){
     --profile-binding-v1-stdin \
     --credentials-stdin \
     --socks-bind "$SOCKS_HOST:$SOCKS_PORT" \
+    --generation 1 \
     --socks-auth-stdin
   pw=''
   cli_proxy_clear

--- a/independent/config/hkustgz.json
+++ b/independent/config/hkustgz.json
@@ -12,6 +12,9 @@
     "windows_modules": "/com/WindowsModule.xml"
   },
   "hash_windows_installer": true,
+  "gateway_connector": {
+    "reviewed_private_gateway_allowed": false
+  },
   "max_artifact_bytes": 536870912,
   "proxy": {
     "allow_system_dns_fallback": false,

--- a/independent/src/bin/ec-engine.rs
+++ b/independent/src/bin/ec-engine.rs
@@ -24,6 +24,7 @@ use ec_compat::engine::socks_auth::{
     EngineCredentials, ProxyAuthentication, ProxyAuthenticationMode, read_engine_credentials,
     read_engine_credentials_prefix,
 };
+use ec_compat::gateway_connector::GatewayConnectorGeneration;
 use ec_compat::{Error, ErrorKind, Result};
 use std::io::Write;
 use std::net::{Ipv4Addr, SocketAddr};
@@ -348,6 +349,16 @@ fn parse_arguments(args: &[String]) -> Result<EngineArguments> {
         #[cfg(feature = "engine-lifecycle-fixture")]
         lifecycle_fixture,
     })
+}
+
+#[cfg(feature = "engine-lifecycle-fixture")]
+fn lifecycle_fixture_selected(arguments: &EngineArguments) -> bool {
+    arguments.lifecycle_fixture
+}
+
+#[cfg(not(feature = "engine-lifecycle-fixture"))]
+fn lifecycle_fixture_selected(_arguments: &EngineArguments) -> bool {
+    false
 }
 
 fn start_control_reader(
@@ -989,6 +1000,46 @@ async fn run_engine<W: Write>(
             Error("engine VPN DNS configuration is invalid".into()),
         )
     })?;
+    let gateway_connector = if let Some(binding) = config_binding
+        .as_ref()
+        .filter(|_| !lifecycle_fixture_selected(arguments))
+    {
+        let base_url = config["base_url"].as_str().ok_or_else(|| {
+            failure(
+                EngineErrorCode::ConfigurationInvalid,
+                StopReason::StartupFailed,
+                Error("engine Gateway connector origin is invalid".into()),
+            )
+        })?;
+        let private_allowed = config["gateway_connector"]["reviewed_private_gateway_allowed"]
+            .as_bool()
+            .ok_or_else(|| {
+                failure(
+                    EngineErrorCode::ConfigurationInvalid,
+                    StopReason::StartupFailed,
+                    Error("engine Gateway connector policy is invalid".into()),
+                )
+            })?;
+        Some(Arc::new(
+            GatewayConnectorGeneration::resolve_system(
+                binding.profile_id(),
+                binding.profile_revision(),
+                arguments.generation,
+                base_url,
+                private_allowed,
+            )
+            .map_err(|error| {
+                let code = if error.kind() == ErrorKind::Configuration {
+                    EngineErrorCode::ConfigurationInvalid
+                } else {
+                    EngineErrorCode::AuthIndeterminate
+                };
+                failure(code, StopReason::StartupFailed, error)
+            })?,
+        ))
+    } else {
+        None
+    };
 
     lifecycle
         .state(EngineState::Authenticating)
@@ -1112,7 +1163,13 @@ async fn run_engine<W: Write>(
         )
         .await;
     }
-    let providers = ProductionProviderSet::from_config(provider_family, &config).map_err(|_| {
+    let providers = match gateway_connector {
+        Some(connector) => {
+            ProductionProviderSet::from_config_with_connector(provider_family, &config, connector)
+        }
+        None => ProductionProviderSet::from_config(provider_family, &config),
+    }
+    .map_err(|_| {
         failure(
             EngineErrorCode::ConfigurationInvalid,
             StopReason::StartupFailed,

--- a/independent/src/engine/provider_composition.rs
+++ b/independent/src/engine/provider_composition.rs
@@ -9,8 +9,10 @@ use crate::engine::provider::{
     CapabilityModel, ProviderCapabilityReport, ProviderCoordinator, UnsupportedResourceProvider,
 };
 use crate::engine::session::{ModernL3TransportBackend, ProductionPasswordAuthProvider};
+use crate::gateway_connector::GatewayConnectorGeneration;
 use crate::{Error, ErrorKind, Result};
 use serde_json::Value;
+use std::sync::Arc;
 
 pub const EASYCONNECT_PASSWORD_MODERN_L3_V1: &str = "easyconnect-password-modern-l3-v1";
 
@@ -66,10 +68,32 @@ pub struct ProductionProviderSet {
 
 impl ProductionProviderSet {
     pub fn from_config(family: ProductionProviderFamily, config: &Value) -> Result<Self> {
+        Self::compose(family, config, None)
+    }
+
+    pub fn from_config_with_connector(
+        family: ProductionProviderFamily,
+        config: &Value,
+        connector: Arc<GatewayConnectorGeneration>,
+    ) -> Result<Self> {
+        Self::compose(family, config, Some(connector))
+    }
+
+    fn compose(
+        family: ProductionProviderFamily,
+        config: &Value,
+        connector: Option<Arc<GatewayConnectorGeneration>>,
+    ) -> Result<Self> {
         match family {
             ProductionProviderFamily::EasyConnectPasswordModernL3V1 => {
+                let authentication = match connector {
+                    Some(connector) => {
+                        ProductionPasswordAuthProvider::new_with_connector(config, connector)?
+                    }
+                    None => ProductionPasswordAuthProvider::new(config),
+                };
                 let coordinator = ProviderCoordinator::new(
-                    ProductionPasswordAuthProvider::new(config),
+                    authentication,
                     UnsupportedResourceProvider,
                     ModernL3TransportBackend::new(config)?,
                     family.compiled_capabilities(),
@@ -107,7 +131,9 @@ impl ProductionProviderSet {
 mod tests {
     use super::*;
     use crate::engine::provider::{Capability, CapabilityAvailability};
+    use crate::gateway_connector::GatewayConnectorGeneration;
     use serde_json::json;
+    use std::net::SocketAddr;
 
     fn config() -> Value {
         json!({
@@ -146,5 +172,35 @@ mod tests {
         assert!(ProductionProviderFamily::parse("dynamic-provider-name").is_err());
         let family = ProductionProviderFamily::EasyConnectPasswordModernL3V1;
         assert!(ProductionProviderSet::from_config(family, &json!({})).is_err());
+    }
+
+    #[test]
+    fn connector_generation_is_owned_by_the_selected_authentication_provider() {
+        let family = ProductionProviderFamily::EasyConnectPasswordModernL3V1;
+        let connector = Arc::new(
+            GatewayConnectorGeneration::from_resolved(
+                "school-a",
+                1,
+                9,
+                "https://gateway.example.test",
+                false,
+                vec!["8.8.8.8:443".parse::<SocketAddr>().unwrap()],
+            )
+            .unwrap(),
+        );
+        let providers = ProductionProviderSet::from_config_with_connector(
+            family,
+            &config(),
+            Arc::clone(&connector),
+        )
+        .unwrap();
+        assert_eq!(
+            providers
+                .authentication_provider()
+                .connector()
+                .unwrap()
+                .generation(),
+            9
+        );
     }
 }

--- a/independent/src/engine/session.rs
+++ b/independent/src/engine/session.rs
@@ -8,6 +8,7 @@ use crate::engine::provider::{
     TransportCapabilities, require_supported,
 };
 use crate::gateway_auth::AuthenticatedSessionId;
+use crate::gateway_connector::GatewayConnectorGeneration;
 use crate::gateway_http::{DEFAULT_TIMEOUT_SECONDS, GatewaySession};
 use crate::modern::{parse_sha256_pin, request_modern_token};
 use crate::xml::{first_descendant_text, parse_xml};
@@ -82,13 +83,32 @@ pub struct ModernL3TransportBackend {
 #[derive(Clone)]
 pub struct ProductionPasswordAuthProvider {
     config: Arc<Value>,
+    connector: Option<Arc<GatewayConnectorGeneration>>,
 }
 
 impl ProductionPasswordAuthProvider {
     pub fn new(config: &Value) -> Self {
         Self {
             config: Arc::new(config.clone()),
+            connector: None,
         }
+    }
+
+    pub fn new_with_connector(
+        config: &Value,
+        connector: Arc<GatewayConnectorGeneration>,
+    ) -> Result<Self> {
+        let base_url = required_text(config, "base_url")?;
+        if connector.origin() != base_url.trim_end_matches('/') {
+            return Err(Error::classified(
+                ErrorKind::Configuration,
+                "authentication connector origin does not match config",
+            ));
+        }
+        Ok(Self {
+            config: Arc::new(config.clone()),
+            connector: Some(connector),
+        })
     }
 
     pub fn authenticate_password_cancellable(
@@ -97,12 +117,17 @@ impl ProductionPasswordAuthProvider {
         password: &str,
         cancellation: &AuthenticationCancellation,
     ) -> ProviderResult<AuthenticatedGatewaySession> {
-        AuthenticatedGatewaySession::authenticate_password_with_cancellation(
+        AuthenticatedGatewaySession::authenticate_password_with_connector_and_cancellation(
             &self.config,
+            self.connector.clone(),
             username,
             password,
             Some(cancellation),
         )
+    }
+
+    pub fn connector(&self) -> Option<&GatewayConnectorGeneration> {
+        self.connector.as_deref()
     }
 }
 
@@ -120,9 +145,15 @@ impl AuthProvider for ProductionPasswordAuthProvider {
     ) -> ProviderResult<AuthOutcome<Self::Session, Self::Challenge>> {
         match request {
             AuthRequest::Password { username, password } => {
-                AuthenticatedGatewaySession::authenticate_password(&self.config, username, password)
-                    .map(AuthOutcome::Authenticated)
-                    .map_err(|error| error.with_failure_kind(ErrorKind::Authentication))
+                AuthenticatedGatewaySession::authenticate_password_with_connector_and_cancellation(
+                    &self.config,
+                    self.connector.clone(),
+                    username,
+                    password,
+                    None,
+                )
+                .map(AuthOutcome::Authenticated)
+                .map_err(|error| error.with_failure_kind(ErrorKind::Authentication))
             }
             AuthRequest::ChallengeResponse { method, .. } => {
                 let capability = method.capability();
@@ -364,16 +395,24 @@ impl AuthenticatedGatewaySession {
         CapabilityModel::production_password_l3()
     }
 
-    fn authenticate_password(
+    fn authenticate_password_with_cancellation(
         config: &Value,
         username: &str,
         password: &str,
+        cancellation: Option<&AuthenticationCancellation>,
     ) -> ProviderResult<Self> {
-        Self::authenticate_password_with_cancellation(config, username, password, None)
+        Self::authenticate_password_with_connector_and_cancellation(
+            config,
+            None,
+            username,
+            password,
+            cancellation,
+        )
     }
 
-    fn authenticate_password_with_cancellation(
+    fn authenticate_password_with_connector_and_cancellation(
         config: &Value,
+        connector: Option<Arc<GatewayConnectorGeneration>>,
         username: &str,
         password: &str,
         cancellation: Option<&AuthenticationCancellation>,
@@ -400,8 +439,16 @@ impl AuthenticatedGatewaySession {
             .as_str()
             .unwrap_or("EasyConnect_windows");
         let logout_path = required_endpoint(config, "logout")?.to_owned();
-        let http =
-            GatewaySession::new(base_url.to_owned(), user_agent.to_owned(), timeout_seconds)?;
+        let http = match connector {
+            Some(connector) => GatewaySession::new_with_connector(
+                connector,
+                user_agent.to_owned(),
+                timeout_seconds,
+            )?,
+            None => {
+                GatewaySession::new(base_url.to_owned(), user_agent.to_owned(), timeout_seconds)?
+            }
+        };
 
         let discovery_path = required_endpoint(config, "discovery")?;
         let _ = http

--- a/independent/src/gateway_http.rs
+++ b/independent/src/gateway_http.rs
@@ -4,6 +4,7 @@
 //! object. The module has no dependency on Engine transport, local proxy, or
 //! probe workflows, making it suitable for a future pending-auth transaction.
 
+use crate::gateway_connector::GatewayConnectorGeneration;
 use crate::xml::MAX_XML_BYTES;
 use crate::{Error, ErrorKind, Result};
 use reqwest::blocking::Client;
@@ -67,10 +68,29 @@ pub struct GatewaySession {
     user_agent: String,
     client: Client,
     cookie_stats: Arc<Mutex<CookieStats>>,
+    connector: Option<Arc<GatewayConnectorGeneration>>,
 }
 
 impl GatewaySession {
     pub fn new(base_url: String, user_agent: String, timeout: u64) -> Result<Self> {
+        Self::build(base_url, user_agent, timeout, None)
+    }
+
+    pub fn new_with_connector(
+        connector: Arc<GatewayConnectorGeneration>,
+        user_agent: String,
+        timeout: u64,
+    ) -> Result<Self> {
+        let base_url = connector.origin().to_owned();
+        Self::build(base_url, user_agent, timeout, Some(connector))
+    }
+
+    fn build(
+        base_url: String,
+        user_agent: String,
+        timeout: u64,
+        connector: Option<Arc<GatewayConnectorGeneration>>,
+    ) -> Result<Self> {
         let parsed = Url::parse(&base_url).map_err(|_| configuration_error("invalid base_url"))?;
         if parsed.scheme() != "https" {
             return Err(configuration_error("gateway base URL must use HTTPS"));
@@ -85,14 +105,24 @@ impl GatewaySession {
                 "gateway user agent has an invalid shape",
             ));
         }
-        let client = Client::builder()
+        let builder = Client::builder();
+        let builder = if let Some(connector) = connector.as_ref() {
+            if connector.origin() != parsed.origin().ascii_serialization() {
+                return Err(configuration_error(
+                    "Gateway connector origin does not match the HTTPS session",
+                ));
+            }
+            connector.apply_to_reqwest_builder(builder)
+        } else {
+            builder.no_proxy()
+        };
+        let client = builder
             // Gateway control traffic must not inherit HTTP(S)_PROXY from the
             // parent shell or a desktop proxy application. The Modern data
             // plane opens its own direct sockets; proxying only discovery,
             // authentication, configuration, or logout would split one VPN
             // session across unrelated underlays and can recurse into this
             // application's not-yet-ready loopback listener.
-            .no_proxy()
             .timeout(Duration::from_secs(timeout))
             .redirect(Policy::none())
             .https_only(true)
@@ -104,7 +134,12 @@ impl GatewaySession {
             user_agent,
             client,
             cookie_stats: Arc::new(Mutex::new(CookieStats::default())),
+            connector,
         })
+    }
+
+    pub fn connector(&self) -> Option<&GatewayConnectorGeneration> {
+        self.connector.as_deref()
     }
 
     pub fn request(
@@ -227,6 +262,8 @@ impl GatewaySession {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gateway_connector::GatewayConnectorGeneration;
+    use std::net::SocketAddr;
 
     #[test]
     fn endpoint_is_origin_bound() {
@@ -258,15 +295,52 @@ mod tests {
         // environment variables in a parallel test process. The locked
         // reqwest API defines `no_proxy()` as clearing explicit matchers and
         // disabling automatic system/environment proxy discovery.
-        let source = include_str!("gateway_http.rs");
-        let builder = source
-            .split_once("let client = Client::builder()")
-            .expect("GatewaySession client builder")
+        let session_source = include_str!("gateway_http.rs");
+        let builder = session_source
+            .split_once("fn build(")
+            .expect("GatewaySession builder")
             .1
-            .split_once(".build()")
-            .expect("GatewaySession client build")
+            .split_once("pub fn connector(")
+            .expect("GatewaySession connector accessor")
             .0;
         assert_eq!(builder.matches(".no_proxy()").count(), 1);
-        assert!(builder.find(".no_proxy()").unwrap() < builder.find(".timeout(").unwrap());
+        assert!(builder.contains("connector.apply_to_reqwest_builder(builder)"));
+
+        let connector_source = include_str!("gateway_connector.rs");
+        let connector_builder = connector_source
+            .split_once("pub fn apply_to_reqwest_builder")
+            .expect("Gateway connector reqwest binding")
+            .1
+            .split_once("pub fn connect_tcp")
+            .expect("Gateway connector TCP binding")
+            .0;
+        assert_eq!(connector_builder.matches(".no_proxy()").count(), 1);
+        assert!(
+            connector_builder.find(".no_proxy()").unwrap()
+                < connector_builder.find(".resolve_to_addrs(").unwrap()
+        );
+    }
+
+    #[test]
+    fn connector_bound_session_preserves_exact_profile_origin_and_generation() {
+        let connector = Arc::new(
+            GatewayConnectorGeneration::from_resolved(
+                "school-a",
+                7,
+                11,
+                "https://vpn.example.edu",
+                false,
+                vec!["8.8.8.8:443".parse::<SocketAddr>().unwrap()],
+            )
+            .unwrap(),
+        );
+        let session =
+            GatewaySession::new_with_connector(Arc::clone(&connector), "fixture-agent".into(), 20)
+                .unwrap();
+        let observed = session.connector().unwrap();
+        assert_eq!(observed.profile_id(), "school-a");
+        assert_eq!(observed.profile_revision(), 7);
+        assert_eq!(observed.generation(), 11);
+        assert_eq!(observed.origin(), "https://vpn.example.edu");
     }
 }

--- a/independent/tests/engine_api.rs
+++ b/independent/tests/engine_api.rs
@@ -246,12 +246,20 @@ fn engine_rechecks_config_digest_and_origin_before_reading_credentials() {
 
 #[test]
 fn matching_config_binding_reaches_the_credential_boundary() {
-    let config = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("config")
         .join("hkustgz.json");
-    let digest = hex::encode(Sha256::digest(std::fs::read(&config).unwrap()));
+    let mut document: Value = serde_json::from_slice(&std::fs::read(source).unwrap()).unwrap();
+    document["base_url"] = Value::String("https://8.8.8.8".into());
+    let config = std::env::temp_dir().join(format!(
+        "hkustgz-connector-credential-boundary-{}.json",
+        std::process::id()
+    ));
+    let payload = serde_json::to_vec(&document).unwrap();
+    std::fs::write(&config, &payload).unwrap();
+    let digest = hex::encode(Sha256::digest(&payload));
     let binding = format!(
-        "{{\"type\":\"engine_config_binding\",\"apiVersion\":1,\"configSha256\":\"{digest}\",\"gatewayOrigin\":\"https://remote.hkust-gz.edu.cn\",\"profileId\":\"hkustgz\",\"profileRevision\":1,\"protocolFamily\":\"easyconnect-password-modern-l3-v1\"}}\n",
+        "{{\"type\":\"engine_config_binding\",\"apiVersion\":1,\"configSha256\":\"{digest}\",\"gatewayOrigin\":\"https://8.8.8.8\",\"profileId\":\"hkustgz\",\"profileRevision\":1,\"protocolFamily\":\"easyconnect-password-modern-l3-v1\"}}\n",
     );
     let output = engine()
         .args([
@@ -261,6 +269,8 @@ fn matching_config_binding_reaches_the_credential_boundary() {
             "--credentials-stdin",
             "--socks-bind",
             "127.0.0.1:6180",
+            "--generation",
+            "9",
         ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -271,12 +281,62 @@ fn matching_config_binding_reaches_the_credential_boundary() {
             child.wait_with_output()
         })
         .unwrap();
+    std::fs::remove_file(config).unwrap();
     assert!(!output.status.success());
     assert!(
         events(&output.stdout).iter().any(|event| {
             event["type"] == "fatal_error" && event["code"] == "CREDENTIALS_INVALID"
         })
     );
+}
+
+#[test]
+fn profile_bound_connector_policy_fails_before_reading_credentials() {
+    let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("config")
+        .join("hkustgz.json");
+    let mut document: Value = serde_json::from_slice(&std::fs::read(source).unwrap()).unwrap();
+    document["base_url"] = Value::String("https://127.0.0.1".into());
+    let config = std::env::temp_dir().join(format!(
+        "hkustgz-forbidden-connector-{}.json",
+        std::process::id()
+    ));
+    let payload = serde_json::to_vec(&document).unwrap();
+    std::fs::write(&config, &payload).unwrap();
+    let digest = hex::encode(Sha256::digest(&payload));
+    let binding = format!(
+        "{{\"type\":\"engine_config_binding\",\"apiVersion\":1,\"configSha256\":\"{digest}\",\"gatewayOrigin\":\"https://127.0.0.1\",\"profileId\":\"hkustgz\",\"profileRevision\":1,\"protocolFamily\":\"easyconnect-password-modern-l3-v1\"}}\n",
+    );
+    let private_credential = "must-not-reach-forbidden-connector";
+    let mut child = engine()
+        .args([
+            "--config",
+            config.to_str().unwrap(),
+            "--profile-binding-v1-stdin",
+            "--credentials-stdin",
+            "--socks-bind",
+            "127.0.0.1:6180",
+            "--generation",
+            "10",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(format!("{binding}student\n{private_credential}\n").as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    std::fs::remove_file(config).unwrap();
+    assert!(events(&output.stdout).iter().any(|event| {
+        event["type"] == "fatal_error" && event["code"] == "CONFIGURATION_INVALID"
+    }));
+    assert!(!String::from_utf8_lossy(&output.stdout).contains(private_credential));
+    assert!(!String::from_utf8_lossy(&output.stderr).contains(private_credential));
 }
 
 #[test]

--- a/independent/tests/module_boundaries.rs
+++ b/independent/tests/module_boundaries.rs
@@ -97,6 +97,32 @@ fn gateway_connector_is_profile_bound_but_credential_and_transport_neutral() {
 }
 
 #[test]
+fn production_gateway_http_is_bound_before_credentials_and_owned_by_one_session() {
+    let engine = source("src/bin/ec-engine.rs");
+    let run = engine
+        .split_once("async fn run_engine")
+        .expect("production run_engine")
+        .1;
+    let connector = run
+        .find("GatewayConnectorGeneration::resolve_system")
+        .expect("profile-bound Gateway connector");
+    let credential = run
+        .find("read_engine_credentials_prefix")
+        .expect("private credential input");
+    assert!(
+        connector < credential,
+        "Gateway origin and peer policy must fail before credential input"
+    );
+
+    let session = source("src/engine/session.rs");
+    assert!(session.contains("GatewaySession::new_with_connector"));
+    assert!(session.contains("http: GatewaySession"));
+    assert!(session.contains(".request(&self.configuration_path"));
+    assert!(session.contains(".request(&self.resource_list_path"));
+    assert!(session.contains(".request_with_timeout(&self.logout_path"));
+}
+
+#[test]
 fn credential_input_is_neutral_to_gateway_and_protocol_layers() {
     let credentials = source("src/credentials.rs");
     for forbidden in [


### PR DESCRIPTION
## Summary

- bind production Gateway discovery, password configuration, login, session configuration, resource-list DNS and logout to one profile/revision/Engine-generation connector and cookie session
- resolve and validate Gateway origin/peer policy before reading credentials; keep unreviewed private Gateway addresses fail-closed
- add a control-renderer crash-loop circuit breaker so a repeated Chromium failure cannot continuously recreate the Electron window
- keep the existing HKUST profile behavior and lifecycle test fixture isolated

## Validation

- Desktop: 800 passed, 0 failed, 1 explicit Windows-only skip
- Real Electron forced double-renderer-crash recovery: PASS
- Real Electron main integration and persistence migration: PASS
- Rust: 210 passed, 0 failed, 1 explicit performance benchmark ignored
- Engine lifecycle fixture: 100/100 rounds
- Clippy all targets/all features: 0 warnings
- architecture gate and tracked secret gate: PASS

## Boundary

This PR covers Gateway HTTP only. Modern token/data-plane sockets remain intentionally deferred to P5c so the TLS-sensitive transport change receives its own review and regression evidence.