### PR TITLE
2.0 P6a: add credential-free custom Gateway probe

### DIFF
--- a/docs/adr/0022-public-gateway-probe.md
+++ b/docs/adr/0022-public-gateway-probe.md
@@ -1,0 +1,49 @@
+# ADR-0022: Credential-free public Gateway compatibility probe
+
+- Status: Accepted for 2.0 P6a
+- Scope: unreviewed `Other` Gateway compatibility check
+- Profile creation, confirmation and credential entry: deferred to later P6 slices
+
+## Decision
+
+The first custom-Gateway operation is a separate Rust process and contains no
+credential input. It accepts one normalized HTTPS root origin and executes one
+compiled EasyConnect public discovery request:
+
+```text
+GET /por/login_auth.csp?apiversion=1
+```
+
+The path, method, headers, parser, timeout bounds and candidate family are
+compiled code. Profile JSON, Renderer input and the Gateway response cannot
+select another path or provider.
+
+The probe constructs a fresh public-only `GatewayConnectorGeneration`, disables
+environment proxies, redirects and Cookie persistence, retains hostname SNI and
+standard PKI verification, limits the response body to 64 KiB and accepts only
+bounded XML content types. Loopback, link-local, private, shared, multicast,
+documentation, reserved and mixed-scope resolution sets remain rejected.
+
+## Output boundary
+
+The process returns only:
+
+- normalized origin;
+- whether the HTTPS identity was valid;
+- `recognized_candidate`, `unsupported` or `unknown`;
+- the one compiled candidate family, when recognized;
+- a bounded sanitized version value, when present;
+- HTTP status.
+
+Raw XML, `TwfID`, CSRF material, RSA keys, Cookies, response headers and target
+addresses never cross stdout. The response buffer is zeroized after parsing.
+A recognized result is only a candidate public authentication surface; it does
+not prove password acceptance, Modern L3, campus DNS, resources or MFA support.
+
+## Deferred activation
+
+This slice deliberately does not create a custom Profile, expose a Renderer
+boolean as authorization, enable credential fields or launch the production
+Engine. A later P6 slice must add a Main-owned, one-use, expiring confirmation
+bound to exact origin, family, draft identity and active-context epoch before
+creating isolated Profile/Account/Workspace state.

