### PR TITLE
2.0 P5c: bind Modern transport to Gateway connector

### DIFF
--- a/docs/adr/0021-gateway-connector-consumption.md
+++ b/docs/adr/0021-gateway-connector-consumption.md
@@ -1,0 +1,55 @@
+# ADR-0021: Consume one Gateway connector across HTTP and Modern transport
+
+- Status: Accepted for 2.0 P5b/P5c
+- Scope: production password authentication and Modern L3
+- Probe compatibility: retained outside the production provider path
+
+## Decision
+
+A profile-bound Engine resolves and validates one immutable
+`GatewayConnectorGeneration` before reading credentials. The same reference is
+then retained by the authenticated HTTP session and by the Modern token
+acquisition. Production connections use it for:
+
+1. discovery, password configuration and password login;
+2. authenticated session configuration and resource-list DNS;
+3. bounded logout and partial-authentication cleanup;
+4. the PKI-verified Modern token socket;
+5. the address-control, packet-send and packet-receive special-TLS sockets.
+
+The token acquisition records the actual connected peer. All three special-TLS
+channels must reconnect to that exact peer, and the peer must still be a member
+of the immutable connector generation. They do not perform another system DNS
+lookup and cannot substitute another Profile or Engine generation.
+
+## TLS and protocol boundary
+
+This decision does not alter the reviewed EasyConnect wire protocol. Modern
+token TLS still uses standard WebPKI verification for the reviewed hostname.
+The isolated TLS 1.1 implementation still verifies its certificate through
+WebPKI, the verified HTTPS leaf binding, or an explicit reviewed pin. Host drift
+is rejected before network I/O, and no certificate bypass is added.
+
+The compatibility probe path retains its explicit legacy resolver and direct
+socket constructor. Production provider composition is the only activated
+path, and it always carries the profile-bound connector when launched by the
+Desktop or reviewed CLI binding.
+
+## Failure and timeout policy
+
+The connector applies one total timeout across its bounded peer set rather than
+granting the full timeout to each address. A requested or connected peer outside
+the generation fails permanently. Ordinary connect refusal, reset, or timeout
+remains a transient data-plane error and may use the existing bounded retry
+policy. Protocol, certificate, host, Profile, revision, and generation drift do
+not become retryable through diagnostic wording.
+
+## Required evidence
+
+- connector construction precedes credential input;
+- HTTP and Cookie state retain the same connector reference;
+- token acquisition retains Profile, revision, generation and exact peer;
+- address-control, send and receive each use the token's connector and peer;
+- special TLS rejects host drift before opening a socket;
+- probe compatibility remains separate from production composition;
+- password-only and lifecycle-fixture regressions stay green.

--- a/independent/src/engine/data_plane.rs
+++ b/independent/src/engine/data_plane.rs
@@ -1,4 +1,5 @@
 use crate::engine::ip_packet::{push_and_extract_ipv4, validate_ipv4_packet};
