### PR TITLE
2.0 P6c/P6d: provision isolated custom Profiles recoverably

### DIFF
--- a/desktop/lib/custom-gateway-onboarding.js
+++ b/desktop/lib/custom-gateway-onboarding.js
@@ -35,6 +35,13 @@ function exactKeys(value, keys, name) {
   return source;
 }
 
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}
+
 function positive(value, name) {
   if (!Number.isSafeInteger(value) || value <= 0) {
     throw new TypeError(`${name} must be a positive safe integer`);
@@ -98,7 +105,7 @@ function customProfileDocument({ profileId, origin, schoolLabel }) {
   }
   const label = boundedLabel(schoolLabel, gateway.hostname);
   const shortName = label.length <= 40 ? label : gateway.hostname.slice(0, 40);
-  return validateSchoolProfileDocument({
+  const document = {
     schemaVersion: 1,
     profileId,
     profileRevision: 1,
@@ -126,7 +133,9 @@ function customProfileDocument({ profileId, origin, schoolLabel }) {
       reviewedPrivateGatewayAllowed: false,
       reviewedDnsFallback: [],
     },
-  });
+  };
+  validateSchoolProfileDocument(document);
+  return deepFreeze(document);
 }
 
 function validatedProbe(value) {
@@ -175,16 +184,18 @@ class CustomGatewayConfirmationOwner {
     const issuedAt = positive(this.now(), 'confirmation issuedAt');
     const expiresAt = issuedAt + this.ttlMs;
     if (!Number.isSafeInteger(expiresAt)) throw new TypeError('confirmation expiry is invalid');
-    const profile = customProfileDocument({
+    const profileDocument = customProfileDocument({
       profileId: draftProfileId,
       origin: probe.normalizedOrigin,
       schoolLabel,
     });
+    const profile = validateSchoolProfileDocument(profileDocument);
     this.#record = Object.freeze({
       confirmationHandle,
       draftProfileId,
       context,
       probe,
+      profileDocument,
       profile,
       issuedAt,
       expiresAt,
@@ -221,6 +232,7 @@ class CustomGatewayConfirmationOwner {
       draftProfileId: record.draftProfileId,
       normalizedOrigin: record.probe.normalizedOrigin,
       candidateFamily: record.probe.candidateFamily,
+      profileDocument: record.profileDocument,
       profile: record.profile,
     });
   }

--- a/desktop/lib/custom-profile-index.js
+++ b/desktop/lib/custom-profile-index.js
@@ -1,0 +1,218 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { atomicWritePrivateFile } = require('./credential-store');
+const { ensurePrivateDirectoryChain } = require('./private-directory');
+const { readPrivateFileBounded } = require('./private-file');
+const { validateOpaqueKey, validateProfileId } = require('./school-profile-schema');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+const CUSTOM_PROFILE_INDEX_VERSION = 1;
+const MAX_CUSTOM_PROFILE_INDEX_BYTES = 256 * 1024;
+const MAX_CUSTOM_PROFILES = 15;
+
+function receipt(data) {
+  if (data === null) return Object.freeze({ present: false, bytes: 0, sha256: null });
+  return Object.freeze({
+    present: true,
+    bytes: data.length,
+    sha256: crypto.createHash('sha256').update(data).digest('hex'),
+  });
+}
+
+function sameReceipt(left, right) {
+  return Boolean(left && right && left.present === right.present && left.bytes === right.bytes &&
+    left.sha256 === right.sha256);
+}
+
+function entry(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype ||
+      JSON.stringify(Object.keys(value).sort()) !==
+        JSON.stringify(['createdAt', 'profileId', 'profileKey'].sort())) {
+    throw new TypeError('custom Profile index entry has an invalid schema');
+  }
+  const profileId = validateProfileId(value.profileId);
+  if (!profileId.startsWith('custom-') || !Number.isSafeInteger(value.createdAt) ||
+      value.createdAt <= 0) {
+    throw new TypeError('custom Profile index entry has an invalid value');
+  }
+  return Object.freeze({
+    profileId,
+    profileKey: validateOpaqueKey(value.profileKey, 'custom Profile index profileKey'),
+    createdAt: value.createdAt,
+  });
+}
+
+function document(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype ||
+      JSON.stringify(Object.keys(value).sort()) !== JSON.stringify(['entries', 'schemaVersion']) ||
+      value.schemaVersion !== CUSTOM_PROFILE_INDEX_VERSION || !Array.isArray(value.entries) ||
+      value.entries.length > MAX_CUSTOM_PROFILES) {
+    throw new TypeError('custom Profile index has an invalid schema');
+  }
+  const entries = value.entries.map(entry);
+  if (new Set(entries.map((value) => value.profileId)).size !== entries.length ||
+      new Set(entries.map((value) => value.profileKey)).size !== entries.length) {
+    throw new TypeError('custom Profile index contains duplicate authority');
+  }
+  return Object.freeze({ schemaVersion: CUSTOM_PROFILE_INDEX_VERSION, entries: Object.freeze(entries) });
+}
+
+function serialize(value) {
+  const data = Buffer.from(`${JSON.stringify(document(value))}\n`, 'utf8');
+  if (data.length > MAX_CUSTOM_PROFILE_INDEX_BYTES) {
+    data.fill(0);
+    throw new TypeError('custom Profile index exceeds its storage bound');
+  }
+  return data;
+}
+
+function append(current, nextEntry) {
+  const normalized = document(current);
+  const next = entry(nextEntry);
+  if (normalized.entries.some((value) => value.profileId === next.profileId ||
+      value.profileKey === next.profileKey) || normalized.entries.length >= MAX_CUSTOM_PROFILES) {
+    throw new Error('custom Profile index cannot add this Profile');
+  }
+  return document({
+    schemaVersion: CUSTOM_PROFILE_INDEX_VERSION,
+    entries: [...normalized.entries, next].sort((left, right) => (
+      left.createdAt - right.createdAt || left.profileId.localeCompare(right.profileId)
+    )),
+  });
+}
+
+class CustomProfileIndexStore {
+  constructor({
+    userData,
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+  } = {}) {
+    if (typeof userData !== 'string' || !path.isAbsolute(userData) || path.resolve(userData) !== userData ||
+        !fileSystem || typeof fileSystem.openSync !== 'function' ||
+        !['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' && (typeof windowsAcl?.protect !== 'function' ||
+          typeof windowsAcl?.verify !== 'function'))) {
+      throw new TypeError('custom Profile index dependencies are invalid');
+    }
+    this.userData = userData;
+    this.filePath = path.join(userData, 'global', 'custom-profile-index.json');
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+  }
+
+  read() {
+    const current = this.#readCurrent();
+    try { return current.document; }
+    finally { current.data?.fill(0); }
+  }
+
+  planAdd(value) {
+    const current = this.#readCurrent();
+    let after = null;
+    try {
+      const indexEntry = entry(value);
+      const next = append(current.document, indexEntry);
+      after = serialize(next);
+      return Object.freeze({
+        entry: indexEntry,
+        before: receipt(current.data),
+        after: receipt(after),
+      });
+    } finally {
+      current.data?.fill(0);
+      after?.fill(0);
+    }
+  }
+
+  applyAdd(value, transition) {
+    const indexEntry = entry(value);
+    const current = this.#readCurrent();
+    let after = null;
+    try {
+      const observed = receipt(current.data);
+      if (sameReceipt(observed, transition.after)) {
+        return current.document.entries.some((candidate) => (
+          candidate.profileId === indexEntry.profileId && candidate.profileKey === indexEntry.profileKey
+        ));
+      }
+      if (!sameReceipt(observed, transition.before)) {
+        throw new Error('custom Profile index changed during provisioning');
+      }
+      after = serialize(append(current.document, indexEntry));
+      if (!sameReceipt(receipt(after), transition.after)) {
+        throw new Error('custom Profile index transition drifted');
+      }
+      ensurePrivateDirectoryChain(this.userData, path.dirname(this.filePath), {
+        fileSystem: this.fileSystem,
+        platform: this.platform,
+      });
+      const options = this.platform === 'win32' ? {
+        protectTemporary: (file) => this.windowsAcl.protect(file) === true,
+        verifyCommitted: (file) => this.windowsAcl.verify(file) === true,
+        removeCommittedOnFailure: true,
+      } : {};
+      if (!atomicWritePrivateFile(this.filePath, after, this.fileSystem, options)) {
+        throw new Error('custom Profile index write failed');
+      }
+      const verified = this.#readCurrent();
+      try { return sameReceipt(receipt(verified.data), transition.after); }
+      finally { verified.data?.fill(0); }
+    } finally {
+      current.data?.fill(0);
+      after?.fill(0);
+    }
+  }
+
+  receipt() {
+    const current = this.#readCurrent();
+    try { return receipt(current.data); }
+    finally { current.data?.fill(0); }
+  }
+
+  #readCurrent() {
+    try { this.fileSystem.lstatSync(this.filePath); }
+    catch (error) {
+      if (error?.code === 'ENOENT') {
+        return { data: null, document: document({ schemaVersion: 1, entries: [] }) };
+      }
+      throw error;
+    }
+    if (this.platform === 'win32' && !this.windowsAcl.verify(this.filePath)) {
+      throw new Error('custom Profile index ACL is invalid');
+    }
+    const { data } = readPrivateFileBounded(this.filePath, {
+      maxBytes: MAX_CUSTOM_PROFILE_INDEX_BYTES,
+      minBytes: 2,
+      platform: this.platform,
+      fileSystem: this.fileSystem,
+    });
+    try {
+      return { data, document: document(JSON.parse(data.toString('utf8'))) };
+    } catch (error) {
+      data.fill(0);
+      throw new Error('custom Profile index is invalid', { cause: error });
+    }
+  }
+}
+
+module.exports = {
+  CUSTOM_PROFILE_INDEX_VERSION,
+  CustomProfileIndexStore,
+  MAX_CUSTOM_PROFILES,
+  customProfileIndexReceipt: receipt,
+  sameCustomProfileIndexReceipt: sameReceipt,
+  validateCustomProfileIndexDocument: document,
+};