--- a/independent/src/bin/ec-gateway-probe.rs
+++ b/independent/src/bin/ec-gateway-probe.rs
@@ -1,0 +1,56 @@
+use ec_compat::gateway_probe::probe_public_gateway;
+use std::time::Duration;
+
+fn origin_argument(arguments: &[String]) -> Option<&str> {
+    if arguments.len() != 2 || arguments[0] != "--origin" {
+        return None;
+    }
+    Some(arguments[1].as_str())
+}
+
+fn main() {
+    let arguments = std::env::args().skip(1).collect::<Vec<_>>();
+    let Some(origin) = origin_argument(&arguments) else {
+        eprintln!("ec-gateway-probe: expected one Gateway origin");
+        std::process::exit(64);
+    };
+    match probe_public_gateway(origin, 1, Duration::from_secs(8)) {
+        Ok(result) => match serde_json::to_string(&result) {
+            Ok(json) => println!("{json}"),
+            Err(_) => {
+                eprintln!("ec-gateway-probe: result could not be encoded");
+                std::process::exit(1);
+            }
+        },
+        Err(_) => {
+            eprintln!("ec-gateway-probe: compatibility check failed");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn argument_contract_is_exact_and_does_not_accept_extra_request_material() {
+        let valid = vec!["--origin".into(), "https://gateway.example.test".into()];
+        assert_eq!(
+            origin_argument(&valid),
+            Some("https://gateway.example.test")
+        );
+        for invalid in [
+            vec![],
+            vec!["--origin".into()],
+            vec!["--path".into(), "/private".into()],
+            vec![
+                "--origin".into(),
+                "https://gateway.example.test".into(),
+                "secret".into(),
+            ],
+        ] {
+            assert_eq!(origin_argument(&invalid), None);
+        }
+    }
+}

--- a/independent/src/gateway_probe.rs
+++ b/independent/src/gateway_probe.rs
@@ -1,0 +1,285 @@
+//! Credential-free, closed-contract probe for an unreviewed Gateway origin.
+//!
+//! This is not authentication and never proves L3, DNS or resource support.
+//! It makes one fixed public EasyConnect discovery request through the same
+//! public-address connector policy used by production, retains no Cookie jar,
+//! and returns only a bounded sanitized classification.
+
+use crate::gateway_connector::GatewayConnectorGeneration;
+use crate::gateway_http::endpoint_url;
+use crate::xml::{first_descendant_text, parse_xml};
+use crate::{Error, ErrorKind, Result};
+use reqwest::blocking::Client;
+use reqwest::header::{ACCEPT, CONTENT_TYPE, USER_AGENT};
+use reqwest::redirect::Policy;
+use serde::Serialize;
+use std::io::Read;
+use std::time::Duration;
+use zeroize::Zeroizing;
+
+pub const PUBLIC_GATEWAY_PROBE_PATH: &str = "/por/login_auth.csp?apiversion=1";
+pub const PUBLIC_GATEWAY_PROBE_FAMILY: &str = "easyconnect-password-modern-l3-v1";
+const PUBLIC_GATEWAY_PROBE_PROFILE_ID: &str = "custom-probe";
+const PUBLIC_GATEWAY_PROBE_PROFILE_REVISION: u64 = 1;
+const MAX_PUBLIC_PROBE_BODY_BYTES: usize = 64 * 1024;
+const MIN_PUBLIC_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
+const MAX_PUBLIC_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
+const PUBLIC_PROBE_USER_AGENT: &str = "CampusConnect-GatewayProbe/1";
+
+fn probe_error(message: impl Into<String>) -> Error {
+    Error::classified(ErrorKind::GatewayHttp, message)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PublicGatewayCompatibility {
+    RecognizedCandidate,
+    Unsupported,
+    Unknown,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PublicGatewayProbeResult {
+    pub schema_version: u8,
+    pub normalized_origin: String,
+    pub https_identity_valid: bool,
+    pub compatibility: PublicGatewayCompatibility,
+    pub candidate_family: Option<String>,
+    pub reported_version: Option<String>,
+    pub http_status: u16,
+}
+
+fn sanitized_version(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if value.len() <= 32
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"._-".contains(&byte))
+    {
+        Some(value.to_owned())
+    } else {
+        Some("present_unknown".to_owned())
+    }
+}
+
+fn classify_public_discovery(
+    body: &[u8],
+) -> (PublicGatewayCompatibility, Option<String>, Option<String>) {
+    let Ok(document) = parse_xml(body, "public Gateway discovery") else {
+        return (PublicGatewayCompatibility::Unknown, None, None);
+    };
+    let root = document.root_element();
+    if root.tag_name().name() != "Auth" {
+        return (PublicGatewayCompatibility::Unknown, None, None);
+    }
+    let error_code = first_descendant_text(root, "ErrorCode");
+    let start_auth = first_descendant_text(root, "StartAuth");
+    let has_known_auth_shape = matches!(error_code.trim(), "1" | "2")
+        && matches!(start_auth.trim(), "0" | "1")
+        && !first_descendant_text(root, "CSRF_RAND_CODE").is_empty();
+    if !has_known_auth_shape {
+        return (PublicGatewayCompatibility::Unknown, None, None);
+    }
+    (
+        PublicGatewayCompatibility::RecognizedCandidate,
+        Some(PUBLIC_GATEWAY_PROBE_FAMILY.to_owned()),
+        sanitized_version(&first_descendant_text(root, "VPNVERSION")),
+    )
+}
+
+fn supported_public_content_type(value: Option<&reqwest::header::HeaderValue>) -> bool {
+    let Some(value) = value.and_then(|value| value.to_str().ok()) else {
+        return false;
+    };
+    if value.len() > 128 {
+        return false;
+    }
+    matches!(
+        value
+            .split(';')
+            .next()
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "application/xml" | "text/xml"
+    )
+}
+
+pub fn probe_public_gateway(
+    origin: &str,
+    generation: u64,
+    timeout: Duration,
+) -> Result<PublicGatewayProbeResult> {
+    let connector = GatewayConnectorGeneration::resolve_system(
+        PUBLIC_GATEWAY_PROBE_PROFILE_ID,
+        PUBLIC_GATEWAY_PROBE_PROFILE_REVISION,
+        generation,
+        origin,
+        false,
+    )?;
+    probe_public_gateway_with_connector(&connector, timeout)
+}
+
+pub fn probe_public_gateway_with_connector(
+    connector: &GatewayConnectorGeneration,
+    timeout: Duration,
+) -> Result<PublicGatewayProbeResult> {
+    if !(MIN_PUBLIC_PROBE_TIMEOUT..=MAX_PUBLIC_PROBE_TIMEOUT).contains(&timeout) {
+        return Err(probe_error(
+            "public Gateway probe timeout is outside its bound",
+        ));
+    }
+    if connector.reviewed_private_gateway_allowed() {
+        return Err(probe_error(
+            "public Gateway probe cannot use a private-address exception",
+        ));
+    }
+    let client = connector
+        .apply_to_reqwest_builder(
+            Client::builder()
+                .redirect(Policy::none())
+                .https_only(true)
+                .cookie_store(false)
+                .timeout(timeout),
+        )
+        .build()
+        .map_err(|_| probe_error("public Gateway probe client could not be created"))?;
+    let url = endpoint_url(connector.origin(), PUBLIC_GATEWAY_PROBE_PATH)?;
+    let mut response = client
+        .get(&url)
+        .header(USER_AGENT, PUBLIC_PROBE_USER_AGENT)
+        .header(ACCEPT, "application/xml,text/xml;q=0.9,*/*;q=0.1")
+        .send()
+        .map_err(|_| probe_error("public Gateway probe request failed"))?;
+    if response.url().origin().ascii_serialization() != connector.origin() {
+        return Err(probe_error("public Gateway probe escaped its origin"));
+    }
+    let status = response.status();
+    let supported_content_type =
+        supported_public_content_type(response.headers().get(CONTENT_TYPE));
+    if status.is_redirection() {
+        return Err(probe_error("public Gateway probe redirect was denied"));
+    }
+    let mut body = Zeroizing::new(Vec::new());
+    response
+        .by_ref()
+        .take((MAX_PUBLIC_PROBE_BODY_BYTES + 1) as u64)
+        .read_to_end(&mut body)
+        .map_err(|_| probe_error("public Gateway probe response could not be read"))?;
+    if body.len() > MAX_PUBLIC_PROBE_BODY_BYTES {
+        return Err(probe_error(
+            "public Gateway probe response exceeds its bound",
+        ));
+    }
+    let (compatibility, candidate_family, reported_version) =
+        if status.is_success() && supported_content_type {
+            classify_public_discovery(&body)
+        } else if status.is_client_error() {
+            (PublicGatewayCompatibility::Unsupported, None, None)
+        } else {
+            (PublicGatewayCompatibility::Unknown, None, None)
+        };
+    Ok(PublicGatewayProbeResult {
+        schema_version: 1,
+        normalized_origin: connector.origin().to_owned(),
+        https_identity_valid: true,
+        compatibility,
+        candidate_family,
+        reported_version,
+        http_status: status.as_u16(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DISCOVERY: &[u8] = include_bytes!("../tests/fixtures/login_auth.xml");
+
+    #[test]
+    fn known_discovery_is_only_a_sanitized_candidate() {
+        let (compatibility, family, version) = classify_public_discovery(DISCOVERY);
+        assert_eq!(
+            compatibility,
+            PublicGatewayCompatibility::RecognizedCandidate
+        );
+        assert_eq!(family.as_deref(), Some(PUBLIC_GATEWAY_PROBE_FAMILY));
+        assert_eq!(version.as_deref(), Some("M7.6.8R2"));
+        let encoded = serde_json::to_string(&(compatibility, family, version)).unwrap();
+        for private in ["REDACTED", "TwfID", "CSRF_RAND_CODE", "RSA_ENCRYPT_KEY"] {
+            assert!(!encoded.contains(private));
+        }
+    }
+
+    #[test]
+    fn unknown_or_malformed_discovery_never_invents_support() {
+        for body in [
+            b"<html>not a Gateway</html>".as_slice(),
+            b"<Auth><ErrorCode>1</ErrorCode></Auth>".as_slice(),
+            b"not xml".as_slice(),
+        ] {
+            assert_eq!(
+                classify_public_discovery(body),
+                (PublicGatewayCompatibility::Unknown, None, None),
+            );
+        }
+    }
+
+    #[test]
+    fn reported_version_is_bounded_and_never_copies_markup() {
+        assert_eq!(sanitized_version("M7.6.8R2").as_deref(), Some("M7.6.8R2"));
+        assert_eq!(
+            sanitized_version("<script>private</script>").as_deref(),
+            Some("present_unknown")
+        );
+        assert_eq!(
+            sanitized_version(&"x".repeat(33)).as_deref(),
+            Some("present_unknown")
+        );
+    }
+
+    #[test]
+    fn only_bounded_xml_content_types_can_reach_the_classifier() {
+        use reqwest::header::HeaderValue;
+        for value in ["application/xml", "text/xml; charset=utf-8", "TEXT/XML"] {
+            let header = HeaderValue::from_str(value).unwrap();
+            assert!(supported_public_content_type(Some(&header)));
+        }
+        for value in ["text/html", "application/json", "text/xml-unsafe"] {
+            let header = HeaderValue::from_str(value).unwrap();
+            assert!(!supported_public_content_type(Some(&header)));
+        }
+        assert!(!supported_public_content_type(None));
+        let oversized = HeaderValue::from_str(&format!("text/xml;{}", "x".repeat(129))).unwrap();
+        assert!(!supported_public_content_type(Some(&oversized)));
+    }
+
+    #[test]
+    fn private_exception_and_unbounded_deadlines_fail_before_network_io() {
+        let connector = GatewayConnectorGeneration::from_resolved(
+            "custom-probe",
+            1,
+            1,
+            "https://gateway.example.test",
+            true,
+            vec!["10.0.0.1:443".parse().unwrap()],
+        )
+        .unwrap();
+        assert!(probe_public_gateway_with_connector(&connector, Duration::from_secs(5)).is_err());
+        let public = GatewayConnectorGeneration::from_resolved(
+            "custom-probe",
+            1,
+            1,
+            "https://gateway.example.test",
+            false,
+            vec!["8.8.8.8:443".parse().unwrap()],
+        )
+        .unwrap();
+        assert!(probe_public_gateway_with_connector(&public, Duration::ZERO).is_err());
+        assert!(probe_public_gateway_with_connector(&public, Duration::from_secs(16)).is_err());
+    }
+}

--- a/independent/src/lib.rs
+++ b/independent/src/lib.rs
@@ -7,6 +7,7 @@ pub mod engine;
 pub mod gateway_auth;
 pub mod gateway_connector;
 pub mod gateway_http;
+pub mod gateway_probe;
 pub mod modern;
 pub mod probe;
 pub mod protocol_map;

--- a/independent/tests/module_boundaries.rs
+++ b/independent/tests/module_boundaries.rs
@@ -146,6 +146,31 @@ fn production_modern_transport_consumes_the_authenticated_connector_generation()
 }
 
 #[test]
+fn public_gateway_probe_is_credential_free_fixed_and_non_promoting() {
+    let probe = source("src/gateway_probe.rs");
+    for forbidden in [
+        "crate::credentials",
+        "crate::gateway_auth",
+        "crate::engine::session",
+        "password_login",
+        "cookie_store(true)",
+        "Policy::limited",
+        "Policy::custom",
+    ] {
+        assert!(
+            !probe.contains(forbidden),
+            "public probe contains {forbidden}"
+        );
+    }
+    assert!(probe.contains("/por/login_auth.csp?apiversion=1"));
+    assert!(probe.contains("Policy::none()"));
+    assert!(probe.contains("cookie_store(false)"));
+    assert!(probe.contains("MAX_PUBLIC_PROBE_BODY_BYTES"));
+    assert!(probe.contains("PublicGatewayCompatibility::RecognizedCandidate"));
+    assert!(!probe.contains("AuthenticatedGatewaySession"));
+}
+
+#[test]
 fn credential_input_is_neutral_to_gateway_and_protocol_layers() {
     let credentials = source("src/credentials.rs");
     for forbidden in [


### PR DESCRIPTION
## Summary

- add a separate Rust public-Gateway probe with no credential input or authenticated session state
- reuse the public-only generation-bound connector, standard PKI/SNI, no environment proxy, no redirects and no Cookie persistence
- compile one fixed EasyConnect discovery path/parser with bounded XML content type, body and deadline
- return only normalized origin, HTTPS identity status, candidate/unsupported/unknown, compiled family, sanitized version and HTTP status
- add an exact CLI contract for later Main integration without enabling custom Profile creation or password entry yet

## Validation

- live credential-free HKUST public canary: recognized candidate, M7.6.8R2, HTTP 200
- Rust: 217 passed, 0 failed, 1 explicit performance benchmark ignored
- Engine lifecycle fixture: 100/100 rounds
- Clippy all targets/all features: 0 warnings
- module-boundary and tracked-secret gates: PASS

## Security boundary

This PR does not create a Profile, expose credentials, promote probe Cookies, infer L3/DNS/MFA support or allow Renderer state to authorize a Gateway. Main-owned expiring confirmation and isolated Profile/Account/Workspace creation remain separate P6 work.