### PR TITLE
2.0 P6b: add Main-owned custom Gateway confirmation

### DIFF
--- a/desktop/lib/custom-gateway-onboarding.js
+++ b/desktop/lib/custom-gateway-onboarding.js
@@ -1,0 +1,240 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const {
+  PROTOCOL_FAMILY,
+  normalizeGatewayOrigin,
+  validateAccountHandle,
+  validateProfileId,
+  validateSchoolProfileDocument,
+} = require('./school-profile-schema');
+
+const GATEWAY_CONFIRMATION_SCHEMA_VERSION = 1;
+const DEFAULT_CONFIRMATION_TTL_MS = 120_000;
+const MIN_CONFIRMATION_TTL_MS = 10_000;
+const MAX_CONFIRMATION_TTL_MS = 300_000;
+const MAX_SCHOOL_LABEL_LENGTH = 96;
+const MAX_REPORTED_VERSION_LENGTH = 32;
+
+function plainObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+  return value;
+}
+
+function exactKeys(value, keys, name) {
+  const source = plainObject(value, name);
+  const actual = Object.keys(source).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length ||
+      actual.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${name} has an invalid schema`);
+  }
+  return source;
+}
+
+function positive(value, name) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function boundedLabel(value, fallback) {
+  if (value == null || String(value).trim() === '') return fallback;
+  if (typeof value !== 'string') throw new TypeError('school label must be text');
+  const label = value.trim();
+  if (!label || label.length > MAX_SCHOOL_LABEL_LENGTH ||
+      /[\u0000-\u001f\u007f<>]/u.test(label)) {
+    throw new TypeError('school label has an invalid value');
+  }
+  return label;
+}
+
+function boundedVersion(value) {
+  if (value == null) return null;
+  if (typeof value !== 'string' || !value || value.length > MAX_REPORTED_VERSION_LENGTH ||
+      !/^[a-zA-Z0-9._-]+$/u.test(value)) {
+    throw new TypeError('reported version has an invalid value');
+  }
+  return value;
+}
+
+function activeContext(value) {
+  const source = exactKeys(value, [
+    'profileId', 'profileRevision', 'accountHandle', 'activeContextEpoch',
+  ], 'active context binding');
+  return Object.freeze({
+    profileId: validateProfileId(source.profileId),
+    profileRevision: positive(source.profileRevision, 'profileRevision'),
+    accountHandle: validateAccountHandle(source.accountHandle),
+    activeContextEpoch: positive(source.activeContextEpoch, 'activeContextEpoch'),
+  });
+}
+
+function sameContext(left, right) {
+  return left.profileId === right.profileId &&
+    left.profileRevision === right.profileRevision &&
+    left.accountHandle === right.accountHandle &&
+    left.activeContextEpoch === right.activeContextEpoch;
+}
+
+function entropyId(prefix, randomBytes) {
+  let entropy = randomBytes(16);
+  if (!Buffer.isBuffer(entropy) || entropy.length !== 16) {
+    entropy?.fill?.(0);
+    throw new TypeError('custom Gateway onboarding entropy is invalid');
+  }
+  try { return `${prefix}-${entropy.toString('hex')}`; }
+  finally { entropy.fill(0); entropy = null; }
+}
+
+function customProfileDocument({ profileId, origin, schoolLabel }) {
+  const gateway = normalizeGatewayOrigin(origin);
+  if (!String(profileId).startsWith('custom-')) {
+    throw new TypeError('custom Profile identity is invalid');
+  }
+  const label = boundedLabel(schoolLabel, gateway.hostname);
+  const shortName = label.length <= 40 ? label : gateway.hostname.slice(0, 40);
+  return validateSchoolProfileDocument({
+    schemaVersion: 1,
+    profileId,
+    profileRevision: 1,
+    profileCredentialBindingRevision: 1,
+    evidenceClass: 'custom-local',
+    branding: {
+      localizedSchoolName: { zh: label, en: label },
+      shortName,
+      bundledAssetKey: null,
+      theme: null,
+    },
+    gateway: {
+      origin: gateway.origin,
+      protocolFamily: PROTOCOL_FAMILY,
+      engineConfigRef: null,
+    },
+    browser: {
+      homeUrl: null,
+      campusDomains: [],
+      directPartnerDomains: [],
+      builtinResourcesRef: null,
+      healthTargets: [],
+    },
+    policy: {
+      reviewedPrivateGatewayAllowed: false,
+      reviewedDnsFallback: [],
+    },
+  });
+}
+
+function validatedProbe(value) {
+  const source = exactKeys(value, [
+    'schema_version', 'normalized_origin', 'https_identity_valid', 'compatibility',
+    'candidate_family', 'reported_version', 'http_status',
+  ], 'public Gateway probe result');
+  if (source.schema_version !== 1 || source.https_identity_valid !== true ||
+      source.compatibility !== 'recognized_candidate' ||
+      source.candidate_family !== PROTOCOL_FAMILY ||
+      !Number.isInteger(source.http_status) || source.http_status < 200 || source.http_status > 299) {
+    throw new TypeError('public Gateway probe did not establish a supported candidate');
+  }
+  const gateway = normalizeGatewayOrigin(source.normalized_origin);
+  return Object.freeze({
+    normalizedOrigin: gateway.origin,
+    candidateFamily: PROTOCOL_FAMILY,
+    reportedVersion: boundedVersion(source.reported_version),
+    httpStatus: source.http_status,
+  });
+}
+
+class CustomGatewayConfirmationOwner {
+  #record = null;
+
+  constructor({
+    randomBytes = crypto.randomBytes,
+    now = Date.now,
+    ttlMs = DEFAULT_CONFIRMATION_TTL_MS,
+  } = {}) {
+    if (typeof randomBytes !== 'function' || typeof now !== 'function' ||
+        !Number.isSafeInteger(ttlMs) || ttlMs < MIN_CONFIRMATION_TTL_MS ||
+        ttlMs > MAX_CONFIRMATION_TTL_MS) {
+      throw new TypeError('custom Gateway confirmation dependencies are invalid');
+    }
+    this.randomBytes = randomBytes;
+    this.now = now;
+    this.ttlMs = ttlMs;
+  }
+
+  issue({ probeResult, schoolLabel = '', activeContext: contextValue } = {}) {
+    const probe = validatedProbe(probeResult);
+    const context = activeContext(contextValue);
+    const draftProfileId = entropyId('custom', this.randomBytes);
+    const confirmationHandle = entropyId('confirmation', this.randomBytes);
+    const issuedAt = positive(this.now(), 'confirmation issuedAt');
+    const expiresAt = issuedAt + this.ttlMs;
+    if (!Number.isSafeInteger(expiresAt)) throw new TypeError('confirmation expiry is invalid');
+    const profile = customProfileDocument({
+      profileId: draftProfileId,
+      origin: probe.normalizedOrigin,
+      schoolLabel,
+    });
+    this.#record = Object.freeze({
+      confirmationHandle,
+      draftProfileId,
+      context,
+      probe,
+      profile,
+      issuedAt,
+      expiresAt,
+    });
+    return this.snapshot();
+  }
+
+  snapshot() {
+    if (!this.#record) return null;
+    if (this.now() >= this.#record.expiresAt) {
+      this.#record = null;
+      return null;
+    }
+    return Object.freeze({
+      schemaVersion: GATEWAY_CONFIRMATION_SCHEMA_VERSION,
+      confirmationHandle: this.#record.confirmationHandle,
+      normalizedOrigin: this.#record.probe.normalizedOrigin,
+      candidateFamily: this.#record.probe.candidateFamily,
+      reportedVersion: this.#record.probe.reportedVersion,
+      expiresAt: this.#record.expiresAt,
+      unverified: true,
+    });
+  }
+
+  consume({ confirmationHandle, activeContext: contextValue } = {}) {
+    const record = this.#record;
+    this.#record = null;
+    if (!record || typeof confirmationHandle !== 'string' ||
+        confirmationHandle !== record.confirmationHandle || this.now() >= record.expiresAt ||
+        !sameContext(activeContext(contextValue), record.context)) {
+      throw new Error('custom Gateway confirmation is unavailable or stale');
+    }
+    return Object.freeze({
+      draftProfileId: record.draftProfileId,
+      normalizedOrigin: record.probe.normalizedOrigin,
+      candidateFamily: record.probe.candidateFamily,
+      profile: record.profile,
+    });
+  }
+
+  invalidate() {
+    if (!this.#record) return false;
+    this.#record = null;
+    return true;
+  }
+}
+
+module.exports = {
+  CustomGatewayConfirmationOwner,
+  DEFAULT_CONFIRMATION_TTL_MS,
+  GATEWAY_CONFIRMATION_SCHEMA_VERSION,
+  customProfileDocument,
+};

--- a/desktop/test/custom-gateway-onboarding.test.js
+++ b/desktop/test/custom-gateway-onboarding.test.js
@@ -1,0 +1,147 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  CustomGatewayConfirmationOwner,
+  customProfileDocument,
+} = require('../lib/custom-gateway-onboarding');
+const { PROTOCOL_FAMILY } = require('../lib/school-profile-schema');
+
+function context(overrides = {}) {
+  return {
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    accountHandle: `account-${'a'.repeat(36)}`,
+    activeContextEpoch: 7,
+    ...overrides,
+  };
+}
+
+function probe(overrides = {}) {
+  return {
+    schema_version: 1,
+    normalized_origin: 'https://vpn.example.edu',
+    https_identity_valid: true,
+    compatibility: 'recognized_candidate',
+    candidate_family: PROTOCOL_FAMILY,
+    reported_version: 'M7.6.8R2',
+    http_status: 200,
+    ...overrides,
+  };
+}
+
+function fixture() {
+  let clock = 1_800_000_000_000;
+  let counter = 0;
+  const owner = new CustomGatewayConfirmationOwner({
+    now: () => clock,
+    ttlMs: 10_000,
+    randomBytes: (length) => Buffer.alloc(length, ++counter),
+  });
+  return { owner, advance: (value) => { clock += value; } };
+}
+
+test('one-use confirmation produces one minimal isolated custom Profile', () => {
+  const f = fixture();
+  const view = f.owner.issue({
+    probeResult: probe(),
+    schoolLabel: 'Example University',
+    activeContext: context(),
+  });
+  assert.equal(view.normalizedOrigin, 'https://vpn.example.edu');
+  assert.equal(view.candidateFamily, PROTOCOL_FAMILY);
+  assert.equal(view.unverified, true);
+  assert.equal('draftProfileId' in view, false);
+  assert.equal('activeContext' in view, false);
+
+  const consumed = f.owner.consume({
+    confirmationHandle: view.confirmationHandle,
+    activeContext: context(),
+  });
+  assert.match(consumed.draftProfileId, /^custom-[a-f0-9]{32}$/u);
+  assert.equal(consumed.profile.evidenceClass, 'custom-local');
+  assert.equal(consumed.profile.gateway.origin.origin, 'https://vpn.example.edu');
+  assert.equal(consumed.profile.gateway.engineConfigRef, null);
+  assert.deepEqual(consumed.profile.browser.campusDomains, []);
+  assert.deepEqual(consumed.profile.browser.healthTargets, []);
+  assert.deepEqual(consumed.profile.policy.reviewedDnsFallback, []);
+  assert.equal(consumed.profile.policy.reviewedPrivateGatewayAllowed, false);
+  assert.equal(f.owner.snapshot(), null);
+  assert.throws(() => f.owner.consume({
+    confirmationHandle: view.confirmationHandle,
+    activeContext: context(),
+  }), /unavailable or stale/u);
+});
+
+test('expiry context drift wrong handles and new probes invalidate authorization', () => {
+  for (const mutate of [
+    (f, view) => ({ confirmationHandle: `${view.confirmationHandle}-wrong`, activeContext: context() }),
+    (_f, view) => ({ confirmationHandle: view.confirmationHandle,
+      activeContext: context({ activeContextEpoch: 8 }) }),
+    (f, view) => { f.advance(10_000); return {
+      confirmationHandle: view.confirmationHandle, activeContext: context(),
+    }; },
+  ]) {
+    const f = fixture();
+    const view = f.owner.issue({ probeResult: probe(), activeContext: context() });
+    assert.throws(() => f.owner.consume(mutate(f, view)), /unavailable or stale/u);
+    assert.equal(f.owner.snapshot(), null);
+  }
+
+  const f = fixture();
+  const first = f.owner.issue({ probeResult: probe(), activeContext: context() });
+  const second = f.owner.issue({ probeResult: probe({
+    normalized_origin: 'https://other.example.edu',
+  }), activeContext: context() });
+  assert.throws(() => f.owner.consume({
+    confirmationHandle: first.confirmationHandle,
+    activeContext: context(),
+  }), /unavailable or stale/u);
+  assert.equal(second.normalizedOrigin, 'https://other.example.edu');
+});
+
+test('only an exact recognized probe can issue a confirmation', () => {
+  for (const invalid of [
+    probe({ https_identity_valid: false }),
+    probe({ compatibility: 'unknown', candidate_family: null }),
+    probe({ candidate_family: 'atrust' }),
+    probe({ normalized_origin: 'http://vpn.example.edu' }),
+    probe({ http_status: 302 }),
+    { ...probe(), rawBody: '<private>' },
+  ]) {
+    assert.throws(() => fixture().owner.issue({
+      probeResult: invalid,
+      activeContext: context(),
+    }));
+  }
+});
+
+test('custom Profile identity and policy never derive authority from the label', () => {
+  const profile = customProfileDocument({
+    profileId: `custom-${'1'.repeat(32)}`,
+    origin: 'https://VPN.Example.EDU.:443/',
+    schoolLabel: '',
+  });
+  assert.equal(profile.gateway.origin.origin, 'https://vpn.example.edu');
+  assert.equal(profile.branding.localizedSchoolName.zh, 'vpn.example.edu');
+  assert.throws(() => customProfileDocument({
+    profileId: `custom-${'2'.repeat(32)}`,
+    origin: 'https://vpn.example.edu',
+    schoolLabel: '<b>Official University</b>',
+  }), /school label/u);
+  assert.throws(() => customProfileDocument({
+    profileId: 'label-derived-profile',
+    origin: 'https://vpn.example.edu',
+    schoolLabel: 'Label',
+  }), /custom Profile identity/u);
+});
+
+test('renderer-visible confirmation contains no persistent key or probe internals', () => {
+  const view = fixture().owner.issue({ probeResult: probe(), activeContext: context() });
+  const encoded = JSON.stringify(view);
+  for (const forbidden of [
+    'profileKey', 'accountKey', 'workspaceKey', 'accountHandle', 'activeContextEpoch',
+    'TwfID', 'cookie', 'token', 'rawBody',
+  ]) assert.equal(encoded.includes(forbidden), false, forbidden);
+});


### PR DESCRIPTION
## Summary

- add one-use, expiring Main-owned authorization for a recognized custom Gateway probe
- bind authorization to exact normalized origin, compiled family, opaque draft Profile identity and current profile/account/epoch
- invalidate on expiry, replay, wrong handle, context drift or a newer probe
- create only a minimal `custom-local` SchoolProfile after successful consumption, with no reviewed assets, routes, DNS fallback, health targets or private-Gateway exception
- expose only a bounded unverified confirmation view to Renderer-facing code

## Validation

- Desktop: 805 passed, 0 failed, 1 explicit Windows-only skip
- architecture gate: PASS (0 cycles, unchanged Main dependency/line caps)
- tracked secret gate and syntax checks: PASS

## Boundary

This slice does not persist or activate the Profile, create an account/workspace, expose password fields or wire IPC. Those operations must consume this exact confirmation inside the later crash-recoverable Profile switch transaction.