--- a/desktop/lib/custom-profile-materializer.js
+++ b/desktop/lib/custom-profile-materializer.js
@@ -1,0 +1,175 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { atomicWritePrivateFile } = require('./credential-store');
+const {
+  CUSTOM_PROFILE_FILE_IDS,
+  CUSTOM_PROFILE_PROVISIONING_VERSION,
+} = require('./custom-profile-provisioning-plan');
+const { ensurePrivateDirectoryChain } = require('./private-directory');
+const { readPrivateFileBounded } = require('./private-file');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+const MAX_CUSTOM_PROFILE_FILE_BYTES = 512 * 1024;
+
+function receipt(data) {
+  if (data === null) return Object.freeze({ present: false, bytes: 0, sha256: null });
+  if (!Buffer.isBuffer(data) || data.length < 2 || data.length > MAX_CUSTOM_PROFILE_FILE_BYTES) {
+    throw new TypeError('custom Profile file has an invalid size');
+  }
+  return Object.freeze({
+    present: true,
+    bytes: data.length,
+    sha256: crypto.createHash('sha256').update(data).digest('hex'),
+  });
+}
+
+function sameReceipt(left, right) {
+  return Boolean(left && right && left.present === right.present && left.bytes === right.bytes &&
+    left.sha256 === right.sha256);
+}
+
+function exactPlan(plan) {
+  if (!plan || plan.schemaVersion !== CUSTOM_PROFILE_PROVISIONING_VERSION ||
+      !plan.layout || !plan.paths || !plan.files ||
+      CUSTOM_PROFILE_FILE_IDS.some((id) => typeof plan.paths[id] !== 'string' ||
+        !Buffer.isBuffer(plan.files[id])) ||
+      Object.keys(plan.paths).length !== CUSTOM_PROFILE_FILE_IDS.length ||
+      Object.keys(plan.files).length !== CUSTOM_PROFILE_FILE_IDS.length) {
+    throw new TypeError('custom Profile materialization plan is invalid');
+  }
+  const root = plan.layout.root;
+  if (typeof root !== 'string' || !path.isAbsolute(root) || path.resolve(root) !== root ||
+      new Set(Object.values(plan.paths)).size !== CUSTOM_PROFILE_FILE_IDS.length ||
+      Object.values(plan.paths).some((file) => {
+        if (!path.isAbsolute(file) || path.resolve(file) !== file) return true;
+        const relative = path.relative(root, file);
+        return !relative || relative === '..' || relative.startsWith(`..${path.sep}`) ||
+          path.isAbsolute(relative);
+      })) {
+    throw new TypeError('custom Profile materialization paths are invalid');
+  }
+  return plan;
+}
+
+class CustomProfileMaterializer {
+  constructor({
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+  } = {}) {
+    if (!fileSystem || typeof fileSystem.openSync !== 'function' ||
+        !['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' && (typeof windowsAcl?.protect !== 'function' ||
+          typeof windowsAcl?.verify !== 'function'))) {
+      throw new TypeError('custom Profile materializer dependencies are invalid');
+    }
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+  }
+
+  expected(planValue) {
+    const plan = exactPlan(planValue);
+    return Object.freeze(Object.fromEntries(CUSTOM_PROFILE_FILE_IDS.map((id) => (
+      [id, receipt(plan.files[id])]
+    ))));
+  }
+
+  observe(planValue) {
+    const plan = exactPlan(planValue);
+    return Object.freeze(Object.fromEntries(CUSTOM_PROFILE_FILE_IDS.map((id) => (
+      [id, this.#fileReceipt(plan.paths[id])]
+    ))));
+  }
+
+  verify(planValue, expectedValue) {
+    const expected = this.#expected(expectedValue);
+    const observed = this.observe(planValue);
+    return CUSTOM_PROFILE_FILE_IDS.every((id) => sameReceipt(observed[id], expected[id]));
+  }
+
+  materialize(planValue, expectedValue) {
+    const plan = exactPlan(planValue);
+    const expected = this.#expected(expectedValue);
+    const calculated = this.expected(plan);
+    if (CUSTOM_PROFILE_FILE_IDS.some((id) => !sameReceipt(expected[id], calculated[id]))) {
+      throw new Error('custom Profile materialization receipt plan drifted');
+    }
+
+    const before = this.observe(plan);
+    for (const id of CUSTOM_PROFILE_FILE_IDS) {
+      if (before[id].present && !sameReceipt(before[id], expected[id])) {
+        throw new Error(`custom Profile destination conflict: ${id}`);
+      }
+    }
+    for (const directory of new Set(Object.values(plan.paths).map(path.dirname))) {
+      ensurePrivateDirectoryChain(plan.layout.root, directory, {
+        fileSystem: this.fileSystem,
+        platform: this.platform,
+      });
+    }
+    const options = this.platform === 'win32' ? {
+      protectTemporary: (file) => this.windowsAcl.protect(file) === true,
+      verifyCommitted: (file) => this.windowsAcl.verify(file) === true,
+      removeCommittedOnFailure: true,
+    } : {};
+    for (const id of CUSTOM_PROFILE_FILE_IDS) {
+      if (before[id].present) continue;
+      if (!atomicWritePrivateFile(plan.paths[id], plan.files[id], this.fileSystem, options) &&
+          !sameReceipt(this.#fileReceipt(plan.paths[id]), expected[id])) {
+        throw new Error(`custom Profile destination write failed: ${id}`);
+      }
+    }
+    if (!this.verify(plan, expected)) {
+      throw new Error('custom Profile destination verification failed');
+    }
+    return true;
+  }
+
+  #expected(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value) ||
+        Object.keys(value).length !== CUSTOM_PROFILE_FILE_IDS.length ||
+        CUSTOM_PROFILE_FILE_IDS.some((id) => !Object.hasOwn(value, id) ||
+          value[id]?.present !== true || !Number.isSafeInteger(value[id].bytes) ||
+          value[id].bytes < 2 || value[id].bytes > MAX_CUSTOM_PROFILE_FILE_BYTES ||
+          !/^[a-f0-9]{64}$/u.test(value[id].sha256))) {
+      throw new TypeError('custom Profile expected receipts are invalid');
+    }
+    return value;
+  }
+
+  #fileReceipt(file) {
+    try { this.fileSystem.lstatSync(file); }
+    catch (error) {
+      if (error?.code === 'ENOENT') return receipt(null);
+      throw error;
+    }
+    if (this.platform === 'win32' && !this.windowsAcl.verify(file)) {
+      throw new Error('custom Profile destination ACL is invalid');
+    }
+    const { data } = readPrivateFileBounded(file, {
+      maxBytes: MAX_CUSTOM_PROFILE_FILE_BYTES,
+      minBytes: 2,
+      platform: this.platform,
+      fileSystem: this.fileSystem,
+    });
+    try { return receipt(data); }
+    finally { data.fill(0); }
+  }
+}
+
+module.exports = {
+  CustomProfileMaterializer,
+  MAX_CUSTOM_PROFILE_FILE_BYTES,
+  customProfileFileReceipt: receipt,
+  sameCustomProfileFileReceipt: sameReceipt,
+};