+use crate::gateway_connector::GatewayConnectorGeneration;
 use crate::modern::{
     ModernCommand, ModernControlRequest, ModernTokenAcquisition, parse_address_reply,
     validate_channel_reply,
@@ -86,6 +87,7 @@ impl EasyConnectDataPlane {
         let peer = acquisition.peer_address();
         let verified_leaf = acquisition.verified_leaf_sha256();
         let mut lease_stream = connect_tls(
+            acquisition.connector(),
             peer,
             gateway_host,
             timeout,
@@ -110,6 +112,7 @@ impl EasyConnectDataPlane {
         }
 
         let mut send_stream = connect_tls(
+            acquisition.connector(),
             peer,
             gateway_host,
             timeout,
@@ -141,6 +144,7 @@ impl EasyConnectDataPlane {
             .map_err(|error| data_plane_stage_error("modern send socket", error))?;
 
         let mut receive_stream = connect_tls(
+            acquisition.connector(),
             peer,
             gateway_host,
             timeout,
@@ -205,13 +209,24 @@ impl EasyConnectDataPlane {
 }
 
 fn connect_tls(
+    connector: Option<&GatewayConnectorGeneration>,
     peer: SocketAddr,
     host: &str,
     timeout: Duration,
     verified_leaf: &[u8; 32],
     configured_pin: Option<&[u8; 32]>,
 ) -> Result<SpecialTls11Stream> {
-    SpecialTls11Stream::connect(peer, host, timeout, verified_leaf, configured_pin)
+    match connector {
+        Some(connector) => SpecialTls11Stream::connect_with_connector(
+            connector,
+            peer,
+            host,
+            timeout,
+            verified_leaf,
+            configured_pin,
+        ),
+        None => SpecialTls11Stream::connect(peer, host, timeout, verified_leaf, configured_pin),
+    }
 }
 
 pub struct AddressLease {

--- a/independent/src/engine/session.rs
+++ b/independent/src/engine/session.rs
@@ -10,7 +10,7 @@ use crate::engine::provider::{
 use crate::gateway_auth::AuthenticatedSessionId;
 use crate::gateway_connector::GatewayConnectorGeneration;
 use crate::gateway_http::{DEFAULT_TIMEOUT_SECONDS, GatewaySession};
-use crate::modern::{parse_sha256_pin, request_modern_token};
+use crate::modern::{parse_sha256_pin, request_modern_token, request_modern_token_with_connector};
 use crate::xml::{first_descendant_text, parse_xml};
 use crate::{Error, ErrorKind, Result};
 use reqwest::Method;
@@ -303,8 +303,16 @@ impl ModernL3TransportBackend {
             }
         }
         ensure_transport_active(cancellation)?;
-        let acquisition =
-            request_modern_token(&self.base_url, &session.session_identifier, self.timeout)?;
+        let acquisition = match session.http.connector_handle() {
+            Some(connector) => request_modern_token_with_connector(
+                connector,
+                &session.session_identifier,
+                self.timeout,
+            )?,
+            None => {
+                request_modern_token(&self.base_url, &session.session_identifier, self.timeout)?
+            }
+        };
         ensure_transport_active(cancellation)?;
         let data_plane_not_before = Instant::now() + MODERN_ADDRESS_SETTLE_DELAY;
         let mut attempt = 1;

--- a/independent/src/gateway_connector.rs
+++ b/independent/src/gateway_connector.rs
@@ -9,7 +9,7 @@
 use crate::{Error, ErrorKind, Result};
 use reqwest::blocking::ClientBuilder;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use url::{Host, Url};
 
 const MAX_PROFILE_ID_BYTES: usize = 64;
@@ -307,19 +307,18 @@ impl GatewayConnectorGeneration {
                 "Gateway connector timeout must be nonzero",
             ));
         }
+        let deadline = Instant::now()
+            .checked_add(timeout)
+            .ok_or_else(|| configuration_error("Gateway connector timeout is too large"))?;
         let mut last_error = None;
         for address in &self.addresses {
-            match TcpStream::connect_timeout(address, timeout) {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match TcpStream::connect_timeout(address, remaining) {
                 Ok(stream) => {
-                    let peer = stream.peer_addr().map_err(|error| {
-                        connector_error(format!("cannot inspect Gateway peer: {error}"))
-                    })?;
-                    if !self.peer_allowed(peer) {
-                        return Err(Error::classified(
-                            ErrorKind::GatewayProtocolInvalid,
-                            "connected Gateway peer is outside the connector generation",
-                        ));
-                    }
+                    self.verify_connected_peer(&stream)?;
                     return Ok(stream);
                 }
                 Err(error) => last_error = Some(error),
@@ -331,6 +330,40 @@ impl GatewayConnectorGeneration {
                 .map(|error| error.to_string())
                 .unwrap_or_else(|| "no address".to_owned())
         )))
+    }
+
+    pub fn connect_tcp_to(&self, peer: SocketAddr, timeout: Duration) -> Result<TcpStream> {
+        if timeout.is_zero() {
+            return Err(configuration_error(
+                "Gateway connector timeout must be nonzero",
+            ));
+        }
+        if !self.peer_allowed(peer) {
+            return Err(Error::classified(
+                ErrorKind::GatewayProtocolInvalid,
+                "requested Gateway peer is outside the connector generation",
+            ));
+        }
+        let stream = TcpStream::connect_timeout(&peer, timeout).map_err(|error| {
+            connector_error(format!(
+                "cannot connect to the selected Gateway peer: {error}"
+            ))
+        })?;
+        self.verify_connected_peer(&stream)?;
+        Ok(stream)
+    }
+
+    fn verify_connected_peer(&self, stream: &TcpStream) -> Result<()> {
+        let peer = stream
+            .peer_addr()
+            .map_err(|error| connector_error(format!("cannot inspect Gateway peer: {error}")))?;
+        if !self.peer_allowed(peer) {
+            return Err(Error::classified(
+                ErrorKind::GatewayProtocolInvalid,
+                "connected Gateway peer is outside the connector generation",
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -371,6 +404,10 @@ mod tests {
             .apply_to_reqwest_builder(Client::builder())
             .build()
             .unwrap();
+        let rejected = connector
+            .connect_tcp_to(public("9.9.9.9"), Duration::from_millis(1))
+            .unwrap_err();
+        assert_eq!(rejected.kind(), ErrorKind::GatewayProtocolInvalid);
     }
 
     #[test]

--- a/independent/src/gateway_http.rs
+++ b/independent/src/gateway_http.rs
@@ -142,6 +142,10 @@ impl GatewaySession {
         self.connector.as_deref()
     }
 
+    pub(crate) fn connector_handle(&self) -> Option<Arc<GatewayConnectorGeneration>> {
+        self.connector.clone()
+    }
+
     pub fn request(
         &self,
         path: &str,

--- a/independent/src/modern.rs
+++ b/independent/src/modern.rs
@@ -1,4 +1,5 @@
 use crate::gateway_auth::{AUTHENTICATED_SESSION_ID_LEN, AuthenticatedSessionId};
+use crate::gateway_connector::GatewayConnectorGeneration;
 use crate::special_tls11::SpecialTls11Stream;
 use crate::{Error, ErrorKind, Result};
 use rand::RngCore;
@@ -77,6 +78,7 @@ pub struct ModernTokenAcquisition {
     token: ModernToken,
     verified_leaf_sha256: [u8; 32],
     peer_address: SocketAddr,
+    connector: Option<Arc<GatewayConnectorGeneration>>,
 }
 
 impl ModernTokenAcquisition {
@@ -90,6 +92,10 @@ impl ModernTokenAcquisition {
 
     pub fn peer_address(&self) -> SocketAddr {
         self.peer_address
+    }
+
+    pub(crate) fn connector(&self) -> Option<&GatewayConnectorGeneration> {
+        self.connector.as_deref()
     }
 }
 
@@ -682,15 +688,30 @@ pub fn parse_server_hello_session_id(records: &[u8]) -> Result<Zeroizing<Vec<u8>
 /// gateway to acknowledge the previous one, so interactive traffic pays a
 /// delayed-ACK stall on every packet instead of a single round trip.
 pub(crate) fn connect_gateway_tcp(address: SocketAddr, timeout: Duration) -> Result<TcpStream> {
-    const KEEPALIVE_IDLE: Duration = Duration::from_secs(15);
-    const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
-
     let stream = TcpStream::connect_timeout(&address, timeout).map_err(|error| {
         Error::classified(
             ErrorKind::DataPlaneTransient,
             format!("cannot connect to the gateway TCP endpoint: {error}"),
         )
     })?;
+    configure_gateway_tcp(stream, timeout)
+}
+
+pub(crate) fn connect_gateway_tcp_to_connector(
+    connector: &GatewayConnectorGeneration,
+    peer: SocketAddr,
+    timeout: Duration,
+) -> Result<TcpStream> {
+    let stream = connector
+        .connect_tcp_to(peer, timeout)
+        .map_err(classify_connector_transport_error)?;
+    configure_gateway_tcp(stream, timeout)
+}
+
+fn configure_gateway_tcp(stream: TcpStream, timeout: Duration) -> Result<TcpStream> {
+    const KEEPALIVE_IDLE: Duration = Duration::from_secs(15);
+    const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
+
     stream.set_read_timeout(Some(timeout)).map_err(|error| {
         Error::classified(
             ErrorKind::DataPlane,
@@ -723,6 +744,19 @@ pub(crate) fn connect_gateway_tcp(address: SocketAddr, timeout: Duration) -> Res
     Ok(stream)
 }
 
+fn classify_connector_transport_error(error: Error) -> Error {
+    let kind = match error.kind() {
+        ErrorKind::GatewayHttp | ErrorKind::GatewayHttpIndeterminate | ErrorKind::Io => {
+            ErrorKind::DataPlaneTransient
+        }
+        _ => ErrorKind::DataPlane,
+    };
+    Error::classified(
+        kind,
+        "Gateway connector rejected the Modern transport socket",
+    )
+}
+
 fn resolve_gateway(url: &Url) -> Result<(String, SocketAddr)> {
     if url.scheme() != "https" {
         return Err(Error("modern token endpoint must use HTTPS".into()));
@@ -747,7 +781,35 @@ pub fn request_modern_token(
     let url = Url::parse(base_url).map_err(|_| Error("invalid modern token base URL".into()))?;
     let (host, address) = resolve_gateway(&url)?;
     let socket = connect_gateway_tcp(address, timeout)?;
+    request_modern_token_on_socket(host, address, socket, None, session)
+}
 
+pub fn request_modern_token_with_connector(
+    connector: Arc<GatewayConnectorGeneration>,
+    session: &AuthenticatedSessionId,
+    timeout: Duration,
+) -> Result<ModernTokenAcquisition> {
+    let socket = connector
+        .connect_tcp(timeout)
+        .map_err(classify_connector_transport_error)?;
+    let address = socket.peer_addr().map_err(|_| {
+        Error::classified(
+            ErrorKind::DataPlane,
+            "Gateway connector Modern peer could not be inspected",
+        )
+    })?;
+    let socket = configure_gateway_tcp(socket, timeout)?;
+    let host = connector.host().to_owned();
+    request_modern_token_on_socket(host, address, socket, Some(connector), session)
+}
+
+fn request_modern_token_on_socket(
+    host: String,
+    address: SocketAddr,
+    socket: TcpStream,
+    connector: Option<Arc<GatewayConnectorGeneration>>,
+    session: &AuthenticatedSessionId,
+) -> Result<ModernTokenAcquisition> {
     let roots = RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     let config = ClientConfig::builder()
         .with_root_certificates(roots)
@@ -795,6 +857,7 @@ pub fn request_modern_token(
         token,
         verified_leaf_sha256,
         peer_address: address,
+        connector,
     })
 }
 
@@ -851,6 +914,38 @@ mod tests {
         assert_eq!(&token.as_bytes()[32..], b"0123456789abcdef");
         assert_eq!(format!("{token:?}"), "ModernToken(<redacted>)");
         assert!(ModernToken::derive(&[1; 15], &session).is_err());
+    }
+
+    #[test]
+    fn token_acquisition_retains_the_exact_connector_generation() {
+        let peer: SocketAddr = "8.8.8.8:443".parse().unwrap();
+        let connector = Arc::new(
+            GatewayConnectorGeneration::from_resolved(
+                "school-a",
+                4,
+                19,
+                "https://gateway.example.test",
+                false,
+                vec![peer],
+            )
+            .unwrap(),
+        );
+        let session = ModernSessionId::from_bytes(b"0123456789abcdef").unwrap();
+        let acquisition = ModernTokenAcquisition {
+            token: ModernToken::derive(&[0xab; 32], &session).unwrap(),
+            verified_leaf_sha256: [7; 32],
+            peer_address: peer,
+            connector: Some(Arc::clone(&connector)),
+        };
+        let observed = acquisition.connector().unwrap();
+        assert_eq!(observed.profile_id(), "school-a");
+        assert_eq!(observed.profile_revision(), 4);
+        assert_eq!(observed.generation(), 19);
+        assert!(observed.peer_allowed(acquisition.peer_address()));
+        assert_eq!(
+            format!("{acquisition:?}"),
+            "ModernTokenAcquisition(<redacted>)"
+        );
     }
 
     #[test]

--- a/independent/src/special_tls11.rs
+++ b/independent/src/special_tls11.rs
@@ -1,4 +1,8 @@
-use crate::modern::{build_special_client_hello, connect_gateway_tcp, verify_special_certificates};
+use crate::gateway_connector::GatewayConnectorGeneration;
+use crate::modern::{
+    build_special_client_hello, connect_gateway_tcp, connect_gateway_tcp_to_connector,
+    verify_special_certificates,
+};
 use crate::{Error, ErrorKind, Result};
 use hmac::{Hmac, Mac};
 use md5::Md5;
@@ -513,7 +517,44 @@ impl SpecialTls11Stream {
         verified_https_leaf_sha256: &[u8; 32],
         configured_special_leaf_sha256: Option<&[u8; 32]>,
     ) -> Result<Self> {
-        let mut stream = connect_gateway_tcp(address, timeout)?;
+        let stream = connect_gateway_tcp(address, timeout)?;
+        Self::handshake(
+            stream,
+            host,
+            verified_https_leaf_sha256,
+            configured_special_leaf_sha256,
+        )
+    }
+
+    pub(crate) fn connect_with_connector(
+        connector: &GatewayConnectorGeneration,
+        peer: SocketAddr,
+        host: &str,
+        timeout: Duration,
+        verified_https_leaf_sha256: &[u8; 32],
+        configured_special_leaf_sha256: Option<&[u8; 32]>,
+    ) -> Result<Self> {
+        if connector.host() != host {
+            return Err(Error::classified(
+                ErrorKind::DataPlane,
+                "special TLS host does not match the Gateway connector",
+            ));
+        }
+        let stream = connect_gateway_tcp_to_connector(connector, peer, timeout)?;
+        Self::handshake(
+            stream,
+            host,
+            verified_https_leaf_sha256,
+            configured_special_leaf_sha256,
+        )
+    }
+
+    fn handshake(
+        mut stream: TcpStream,
+        host: &str,
+        verified_https_leaf_sha256: &[u8; 32],
+        configured_special_leaf_sha256: Option<&[u8; 32]>,
+    ) -> Result<Self> {
         let mut client_random = [0_u8; 32];
         OsRng.fill_bytes(&mut client_random);
         let client_hello = build_special_client_hello(client_random)?;
@@ -701,6 +742,33 @@ impl SpecialTls11Stream {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn connector_bound_handshake_rejects_host_drift_before_network_io() {
+        let peer: SocketAddr = "8.8.8.8:443".parse().unwrap();
+        let connector = GatewayConnectorGeneration::from_resolved(
+            "school-a",
+            1,
+            9,
+            "https://gateway.example.test",
+            false,
+            vec![peer],
+        )
+        .unwrap();
+        let result = SpecialTls11Stream::connect_with_connector(
+            &connector,
+            peer,
+            "different.example.test",
+            Duration::from_millis(1),
+            &[0; 32],
+            None,
+        );
+        let error = match result {
+            Ok(_) => panic!("host drift reached a special TLS connection"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), ErrorKind::DataPlane);
+    }
 
     #[test]
     fn cipher_free_shutdown_handle_wakes_a_blocked_peer() {

--- a/independent/tests/module_boundaries.rs
+++ b/independent/tests/module_boundaries.rs
@@ -123,6 +123,29 @@ fn production_gateway_http_is_bound_before_credentials_and_owned_by_one_session(
 }
 
 #[test]
+fn production_modern_transport_consumes_the_authenticated_connector_generation() {
+    let session = source("src/engine/session.rs");
+    assert!(session.contains("session.http.connector_handle()"));
+    assert!(session.contains("request_modern_token_with_connector"));
+
+    let modern = source("src/modern.rs");
+    assert!(modern.contains("connector: Option<Arc<GatewayConnectorGeneration>>"));
+    assert!(modern.contains(".connect_tcp(timeout)"));
+
+    let data_plane = source("src/engine/data_plane.rs");
+    assert_eq!(
+        data_plane.matches("acquisition.connector()").count(),
+        3,
+        "address, send and receive channels must consume the token connector"
+    );
+    assert!(data_plane.contains("SpecialTls11Stream::connect_with_connector"));
+
+    let special_tls = source("src/special_tls11.rs");
+    assert!(special_tls.contains("connect_gateway_tcp_to_connector(connector, peer, timeout)"));
+    assert!(special_tls.contains("connector.host() != host"));
+}
+
+#[test]
 fn credential_input_is_neutral_to_gateway_and_protocol_layers() {
     let credentials = source("src/credentials.rs");
     for forbidden in [


### PR DESCRIPTION
## Summary

- carry the exact profile/revision/Engine-generation `GatewayConnectorGeneration` from authenticated HTTP state into Modern token acquisition
- open the PKI-verified token socket only through the connector's bounded peer set and retain its exact connected peer
- force address-control, send and receive special-TLS channels to reconnect only to that peer through the same connector generation
- reject host or peer drift before special-TLS network I/O and apply one total timeout across connector address attempts
- retain the compatibility probe path without changing the reviewed EasyConnect TLS 1.1 handshake or certificate checks

## Validation

- Rust: 212 passed, 0 failed, 1 explicit performance benchmark ignored
- Engine lifecycle fixture: 100/100 rounds
- Clippy all targets/all features: 0 warnings
- module boundary and exact connector/peer tests: PASS
- tracked secret gate: PASS

## Boundary

No TLS cipher, handshake, certificate, heartbeat, token derivation, packet framing or retry protocol was rewritten. This PR changes socket ownership and routing only.