--- a/desktop/lib/custom-profile-provisioning-journal.js
+++ b/desktop/lib/custom-profile-provisioning-journal.js
@@ -1,0 +1,214 @@
+'use strict';
+
+const {
+  CUSTOM_PROFILE_FILE_IDS,
+} = require('./custom-profile-provisioning-plan');
+const {
+  validateOpaqueKey,
+  validateProfileId,
+  validateSchoolProfileDocument,
+} = require('./school-profile-schema');
+
+const CUSTOM_PROFILE_PROVISIONING_JOURNAL_VERSION = 1;
+const CUSTOM_PROFILE_PROVISIONING_TYPE = 'custom_profile_provisioning';
+const STATES = Object.freeze(['prepared', 'materialized', 'indexed']);
+const SHA256 = /^[a-f0-9]{64}$/u;
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}
+
+function plainObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+  return value;
+}
+
+function exactKeys(value, keys, name) {
+  const source = plainObject(value, name);
+  const actual = Object.keys(source).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${name} has an invalid schema`);
+  }
+  return source;
+}
+
+function positive(value, name) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function optionalTimestamp(value, name) {
+  return value === null ? null : positive(value, name);
+}
+
+function presentReceipt(value, name) {
+  const source = exactKeys(value, ['present', 'bytes', 'sha256'], name);
+  if (source.present !== true || !Number.isSafeInteger(source.bytes) || source.bytes < 2 ||
+      source.bytes > 512 * 1024 || typeof source.sha256 !== 'string' || !SHA256.test(source.sha256)) {
+    throw new TypeError(`${name} is invalid`);
+  }
+  return Object.freeze({ present: true, bytes: source.bytes, sha256: source.sha256 });
+}
+
+function maybeReceipt(value, name) {
+  const source = exactKeys(value, ['present', 'bytes', 'sha256'], name);
+  if (source.present === false && source.bytes === 0 && source.sha256 === null) {
+    return Object.freeze({ present: false, bytes: 0, sha256: null });
+  }
+  return presentReceipt(source, name);
+}
+
+function identity(value) {
+  const source = exactKeys(value, [
+    'provisioningId', 'profileId', 'profileKey', 'accountKey', 'workspaceKey',
+  ], 'custom Profile provisioning identity');
+  const profileId = validateProfileId(source.profileId);
+  if (!profileId.startsWith('custom-')) {
+    throw new TypeError('custom Profile provisioning profileId is invalid');
+  }
+  const result = {
+    provisioningId: validateOpaqueKey(source.provisioningId, 'provisioningId'),
+    profileId,
+    profileKey: validateOpaqueKey(source.profileKey, 'profileKey'),
+    accountKey: validateOpaqueKey(source.accountKey, 'accountKey'),
+    workspaceKey: validateOpaqueKey(source.workspaceKey, 'workspaceKey'),
+  };
+  if (new Set([
+    result.provisioningId, result.profileKey, result.accountKey, result.workspaceKey,
+  ]).size !== 4) {
+    throw new TypeError('custom Profile provisioning keys must be distinct');
+  }
+  return Object.freeze(result);
+}
+
+function fileReceipts(value) {
+  const source = exactKeys(value, CUSTOM_PROFILE_FILE_IDS, 'custom Profile file receipts');
+  return Object.freeze(Object.fromEntries(CUSTOM_PROFILE_FILE_IDS.map((id) => (
+    [id, presentReceipt(source[id], `custom Profile file receipt ${id}`)]
+  ))));
+}
+
+function indexTransition(value) {
+  const source = exactKeys(value, ['entry', 'before', 'after'], 'custom Profile index transition');
+  const indexEntry = exactKeys(source.entry, ['profileId', 'profileKey', 'createdAt'],
+    'custom Profile index entry');
+  const profileId = validateProfileId(indexEntry.profileId);
+  if (!profileId.startsWith('custom-')) throw new TypeError('custom Profile index identity is invalid');
+  return Object.freeze({
+    entry: Object.freeze({
+      profileId,
+      profileKey: validateOpaqueKey(indexEntry.profileKey, 'custom Profile index profileKey'),
+      createdAt: positive(indexEntry.createdAt, 'custom Profile index createdAt'),
+    }),
+    before: maybeReceipt(source.before, 'custom Profile index before receipt'),
+    after: presentReceipt(source.after, 'custom Profile index after receipt'),
+  });
+}
+
+function validateCustomProfileProvisioningJournal(value) {
+  const source = exactKeys(value, [
+    'schemaVersion', 'type', 'state', 'identity', 'profileDocument', 'createdAt',
+    'fileReceipts', 'indexTransition', 'materializedAt', 'indexedAt',
+  ], 'custom Profile provisioning journal');
+  if (source.schemaVersion !== CUSTOM_PROFILE_PROVISIONING_JOURNAL_VERSION ||
+      source.type !== CUSTOM_PROFILE_PROVISIONING_TYPE || !STATES.includes(source.state)) {
+    throw new TypeError('custom Profile provisioning journal version or state is unsupported');
+  }
+  const boundIdentity = identity(source.identity);
+  const profileDocument = JSON.parse(JSON.stringify(plainObject(
+    source.profileDocument,
+    'custom Profile source document',
+  )));
+  const profile = validateSchoolProfileDocument(profileDocument);
+  if (profile.evidenceClass !== 'custom-local' || profile.profileId !== boundIdentity.profileId) {
+    throw new TypeError('custom Profile provisioning document identity does not match');
+  }
+  const createdAt = positive(source.createdAt, 'custom Profile provisioning createdAt');
+  const transition = indexTransition(source.indexTransition);
+  if (transition.entry.profileId !== boundIdentity.profileId ||
+      transition.entry.profileKey !== boundIdentity.profileKey ||
+      transition.entry.createdAt !== createdAt) {
+    throw new TypeError('custom Profile index transition does not match provisioning authority');
+  }
+  const materializedAt = optionalTimestamp(source.materializedAt, 'materializedAt');
+  const indexedAt = optionalTimestamp(source.indexedAt, 'indexedAt');
+  if (source.state === 'prepared' && (materializedAt !== null || indexedAt !== null) ||
+      source.state === 'materialized' && (materializedAt === null || indexedAt !== null) ||
+      source.state === 'indexed' && (materializedAt === null || indexedAt === null) ||
+      materializedAt !== null && materializedAt < createdAt ||
+      indexedAt !== null && indexedAt < materializedAt) {
+    throw new TypeError('custom Profile provisioning timestamps are inconsistent');
+  }
+  return deepFreeze({
+    schemaVersion: CUSTOM_PROFILE_PROVISIONING_JOURNAL_VERSION,
+    type: CUSTOM_PROFILE_PROVISIONING_TYPE,
+    state: source.state,
+    identity: boundIdentity,
+    profileDocument,
+    createdAt,
+    fileReceipts: fileReceipts(source.fileReceipts),
+    indexTransition: transition,
+    materializedAt,
+    indexedAt,
+  });
+}
+
+function createPreparedCustomProfileProvisioning({ plan, fileReceipts: receipts, indexTransition: transition } = {}) {
+  if (!plan || !plan.identity || !plan.profileDocument) {
+    throw new TypeError('custom Profile provisioning plan is unavailable');
+  }
+  return validateCustomProfileProvisioningJournal({
+    schemaVersion: CUSTOM_PROFILE_PROVISIONING_JOURNAL_VERSION,
+    type: CUSTOM_PROFILE_PROVISIONING_TYPE,
+    state: 'prepared',
+    identity: plan.identity,
+    profileDocument: plan.profileDocument,
+    createdAt: plan.createdAt,
+    fileReceipts: receipts,
+    indexTransition: transition,
+    materializedAt: null,
+    indexedAt: null,
+  });
+}
+
+function markCustomProfileMaterialized(value, { now = Date.now } = {}) {
+  const current = validateCustomProfileProvisioningJournal(value);
+  if (current.state !== 'prepared' || typeof now !== 'function') {
+    throw new TypeError('only prepared custom Profile provisioning can materialize');
+  }
+  return validateCustomProfileProvisioningJournal({
+    ...current,
+    state: 'materialized',
+    materializedAt: now(),
+  });
+}
+
+function markCustomProfileIndexed(value, { now = Date.now } = {}) {
+  const current = validateCustomProfileProvisioningJournal(value);
+  if (current.state !== 'materialized' || typeof now !== 'function') {
+    throw new TypeError('only materialized custom Profile provisioning can index');
+  }
+  return validateCustomProfileProvisioningJournal({
+    ...current,
+    state: 'indexed',
+    indexedAt: now(),
+  });
+}
+
+module.exports = {
+  CUSTOM_PROFILE_PROVISIONING_JOURNAL_VERSION,
+  CUSTOM_PROFILE_PROVISIONING_TYPE,
+  createPreparedCustomProfileProvisioning,
+  markCustomProfileIndexed,
+  markCustomProfileMaterialized,
+  validateCustomProfileProvisioningJournal,
+};

--- a/desktop/lib/custom-profile-provisioning-plan.js
+++ b/desktop/lib/custom-profile-provisioning-plan.js
@@ -1,0 +1,201 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const {
+  validateLocalResourcesDocument,
+  validateProfileSettingsDocument,
+  validateProfileStateDocument,
+  validateWorkspaceSettingsDocument,
+} = require('./profile-workspace-documents');
+const {
+  createProfileAccountWorkspaceLayout,
+} = require('./profile-workspace-layout');
+const {
+  PROTOCOL_FAMILY,
+  validateCampusAccountDocument,
+  validateProfileId,
+  validateSchoolProfileDocument,
+  validateWorkspaceScopeDocument,
+} = require('./school-profile-schema');
+
+const CUSTOM_PROFILE_PROVISIONING_VERSION = 1;
+
+function plainObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+  return value;
+}
+
+function exactKeys(value, keys, name) {
+  const source = plainObject(value, name);
+  const actual = Object.keys(source).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length ||
+      actual.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${name} has an invalid schema`);
+  }
+  return source;
+}
+
+function timestamp(value) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError('custom Profile provisioning timestamp is invalid');
+  }
+  return value;
+}
+
+function entropyKey(prefix, randomBytes) {
+  let entropy = randomBytes(16);
+  if (!Buffer.isBuffer(entropy) || entropy.length !== 16) {
+    entropy?.fill?.(0);
+    throw new TypeError('custom Profile provisioning entropy is invalid');
+  }
+  try { return `${prefix}-${entropy.toString('hex')}`; }
+  finally { entropy.fill(0); entropy = null; }
+}
+
+function jsonBuffer(value) {
+  return Buffer.from(`${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function createCustomProfileProvisioningIdentity({ profileId, randomBytes = crypto.randomBytes } = {}) {
+  const id = validateProfileId(profileId);
+  if (!id.startsWith('custom-') || typeof randomBytes !== 'function') {
+    throw new TypeError('custom Profile provisioning identity is invalid');
+  }
+  return Object.freeze({
+    provisioningId: entropyKey('provision', randomBytes),
+    profileId: id,
+    profileKey: entropyKey('profile', randomBytes),
+    accountKey: entropyKey('account', randomBytes),
+    workspaceKey: entropyKey('workspace', randomBytes),
+  });
+}
+
+function createCustomProfileProvisioningPlan({
+  userData,
+  confirmation,
+  identity,
+  now = Date.now,
+} = {}) {
+  if (typeof now !== 'function') throw new TypeError('custom Profile provisioning clock is invalid');
+  const consumed = exactKeys(confirmation, [
+    'draftProfileId', 'normalizedOrigin', 'candidateFamily', 'profileDocument', 'profile',
+  ], 'consumed Gateway confirmation');
+  const keys = exactKeys(identity, [
+    'provisioningId', 'profileId', 'profileKey', 'accountKey', 'workspaceKey',
+  ], 'custom Profile provisioning identity');
+  const profile = validateSchoolProfileDocument(consumed.profileDocument);
+  if (profile.evidenceClass !== 'custom-local' || profile.profileId !== consumed.draftProfileId ||
+      profile.profileId !== keys.profileId || profile.gateway.origin.origin !== consumed.normalizedOrigin ||
+      profile.gateway.protocolFamily !== consumed.candidateFamily ||
+      consumed.candidateFamily !== PROTOCOL_FAMILY ||
+      JSON.stringify(profile) !== JSON.stringify(consumed.profile)) {
+    throw new TypeError('consumed Gateway confirmation does not match its custom Profile');
+  }
+  const createdAt = timestamp(now());
+  const accountDocument = validateCampusAccountDocument({
+    schemaVersion: 1,
+    accountKey: keys.accountKey,
+    accountRevision: 1,
+    accountCredentialRevision: 1,
+    role: 'primary',
+    state: 'enabled',
+    profileId: profile.profileId,
+    profileRevision: profile.profileRevision,
+    gatewayOrigin: profile.gateway.origin.origin,
+    protocolFamily: profile.gateway.protocolFamily,
+    workspaceKey: keys.workspaceKey,
+    activeCredentialVersion: null,
+    createdAt,
+    updatedAt: createdAt,
+  });
+  const workspaceDocument = validateWorkspaceScopeDocument({
+    schemaVersion: 1,
+    profileId: profile.profileId,
+    profileRevision: profile.profileRevision,
+    accountKey: keys.accountKey,
+    accountRevision: accountDocument.accountRevision,
+    workspaceKey: keys.workspaceKey,
+    activeContextEpoch: 1,
+  }, { account: accountDocument });
+  const layout = createProfileAccountWorkspaceLayout({
+    userData,
+    profileKey: keys.profileKey,
+    accountKey: keys.accountKey,
+    workspaceKey: keys.workspaceKey,
+    adoptLegacyHkustBrowserPartition: false,
+  });
+  const documents = {
+    schoolProfile: consumed.profileDocument,
+    profileSettings: validateProfileSettingsDocument({
+      schemaVersion: 1,
+      profileId: profile.profileId,
+      profileRevision: profile.profileRevision,
+      primaryAccountKey: keys.accountKey,
+    }),
+    profileState: validateProfileStateDocument({
+      schemaVersion: 1,
+      migrationId: keys.provisioningId,
+      profileId: profile.profileId,
+      profileRevision: profile.profileRevision,
+      profileCredentialBindingRevision: profile.profileCredentialBindingRevision,
+      gatewayOrigin: profile.gateway.origin.origin,
+      protocolFamily: profile.gateway.protocolFamily,
+    }),
+    account: accountDocument,
+    workspaceSettings: validateWorkspaceSettingsDocument({
+      schemaVersion: 1,
+      autoReconnect: true,
+      maxAttempts: 3,
+      autoConnect: false,
+      routeDomains: [],
+    }),
+    workspaceState: workspaceDocument,
+    localResources: validateLocalResourcesDocument({ schemaVersion: 1, resources: [] }),
+    favorites: Object.freeze({ schemaVersion: 1, entries: Object.freeze([]) }),
+    recentResources: Object.freeze({ schemaVersion: 1, entries: Object.freeze([]) }),
+    externalIntegrations: Object.freeze({ schemaVersion: 1, entries: Object.freeze([]) }),
+  };
+  const paths = Object.freeze({
+    schoolProfile: layout.profile.document,
+    profileSettings: layout.profile.settings,
+    profileState: layout.profile.state,
+    account: layout.account.document,
+    workspaceSettings: layout.workspace.settings,
+    workspaceState: layout.workspace.state,
+    localResources: layout.workspace.localResources,
+    favorites: layout.workspace.favorites,
+    recentResources: layout.workspace.recentResources,
+    externalIntegrations: layout.workspace.externalIntegrations,
+  });
+  const files = Object.freeze(Object.fromEntries(Object.entries(documents).map(([name, document]) => (
+    [name, jsonBuffer(document)]
+  ))));
+  return Object.freeze({
+    schemaVersion: CUSTOM_PROFILE_PROVISIONING_VERSION,
+    identity: Object.freeze({ ...keys }),
+    context: Object.freeze({
+      profileId: profile.profileId,
+      profileKey: keys.profileKey,
+      profileRevision: profile.profileRevision,
+      profileCredentialBindingRevision: profile.profileCredentialBindingRevision,
+      accountKey: keys.accountKey,
+      accountRevision: accountDocument.accountRevision,
+      accountCredentialRevision: accountDocument.accountCredentialRevision,
+      workspaceKey: keys.workspaceKey,
+      activeContextEpoch: workspaceDocument.activeContextEpoch,
+    }),
+    layout,
+    paths,
+    files,
+  });
+}
+
+module.exports = {
+  CUSTOM_PROFILE_PROVISIONING_VERSION,
+  createCustomProfileProvisioningIdentity,
+  createCustomProfileProvisioningPlan,
+};

--- a/desktop/lib/custom-profile-provisioning-plan.js
+++ b/desktop/lib/custom-profile-provisioning-plan.js
@@ -19,6 +19,11 @@ const {
 } = require('./school-profile-schema');
 
 const CUSTOM_PROFILE_PROVISIONING_VERSION = 1;
+const CUSTOM_PROFILE_FILE_IDS = Object.freeze([
+  'schoolProfile', 'profileSettings', 'profileState', 'account',
+  'workspaceSettings', 'workspaceState', 'localResources', 'favorites',
+  'recentResources', 'externalIntegrations',
+]);
 
 function plainObject(value, name) {
   if (!value || typeof value !== 'object' || Array.isArray(value) ||
@@ -174,8 +179,16 @@ function createCustomProfileProvisioningPlan({
   const files = Object.freeze(Object.fromEntries(Object.entries(documents).map(([name, document]) => (
     [name, jsonBuffer(document)]
   ))));
+  if (Object.keys(paths).length !== CUSTOM_PROFILE_FILE_IDS.length ||
+      Object.keys(files).length !== CUSTOM_PROFILE_FILE_IDS.length ||
+      CUSTOM_PROFILE_FILE_IDS.some((name) => !Object.hasOwn(paths, name) ||
+        !Object.hasOwn(files, name))) {
+    throw new Error('custom Profile destination plan has an invalid file set');
+  }
   return Object.freeze({
     schemaVersion: CUSTOM_PROFILE_PROVISIONING_VERSION,
+    createdAt,
+    profileDocument: consumed.profileDocument,
     identity: Object.freeze({ ...keys }),
     context: Object.freeze({
       profileId: profile.profileId,
@@ -195,6 +208,7 @@ function createCustomProfileProvisioningPlan({
 }
 
 module.exports = {
+  CUSTOM_PROFILE_FILE_IDS,
   CUSTOM_PROFILE_PROVISIONING_VERSION,
   createCustomProfileProvisioningIdentity,
   createCustomProfileProvisioningPlan,

--- a/desktop/lib/custom-profile-provisioning-runtime.js
+++ b/desktop/lib/custom-profile-provisioning-runtime.js
@@ -1,0 +1,175 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const {
+  CustomProfileIndexStore,
+  sameCustomProfileIndexReceipt,
+} = require('./custom-profile-index');
+const { CustomProfileMaterializer, sameCustomProfileFileReceipt } =
+  require('./custom-profile-materializer');
+const {
+  createPreparedCustomProfileProvisioning,
+  markCustomProfileIndexed,
+  markCustomProfileMaterialized,
+} = require('./custom-profile-provisioning-journal');
+const {
+  createCustomProfileProvisioningIdentity,
+  createCustomProfileProvisioningPlan,
+  CUSTOM_PROFILE_FILE_IDS,
+} = require('./custom-profile-provisioning-plan');
+const {
+  CustomProfileProvisioningJournalStore,
+} = require('./custom-profile-provisioning-store');
+const { validateSchoolProfileDocument } = require('./school-profile-schema');
+
+class CustomProfileProvisioningRuntime {
+  constructor({
+    userData,
+    journalStore = null,
+    indexStore = null,
+    materializer = null,
+    randomBytes = crypto.randomBytes,
+    now = Date.now,
+  } = {}) {
+    if (typeof randomBytes !== 'function' || typeof now !== 'function') {
+      throw new TypeError('custom Profile provisioning runtime dependencies are invalid');
+    }
+    this.userData = userData;
+    this.journalStore = journalStore || new CustomProfileProvisioningJournalStore({ userData });
+    this.indexStore = indexStore || new CustomProfileIndexStore({ userData });
+    this.materializer = materializer || new CustomProfileMaterializer();
+    this.randomBytes = randomBytes;
+    this.now = now;
+    this.running = false;
+  }
+
+  begin(confirmation) {
+    return this.#singleFlight(() => {
+      if (this.journalStore.read() !== null) {
+        throw new Error('custom Profile provisioning is already pending');
+      }
+      const identity = createCustomProfileProvisioningIdentity({
+        profileId: confirmation?.draftProfileId,
+        randomBytes: this.randomBytes,
+      });
+      const plan = createCustomProfileProvisioningPlan({
+        userData: this.userData,
+        confirmation,
+        identity,
+        now: this.now,
+      });
+      const fileReceipts = this.materializer.expected(plan);
+      const indexTransition = this.indexStore.planAdd(this.#indexEntry(plan));
+      const prepared = createPreparedCustomProfileProvisioning({
+        plan,
+        fileReceipts,
+        indexTransition,
+      });
+      const stored = this.journalStore.prepare(prepared);
+      if (!stored?.prepared || JSON.stringify(this.journalStore.read()) !== JSON.stringify(prepared)) {
+        throw new Error('custom Profile provisioning prepare was not confirmed');
+      }
+      return this.#resume(prepared);
+    });
+  }
+
+  recover() {
+    return this.#singleFlight(() => {
+      const journal = this.journalStore.read();
+      if (journal === null) return Object.freeze({ ok: true, status: 'none' });
+      return this.#resume(journal);
+    });
+  }
+
+  #resume(journalValue) {
+    let journal = journalValue;
+    const plan = this.#planFromJournal(journal);
+    const expected = this.materializer.expected(plan);
+    if (CUSTOM_PROFILE_FILE_IDS.some((id) => (
+      !sameCustomProfileFileReceipt(expected[id], journal.fileReceipts[id])
+    ))) {
+      throw new Error('custom Profile provisioning file receipts do not match the journal');
+    }
+
+    if (journal.state === 'prepared') {
+      this.materializer.materialize(plan, journal.fileReceipts);
+      const materialized = markCustomProfileMaterialized(journal, { now: this.now });
+      const stored = this.journalStore.markMaterialized(materialized);
+      if (!stored?.materialized ||
+          JSON.stringify(this.journalStore.read()) !== JSON.stringify(materialized)) {
+        throw new Error('custom Profile materialized transition was not confirmed');
+      }
+      journal = materialized;
+    }
+
+    if (journal.state === 'materialized') {
+      if (!this.materializer.verify(plan, journal.fileReceipts)) {
+        throw new Error('custom Profile destination changed after materialization');
+      }
+      if (!this.indexStore.applyAdd(journal.indexTransition.entry, journal.indexTransition) ||
+          !sameCustomProfileIndexReceipt(
+            this.indexStore.receipt(),
+            journal.indexTransition.after,
+          )) {
+        throw new Error('custom Profile index commit was not confirmed');
+      }
+      const indexed = markCustomProfileIndexed(journal, { now: this.now });
+      const stored = this.journalStore.markIndexed(indexed);
+      if (!stored?.indexed || JSON.stringify(this.journalStore.read()) !== JSON.stringify(indexed)) {
+        throw new Error('custom Profile indexed transition was not confirmed');
+      }
+      journal = indexed;
+    }
+
+    if (journal.state !== 'indexed' || !this.materializer.verify(plan, journal.fileReceipts) ||
+        !sameCustomProfileIndexReceipt(this.indexStore.receipt(), journal.indexTransition.after) ||
+        !this.indexStore.read().entries.some((entry) => (
+          entry.profileId === journal.identity.profileId &&
+          entry.profileKey === journal.identity.profileKey
+        ))) {
+      throw new Error('custom Profile provisioning final authority is incomplete');
+    }
+    if (this.journalStore.clearIndexed() !== true) {
+      throw new Error('custom Profile provisioning journal was not cleared');
+    }
+    return Object.freeze({
+      ok: true,
+      status: 'provisioned',
+      profileId: journal.identity.profileId,
+      context: plan.context,
+    });
+  }
+
+  #planFromJournal(journal) {
+    const profile = validateSchoolProfileDocument(journal.profileDocument);
+    return createCustomProfileProvisioningPlan({
+      userData: this.userData,
+      confirmation: {
+        draftProfileId: journal.identity.profileId,
+        normalizedOrigin: profile.gateway.origin.origin,
+        candidateFamily: profile.gateway.protocolFamily,
+        profileDocument: journal.profileDocument,
+        profile,
+      },
+      identity: journal.identity,
+      now: () => journal.createdAt,
+    });
+  }
+
+  #indexEntry(plan) {
+    return Object.freeze({
+      profileId: plan.context.profileId,
+      profileKey: plan.context.profileKey,
+      createdAt: plan.createdAt,
+    });
+  }
+
+  #singleFlight(operation) {
+    if (this.running) throw new Error('custom Profile provisioning is already running');
+    this.running = true;
+    try { return operation(); }
+    finally { this.running = false; }
+  }
+}
+
+module.exports = { CustomProfileProvisioningRuntime };

--- a/desktop/lib/custom-profile-provisioning-store.js
+++ b/desktop/lib/custom-profile-provisioning-store.js
@@ -1,0 +1,178 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { atomicWritePrivateFile } = require('./credential-store');
+const {
+  validateCustomProfileProvisioningJournal,
+} = require('./custom-profile-provisioning-journal');
+const { ensurePrivateDirectoryChain, fsyncPrivateDirectory } = require('./private-directory');
+const { readPrivateFileBounded } = require('./private-file');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+const MAX_CUSTOM_PROFILE_PROVISIONING_JOURNAL_BYTES = 256 * 1024;
+
+function binding(value) {
+  return JSON.stringify({
+    schemaVersion: value.schemaVersion,
+    type: value.type,
+    identity: value.identity,
+    profileDocument: value.profileDocument,
+    createdAt: value.createdAt,
+    fileReceipts: value.fileReceipts,
+    indexTransition: value.indexTransition,
+  });
+}
+
+function sameDocument(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function serialize(value) {
+  const normalized = validateCustomProfileProvisioningJournal(value);
+  const data = Buffer.from(`${JSON.stringify(normalized)}\n`, 'utf8');
+  if (data.length < 2 || data.length > MAX_CUSTOM_PROFILE_PROVISIONING_JOURNAL_BYTES) {
+    data.fill(0);
+    throw new TypeError('custom Profile provisioning journal exceeds its storage bound');
+  }
+  return { normalized, data };
+}
+
+class CustomProfileProvisioningJournalStore {
+  constructor({
+    userData,
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+  } = {}) {
+    if (typeof userData !== 'string' || !path.isAbsolute(userData) || path.resolve(userData) !== userData ||
+        !fileSystem || typeof fileSystem.openSync !== 'function' ||
+        !['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' && (typeof windowsAcl?.protect !== 'function' ||
+          typeof windowsAcl?.verify !== 'function'))) {
+      throw new TypeError('custom Profile provisioning store dependencies are invalid');
+    }
+    this.userData = userData;
+    this.filePath = path.join(userData, 'global', 'custom-profile-provisioning.json');
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+  }
+
+  read() {
+    try { this.fileSystem.lstatSync(this.filePath); }
+    catch (error) {
+      if (error?.code === 'ENOENT') return null;
+      throw error;
+    }
+    if (this.platform === 'win32' && !this.windowsAcl.verify(this.filePath)) {
+      throw new Error('custom Profile provisioning journal ACL is invalid');
+    }
+    const { data } = readPrivateFileBounded(this.filePath, {
+      maxBytes: MAX_CUSTOM_PROFILE_PROVISIONING_JOURNAL_BYTES,
+      minBytes: 2,
+      platform: this.platform,
+      fileSystem: this.fileSystem,
+    });
+    try { return validateCustomProfileProvisioningJournal(JSON.parse(data.toString('utf8'))); }
+    catch (error) { throw new Error('custom Profile provisioning journal is invalid', { cause: error }); }
+    finally { data.fill(0); }
+  }
+
+  prepare(value) {
+    const { normalized, data } = serialize(value);
+    if (normalized.state !== 'prepared') {
+      data.fill(0);
+      throw new TypeError('custom Profile provisioning journal must start prepared');
+    }
+    const directory = path.dirname(this.filePath);
+    let descriptor = null;
+    let created = false;
+    try {
+      ensurePrivateDirectoryChain(this.userData, directory, {
+        fileSystem: this.fileSystem,
+        platform: this.platform,
+      });
+      descriptor = this.fileSystem.openSync(this.filePath, 'wx', 0o600);
+      created = true;
+      this.fileSystem.writeFileSync(descriptor, data);
+      this.fileSystem.fsyncSync?.(descriptor);
+      this.fileSystem.closeSync(descriptor);
+      descriptor = null;
+      if (this.platform === 'win32' &&
+          (!this.windowsAcl.protect(this.filePath) || !this.windowsAcl.verify(this.filePath))) {
+        throw new Error('custom Profile provisioning journal ACL could not be established');
+      }
+      const durable = fsyncPrivateDirectory(directory, this.fileSystem, this.platform);
+      if (!durable && !sameDocument(this.read(), normalized)) {
+        throw new Error('custom Profile provisioning journal prepare is unconfirmed');
+      }
+      return { prepared: true, durabilityUnconfirmed: !durable };
+    } catch (error) {
+      if (descriptor !== null) {
+        try { this.fileSystem.closeSync(descriptor); } catch {}
+      }
+      if (created) {
+        try { this.fileSystem.unlinkSync(this.filePath); } catch {}
+      }
+      if (error?.code === 'EEXIST') {
+        throw new Error('custom Profile provisioning journal already exists');
+      }
+      throw new Error('custom Profile provisioning journal prepare failed', { cause: error });
+    } finally {
+      data.fill(0);
+    }
+  }
+
+  markMaterialized(value) { return this.#transition(value, 'prepared', 'materialized'); }
+
+  markIndexed(value) { return this.#transition(value, 'materialized', 'indexed'); }
+
+  clearIndexed() {
+    const current = this.read();
+    if (!current || current.state !== 'indexed') {
+      throw new Error('only indexed custom Profile provisioning can be cleared');
+    }
+    const directory = path.dirname(this.filePath);
+    this.fileSystem.unlinkSync(this.filePath);
+    if (!fsyncPrivateDirectory(directory, this.fileSystem, this.platform)) {
+      throw new Error('custom Profile provisioning journal clear was not durable');
+    }
+    return true;
+  }
+
+  #transition(value, expectedState, nextState) {
+    const current = this.read();
+    const { normalized, data } = serialize(value);
+    try {
+      if (!current || current.state !== expectedState || normalized.state !== nextState ||
+          binding(current) !== binding(normalized)) {
+        throw new Error('custom Profile provisioning transition binding does not match');
+      }
+      const options = this.platform === 'win32' ? {
+        protectTemporary: (file) => this.windowsAcl.protect(file) === true,
+        verifyCommitted: (file) => this.windowsAcl.verify(file) === true,
+        removeCommittedOnFailure: true,
+      } : {};
+      const written = atomicWritePrivateFile(this.filePath, data, this.fileSystem, options);
+      const observed = this.read();
+      if (!sameDocument(observed, normalized)) {
+        throw new Error(`custom Profile provisioning ${nextState} is unconfirmed`);
+      }
+      return { [nextState]: true, durabilityUnconfirmed: !written };
+    } finally {
+      data.fill(0);
+    }
+  }
+}
+
+module.exports = {
+  CustomProfileProvisioningJournalStore,
+  MAX_CUSTOM_PROFILE_PROVISIONING_JOURNAL_BYTES,
+};

--- a/desktop/lib/pac.js
+++ b/desktop/lib/pac.js
@@ -43,7 +43,7 @@ function normalizeRouteDomains(input, defaultDomains = DEFAULT_ROUTE_DOMAINS) {
   const normalized = collectRouteDomains(values);
   if (normalized.length) return normalized;
   const fallback = collectRouteDomains(defaultDomains);
-  return fallback.length ? fallback : [...DEFAULT_ROUTE_DOMAINS];
+  return fallback;
 }
 
 function buildPac(routeDomains, port, options = {}) {

--- a/desktop/lib/private-directory.js
+++ b/desktop/lib/private-directory.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function normalizedRoot(value) {
+  if (typeof value !== 'string' || !path.isAbsolute(value) || path.resolve(value) !== value ||
+      value === path.parse(value).root) {
+    throw new TypeError('private directory root is invalid');
+  }
+  return value;
+}
+
+function ensurePrivateDirectoryChain(rootValue, directoryValue, {
+  fileSystem = fs,
+  platform = process.platform,
+} = {}) {
+  const root = normalizedRoot(rootValue);
+  if (typeof directoryValue !== 'string' || !path.isAbsolute(directoryValue) ||
+      path.resolve(directoryValue) !== directoryValue) {
+    throw new TypeError('private directory target is invalid');
+  }
+  const relative = path.relative(root, directoryValue);
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new TypeError('private directory escapes its root');
+  }
+  try { fileSystem.mkdirSync(root, { recursive: true, mode: 0o700 }); }
+  catch (error) { throw new Error('private directory root could not be created', { cause: error }); }
+  let current = root;
+  for (const component of ['', ...relative.split(path.sep).filter(Boolean)]) {
+    if (component) current = path.join(current, component);
+    let stat;
+    try { stat = fileSystem.lstatSync(current); }
+    catch (error) {
+      if (error?.code !== 'ENOENT' || !component) throw error;
+      fileSystem.mkdirSync(current, { mode: 0o700 });
+      stat = fileSystem.lstatSync(current);
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink() ||
+        (platform !== 'win32' && (stat.mode & 0o077) !== 0)) {
+      throw new Error('private directory is not owner-only and link-free');
+    }
+  }
+  return true;
+}
+
+function fsyncPrivateDirectory(directory, fileSystem = fs, platform = process.platform) {
+  let descriptor = null;
+  try {
+    descriptor = fileSystem.openSync(directory, 'r');
+    fileSystem.fsyncSync?.(descriptor);
+    return true;
+  } catch {
+    return platform === 'win32';
+  } finally {
+    if (descriptor !== null) {
+      try { fileSystem.closeSync(descriptor); } catch {}
+    }
+  }
+}
+
+module.exports = { ensurePrivateDirectoryChain, fsyncPrivateDirectory };

--- a/desktop/lib/profile-workspace-documents.js
+++ b/desktop/lib/profile-workspace-documents.js
@@ -130,10 +130,10 @@ function validateWorkspaceSettingsDocument(value) {
   ], 'workspace settings');
   if (!Number.isSafeInteger(source.maxAttempts) || source.maxAttempts < 0 ||
       source.maxAttempts > 10 || !Array.isArray(source.routeDomains) ||
-      source.routeDomains.length < 1 || source.routeDomains.length > 64) {
+      source.routeDomains.length > 64) {
     throw new TypeError('workspace settings contain an unsupported value');
   }
-  const routeDomains = normalizeRouteDomains(source.routeDomains);
+  const routeDomains = normalizeRouteDomains(source.routeDomains, []);
   if (routeDomains.length !== source.routeDomains.length ||
       routeDomains.some((domain, index) => domain !== source.routeDomains[index])) {
     throw new TypeError('workspace route domains are not canonical');

--- a/desktop/lib/profile-workspace-layout.js
+++ b/desktop/lib/profile-workspace-layout.js
@@ -75,6 +75,7 @@ function createProfileAccountRoots(root, keys) {
     },
     profile: {
       root: profileRoot,
+      document: path.join(profileRoot, 'school-profile.json'),
       settings: path.join(profileRoot, 'profile-settings.json'),
       state: path.join(profileRoot, 'profile-state.json'),
     },

--- a/desktop/test/custom-gateway-onboarding.test.js
+++ b/desktop/test/custom-gateway-onboarding.test.js
@@ -61,6 +61,7 @@ test('one-use confirmation produces one minimal isolated custom Profile', () => 
   });
   assert.match(consumed.draftProfileId, /^custom-[a-f0-9]{32}$/u);
   assert.equal(consumed.profile.evidenceClass, 'custom-local');
+  assert.equal(consumed.profileDocument.gateway.origin, 'https://vpn.example.edu');
   assert.equal(consumed.profile.gateway.origin.origin, 'https://vpn.example.edu');
   assert.equal(consumed.profile.gateway.engineConfigRef, null);
   assert.deepEqual(consumed.profile.browser.campusDomains, []);
@@ -123,7 +124,7 @@ test('custom Profile identity and policy never derive authority from the label',
     origin: 'https://VPN.Example.EDU.:443/',
     schoolLabel: '',
   });
-  assert.equal(profile.gateway.origin.origin, 'https://vpn.example.edu');
+  assert.equal(profile.gateway.origin, 'https://vpn.example.edu');
   assert.equal(profile.branding.localizedSchoolName.zh, 'vpn.example.edu');
   assert.throws(() => customProfileDocument({
     profileId: `custom-${'2'.repeat(32)}`,

--- a/desktop/test/custom-profile-provisioning-boundary.test.js
+++ b/desktop/test/custom-profile-provisioning-boundary.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+function source(file) {
+  return fs.readFileSync(path.join(__dirname, '..', 'lib', file), 'utf8');
+}
+
+test('custom Profile provisioning is credential Engine Browser and Renderer neutral', () => {
+  const files = [
+    'custom-profile-provisioning-plan.js',
+    'custom-profile-provisioning-journal.js',
+    'custom-profile-provisioning-store.js',
+    'custom-profile-materializer.js',
+    'custom-profile-index.js',
+    'custom-profile-provisioning-runtime.js',
+  ];
+  const combined = files.map(source).join('\n');
+  for (const forbidden of [
+    "require('electron')",
+    'safeStorage',
+    'vpn-credential-envelope',
+    'EngineSupervisor',
+    'CampusBrowser',
+    'ipcMain',
+    'renderer/',
+  ]) assert.equal(combined.includes(forbidden), false, forbidden);
+  assert.equal(combined.includes('activeCredentialVersion: null'), true);
+  assert.equal(combined.includes('autoConnect: false'), true);
+});
+
+test('production Main cannot activate unfinished custom provisioning yet', () => {
+  const main = fs.readFileSync(path.join(__dirname, '..', 'main.js'), 'utf8');
+  assert.equal(main.includes("require('./lib/custom-profile-provisioning-runtime')"), false);
+  assert.equal(main.includes("require('./lib/custom-profile-index')"), false);
+});

--- a/desktop/test/custom-profile-provisioning-plan.test.js
+++ b/desktop/test/custom-profile-provisioning-plan.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  CustomGatewayConfirmationOwner,
+} = require('../lib/custom-gateway-onboarding');
+const {
+  createCustomProfileProvisioningIdentity,
+  createCustomProfileProvisioningPlan,
+} = require('../lib/custom-profile-provisioning-plan');
+const { PROTOCOL_FAMILY } = require('../lib/school-profile-schema');
+
+function activeContext() {
+  return {
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    accountHandle: `account-${'a'.repeat(36)}`,
+    activeContextEpoch: 7,
+  };
+}
+
+function confirmation() {
+  let seed = 0;
+  const owner = new CustomGatewayConfirmationOwner({
+    randomBytes: (length) => Buffer.alloc(length, ++seed),
+    now: () => 1_800_000_000_000,
+    ttlMs: 10_000,
+  });
+  const view = owner.issue({
+    probeResult: {
+      schema_version: 1,
+      normalized_origin: 'https://vpn.example.edu',
+      https_identity_valid: true,
+      compatibility: 'recognized_candidate',
+      candidate_family: PROTOCOL_FAMILY,
+      reported_version: 'M7.6.8R2',
+      http_status: 200,
+    },
+    schoolLabel: 'Example University',
+    activeContext: activeContext(),
+  });
+  return owner.consume({ confirmationHandle: view.confirmationHandle, activeContext: activeContext() });
+}
+
+function identity(profileId) {
+  let seed = 10;
+  return createCustomProfileProvisioningIdentity({
+    profileId,
+    randomBytes: (length) => Buffer.alloc(length, ++seed),
+  });
+}
+
+test('confirmed custom Gateway produces one credential-free isolated destination plan', () => {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'custom-profile-plan-'));
+  try {
+    const consumed = confirmation();
+    const plan = createCustomProfileProvisioningPlan({
+      userData,
+      confirmation: consumed,
+      identity: identity(consumed.draftProfileId),
+      now: () => 1_800_000_000_100,
+    });
+    assert.equal(plan.context.profileId, consumed.draftProfileId);
+    assert.equal(plan.context.activeContextEpoch, 1);
+    assert.equal(plan.layout.browserPartition.startsWith('persist:campus-workspace-'), true);
+    assert.notEqual(plan.layout.browserPartition, 'persist:hkustgz-campus-browser');
+    assert.equal(Object.keys(plan.files).length, 10);
+    for (const [name, file] of Object.entries(plan.paths)) {
+      assert.equal(path.isAbsolute(file), true, name);
+      assert.equal(path.relative(userData, file).startsWith('..'), false, name);
+      assert.equal(Buffer.isBuffer(plan.files[name]), true, name);
+    }
+    const account = JSON.parse(plan.files.account.toString('utf8'));
+    const workspace = JSON.parse(plan.files.workspaceSettings.toString('utf8'));
+    assert.equal(account.activeCredentialVersion, null);
+    assert.deepEqual(workspace.routeDomains, []);
+    assert.equal(Object.hasOwn(plan.files, 'vpnCredential'), false);
+    const encoded = JSON.stringify(plan);
+    for (const forbidden of ['password', 'TwfID', 'reviewedDnsFallback']) {
+      assert.equal(encoded.includes(forbidden), false, forbidden);
+    }
+  } finally {
+    fs.rmSync(userData, { recursive: true, force: true });
+  }
+});
+
+test('plan rejects confirmation identity origin family and normalized Profile drift', () => {
+  const userData = path.join(os.tmpdir(), 'custom-profile-plan-drift');
+  const consumed = confirmation();
+  const base = {
+    userData,
+    confirmation: consumed,
+    identity: identity(consumed.draftProfileId),
+    now: () => 1_800_000_000_100,
+  };
+  for (const changed of [
+    { ...consumed, draftProfileId: `custom-${'9'.repeat(32)}` },
+    { ...consumed, normalizedOrigin: 'https://other.example.edu' },
+    { ...consumed, candidateFamily: 'atrust' },
+    { ...consumed, extra: true },
+  ]) {
+    assert.throws(() => createCustomProfileProvisioningPlan({ ...base, confirmation: changed }));
+  }
+});
+
+test('provisioning identity is random opaque and never derived from the Gateway', () => {
+  const profileId = `custom-${'1'.repeat(32)}`;
+  const value = identity(profileId);
+  assert.equal(value.profileId, profileId);
+  assert.equal(new Set([
+    value.provisioningId, value.profileKey, value.accountKey, value.workspaceKey,
+  ]).size, 4);
+  assert.equal(JSON.stringify(value).includes('vpn.example.edu'), false);
+  assert.throws(() => createCustomProfileProvisioningIdentity({
+    profileId: 'hkustgz',
+    randomBytes: () => Buffer.alloc(16, 1),
+  }), /identity/u);
+});

--- a/desktop/test/custom-profile-provisioning-plan.test.js
+++ b/desktop/test/custom-profile-provisioning-plan.test.js
@@ -79,8 +79,9 @@ test('confirmed custom Gateway produces one credential-free isolated destination
     assert.equal(account.activeCredentialVersion, null);
     assert.deepEqual(workspace.routeDomains, []);
     assert.equal(Object.hasOwn(plan.files, 'vpnCredential'), false);
+    assert.deepEqual(plan.profileDocument.policy.reviewedDnsFallback, []);
     const encoded = JSON.stringify(plan);
-    for (const forbidden of ['password', 'TwfID', 'reviewedDnsFallback']) {
+    for (const forbidden of ['"password":', 'TwfID']) {
       assert.equal(encoded.includes(forbidden), false, forbidden);
     }
   } finally {

--- a/desktop/test/custom-profile-storage.test.js
+++ b/desktop/test/custom-profile-storage.test.js
@@ -1,0 +1,257 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { CustomGatewayConfirmationOwner } = require('../lib/custom-gateway-onboarding');
+const { CustomProfileIndexStore } = require('../lib/custom-profile-index');
+const { CustomProfileMaterializer } = require('../lib/custom-profile-materializer');
+const { CustomProfileProvisioningRuntime } = require('../lib/custom-profile-provisioning-runtime');
+const {
+  CustomProfileProvisioningJournalStore,
+} = require('../lib/custom-profile-provisioning-store');
+const {
+  createCustomProfileProvisioningIdentity,
+  createCustomProfileProvisioningPlan,
+} = require('../lib/custom-profile-provisioning-plan');
+const { PROTOCOL_FAMILY } = require('../lib/school-profile-schema');
+
+function root(t) {
+  const value = fs.mkdtempSync(path.join(os.tmpdir(), 'custom-profile-storage-'));
+  fs.chmodSync(value, 0o700);
+  t.after(() => fs.rmSync(value, { recursive: true, force: true }));
+  return value;
+}
+
+function consumedConfirmation(seed = 1) {
+  let entropy = seed;
+  const owner = new CustomGatewayConfirmationOwner({
+    randomBytes: (length) => Buffer.alloc(length, entropy++),
+    now: () => 1_800_000_000_000,
+    ttlMs: 10_000,
+  });
+  const context = {
+    profileId: 'hkustgz', profileRevision: 1,
+    accountHandle: `account-${'a'.repeat(36)}`, activeContextEpoch: 7,
+  };
+  const view = owner.issue({
+    probeResult: {
+      schema_version: 1,
+      normalized_origin: `https://vpn${seed}.example.edu`,
+      https_identity_valid: true,
+      compatibility: 'recognized_candidate',
+      candidate_family: PROTOCOL_FAMILY,
+      reported_version: 'M7.6.8R2',
+      http_status: 200,
+    },
+    activeContext: context,
+  });
+  return owner.consume({ confirmationHandle: view.confirmationHandle, activeContext: context });
+}
+
+function plan(userData, seed = 1) {
+  const confirmation = consumedConfirmation(seed);
+  let entropy = seed + 20;
+  const identity = createCustomProfileProvisioningIdentity({
+    profileId: confirmation.draftProfileId,
+    randomBytes: (length) => Buffer.alloc(length, entropy++),
+  });
+  return createCustomProfileProvisioningPlan({
+    userData,
+    confirmation,
+    identity,
+    now: () => 1_800_000_000_100 + seed,
+  });
+}
+
+test('materializer preflights then writes and verifies one exact idempotent plan', (t) => {
+  const userData = root(t);
+  const value = plan(userData);
+  const materializer = new CustomProfileMaterializer();
+  const expected = materializer.expected(value);
+  assert.equal(materializer.verify(value, expected), false);
+  assert.equal(materializer.materialize(value, expected), true);
+  assert.equal(materializer.verify(value, expected), true);
+  assert.equal(materializer.materialize(value, expected), true);
+  for (const file of Object.values(value.paths)) {
+    const stat = fs.lstatSync(file);
+    assert.equal(stat.isFile() && !stat.isSymbolicLink(), true);
+    assert.equal(stat.mode & 0o077, 0);
+    assert.equal(stat.nlink, 1);
+  }
+});
+
+test('destination conflict blocks before any other plan file is written', (t) => {
+  const userData = root(t);
+  const value = plan(userData);
+  fs.mkdirSync(path.dirname(value.paths.profileState), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(value.paths.profileState, '{"conflict":true}\n', { mode: 0o600 });
+  const materializer = new CustomProfileMaterializer();
+  assert.throws(() => materializer.materialize(value, materializer.expected(value)), /conflict/u);
+  assert.equal(fs.existsSync(value.paths.schoolProfile), false);
+  assert.equal(fs.existsSync(value.paths.account), false);
+});
+
+test('materializer never follows a destination symlink', { skip: process.platform === 'win32' }, (t) => {
+  const userData = root(t);
+  const value = plan(userData);
+  const outside = path.join(userData, 'outside.json');
+  fs.writeFileSync(outside, '{}\n', { mode: 0o600 });
+  fs.mkdirSync(path.dirname(value.paths.schoolProfile), { recursive: true, mode: 0o700 });
+  fs.symlinkSync(outside, value.paths.schoolProfile);
+  const materializer = new CustomProfileMaterializer();
+  assert.throws(() => materializer.materialize(value, materializer.expected(value)), /private file/u);
+  assert.equal(fs.readFileSync(outside, 'utf8'), '{}\n');
+});
+
+test('custom Profile index is owner-only additive idempotent and bounded', (t) => {
+  const userData = root(t);
+  const firstPlan = plan(userData, 1);
+  const store = new CustomProfileIndexStore({ userData });
+  const entry = {
+    profileId: firstPlan.context.profileId,
+    profileKey: firstPlan.context.profileKey,
+    createdAt: firstPlan.createdAt,
+  };
+  const transition = store.planAdd(entry);
+  assert.equal(transition.before.present, false);
+  assert.equal(store.applyAdd(entry, transition), true);
+  assert.equal(store.applyAdd(entry, transition), true);
+  assert.deepEqual(store.read().entries, [entry]);
+  const stat = fs.lstatSync(store.filePath);
+  assert.equal(stat.mode & 0o077, 0);
+  assert.throws(() => store.planAdd(entry), /cannot add/u);
+
+  const secondPlan = plan(userData, 2);
+  const second = {
+    profileId: secondPlan.context.profileId,
+    profileKey: secondPlan.context.profileKey,
+    createdAt: secondPlan.createdAt,
+  };
+  const next = store.planAdd(second);
+  assert.equal(store.applyAdd(second, next), true);
+  assert.equal(store.read().entries.length, 2);
+});
+
+test('custom Profile index rejects broad permissions and links', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const userData = root(t);
+  const store = new CustomProfileIndexStore({ userData });
+  fs.mkdirSync(path.dirname(store.filePath), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(store.filePath, '{"schemaVersion":1,"entries":[]}\n', { mode: 0o644 });
+  assert.throws(() => store.read(), /private file/u);
+  fs.unlinkSync(store.filePath);
+  const outside = path.join(userData, 'outside-index.json');
+  fs.writeFileSync(outside, '{"schemaVersion":1,"entries":[]}\n', { mode: 0o600 });
+  fs.symlinkSync(outside, store.filePath);
+  assert.throws(() => store.read(), /private file/u);
+});
+
+function faultOnce(store, method) {
+  let armed = true;
+  return new Proxy(store, {
+    get(target, property) {
+      if (property === method) {
+        return (...arguments_) => {
+          if (armed) {
+            armed = false;
+            throw new Error(`synthetic ${method} crash`);
+          }
+          return target[property](...arguments_);
+        };
+      }
+      const value = target[property];
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+function runtime(userData, overrides = {}) {
+  let entropy = 80;
+  return new CustomProfileProvisioningRuntime({
+    userData,
+    randomBytes: (length) => Buffer.alloc(length, ++entropy),
+    now: () => 1_800_000_000_500,
+    ...overrides,
+  });
+}
+
+test('runtime commits files and index then clears its journal without activating GlobalSettings', (t) => {
+  const userData = root(t);
+  const global = path.join(userData, 'global');
+  fs.mkdirSync(global, { mode: 0o700 });
+  const settings = path.join(global, 'settings.json');
+  fs.writeFileSync(settings, '{"unrelated":"authority"}\n', { mode: 0o600 });
+  const before = fs.readFileSync(settings);
+  const result = runtime(userData).begin(consumedConfirmation(7));
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 'provisioned');
+  assert.equal(fs.readFileSync(settings).equals(before), true);
+  assert.equal(new CustomProfileIndexStore({ userData }).read().entries.length, 1);
+  assert.equal(new CustomProfileProvisioningJournalStore({ userData }).read(), null);
+  assert.equal(fs.existsSync(path.join(
+    userData, 'profiles', result.context.profileKey, 'school-profile.json',
+  )), true);
+});
+
+test('prepared materialized and indexed crash points recover idempotently', (t) => {
+  for (const fault of ['markMaterialized', 'markIndexed', 'clearIndexed']) {
+    const userData = path.join(root(t), fault);
+    fs.mkdirSync(userData, { mode: 0o700 });
+    const store = new CustomProfileProvisioningJournalStore({ userData });
+    const first = runtime(userData, { journalStore: faultOnce(store, fault) });
+    assert.throws(() => first.begin(consumedConfirmation(fault.length)),
+      new RegExp(`synthetic ${fault}`));
+    const pending = store.read();
+    assert.ok(pending, fault);
+    const result = runtime(userData, { journalStore: store }).recover();
+    assert.equal(result.status, 'provisioned', fault);
+    assert.equal(store.read(), null, fault);
+    assert.equal(new CustomProfileIndexStore({ userData }).read().entries.length, 1, fault);
+  }
+});
+
+test('a destination conflict leaves a prepared journal and never indexes or activates it', (t) => {
+  const userData = root(t);
+  const confirmation = consumedConfirmation(9);
+  let entropy = 80;
+  const deterministic = () => runtime(userData, {
+    randomBytes: (length) => Buffer.alloc(length, ++entropy),
+  });
+  // Build the same first identity separately so a hostile conflicting target
+  // can be placed before the runtime reaches its materialization phase.
+  let identityEntropy = 80;
+  const identity = createCustomProfileProvisioningIdentity({
+    profileId: confirmation.draftProfileId,
+    randomBytes: (length) => Buffer.alloc(length, ++identityEntropy),
+  });
+  const planned = createCustomProfileProvisioningPlan({
+    userData,
+    confirmation,
+    identity,
+    now: () => 1_800_000_000_500,
+  });
+  fs.mkdirSync(path.dirname(planned.paths.account), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(planned.paths.account, '{"conflict":true}\n', { mode: 0o600 });
+  assert.throws(() => deterministic().begin(confirmation), /destination conflict/u);
+  assert.equal(new CustomProfileIndexStore({ userData }).read().entries.length, 0);
+  assert.equal(new CustomProfileProvisioningJournalStore({ userData }).read()?.state, 'prepared');
+});
+
+test('provisioning journal rejects broad permissions and links', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const userData = root(t);
+  const store = new CustomProfileProvisioningJournalStore({ userData });
+  fs.mkdirSync(path.dirname(store.filePath), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(store.filePath, '{}\n', { mode: 0o644 });
+  assert.throws(() => store.read(), /private file/u);
+  fs.unlinkSync(store.filePath);
+  const outside = path.join(userData, 'outside-journal.json');
+  fs.writeFileSync(outside, '{}\n', { mode: 0o600 });
+  fs.symlinkSync(outside, store.filePath);
+  assert.throws(() => store.read(), /private file/u);
+});

--- a/desktop/test/pac.test.js
+++ b/desktop/test/pac.test.js
@@ -14,6 +14,8 @@ test('route domains are normalized, deduplicated, and bounded', () => {
   assert.deepEqual(normalizeRouteDomains(undefined, ['Campus.Example.EDU']), [
     'campus.example.edu',
   ]);
+  assert.deepEqual(normalizeRouteDomains([], []), [],
+    'a custom Profile with no reviewed domains must not inherit another school');
 });
 
 test('PAC routes only explicit suffixes and literal private addresses', () => {

--- a/desktop/test/profile-workspace-documents.test.js
+++ b/desktop/test/profile-workspace-documents.test.js
@@ -54,6 +54,13 @@ test('runtime storage documents are exact canonical and immutable', () => {
   }
   assert.equal(Object.isFrozen(workspace.routeDomains), true);
   assert.equal(state.gatewayOrigin, 'https://remote.hkust-gz.edu.cn');
+  assert.deepEqual(validateWorkspaceSettingsDocument({
+    schemaVersion: 1,
+    autoReconnect: true,
+    maxAttempts: 3,
+    autoConnect: false,
+    routeDomains: [],
+  }).routeDomains, [], 'an unreviewed custom Profile starts without invented campus domains');
 });
 
 test('runtime storage documents reject drift instead of normalizing it silently', () => {

--- a/docs/adr/0023-custom-profile-provisioning.md
+++ b/docs/adr/0023-custom-profile-provisioning.md
@@ -1,0 +1,55 @@
+# ADR-0023: Crash-recoverable custom Profile provisioning
+
+- Status: Accepted for 2.0 P6c/P6d
+- Scope: inactive credential-free custom Profile/Account/Workspace creation
+- Active Profile switch and credential entry: deferred
+
+## Decision
+
+Consuming a Main-owned Gateway confirmation produces one deterministic plan
+with fresh opaque `profileKey`, `accountKey`, `workspaceKey` and provisioning
+identity. The plan contains exactly ten owner-only JSON targets:
+
+- the raw `custom-local` SchoolProfile source document;
+- Profile settings and immutable Profile state;
+- one credential-free primary CampusAccount;
+- Workspace settings and Workspace scope;
+- empty local resources, favorites, recents and external-integration state.
+
+No VPN credential, Cookie, certificate pin, routing rule, Browser password,
+proxy credential or log is copied. `autoConnect` is false and `routeDomains` is
+an explicit empty set. The Browser partition is derived from the new Workspace
+key and never reuses the HKUST legacy partition.
+
+## Transaction
+
+One owner-only global journal advances:
+
+```text
+prepared → materialized → indexed → clear
+```
+
+`prepared` binds the raw Profile document, opaque identities, creation time,
+the SHA-256 receipt of every target file and the before/after CustomProfileIndex
+receipts. The materializer preflights every target before its first write.
+Absent targets are written by same-directory atomic replacement; already exact
+targets are accepted during recovery; any other file, link, hard link, broad
+permission, path escape or digest conflict blocks the transaction.
+
+After every file is exact, `materialized` permits one additive index commit.
+The index contains only custom `profileId`, opaque `profileKey` and creation
+time. If a crash occurs after the index rename but before the journal advances,
+the exact after receipt makes replay idempotent. `indexed` is cleared only after
+both file receipts and index authority are reverified.
+
+## Activation boundary
+
+Provisioning never writes GlobalSettings and never activates an
+`ActiveContextLease`. A completed custom Profile is inactive and has no
+credential. A later P6 slice must load the persisted Profile from its exact
+opaque root, create a Profile-aware Engine config, and run the existing P4
+cleanup/activation journal before it becomes current. Renderer IPC must never
+receive the provisioning context keys returned to Main.
+
+Deletion remains deferred. Partial or conflicting destinations stay journaled
+and fail closed; they are not recursively removed by startup guesses.


### PR DESCRIPTION
## Summary

- convert one consumed custom-Gateway confirmation into a complete credential-free Profile/Account/Workspace plan
- generate independent opaque profile/account/workspace/provisioning keys and a non-HKUST Browser partition
- materialize exactly ten owner-only files only after a full conflict/link/permission preflight
- add an owner-only additive CustomProfileIndex and a prepared → materialized → indexed recovery journal
- recover idempotently after partial file writes, index commit, transition failure or journal-clear failure
- keep VPN credential absent, auto-connect disabled and campus domains explicitly empty so custom Profiles never inherit HKUST authority
- never write GlobalSettings or activate the new Profile in this slice

## Validation

- Desktop: 819 passed, 0 failed, 1 explicit Windows-only skip
- real filesystem success, idempotence, conflict, permissions and symlink tests: PASS
- prepared/materialized/indexed synthetic crash recovery: PASS
- architecture gate: PASS (0 cycles, unchanged Main dependency/line caps)
- tracked secret and syntax gates: PASS

## Boundary

The completed custom Profile remains inactive and credential-free. Production Main composition, Profile-aware Engine config generation, active-context switching and UI are later P6 slices. Persistent context keys returned to Main must never cross Renderer IPC.