### PR TITLE
2.0 P6e: verify custom Profile runtime candidates

### DIFF
--- a/desktop/lib/custom-engine-config.js
+++ b/desktop/lib/custom-engine-config.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const { readPrivateFileBounded } = require('./private-file');
+const {
+  PROTOCOL_FAMILY,
+  validateSchoolProfileDocument,
+} = require('./school-profile-schema');
+const { verifyWindowsFileOwnerOnly } = require('./windows-private-file');
+
+const CUSTOM_ENGINE_CONFIG_VERSION = 1;
+const MAX_CUSTOM_ENGINE_CONFIG_BYTES = 64 * 1024;
+
+function createCustomEngineConfigDocument(rawProfile) {
+  const profile = validateSchoolProfileDocument(rawProfile);
+  if (profile.evidenceClass !== 'custom-local' ||
+      profile.gateway.protocolFamily !== PROTOCOL_FAMILY ||
+      profile.gateway.engineConfigRef !== null ||
+      profile.policy.reviewedPrivateGatewayAllowed ||
+      profile.policy.reviewedDnsFallback.length) {
+    throw new TypeError('custom Engine config requires a minimal custom-local Profile');
+  }
+  return Object.freeze({
+    schema_version: CUSTOM_ENGINE_CONFIG_VERSION,
+    base_url: profile.gateway.origin.origin,
+    endpoints: Object.freeze({
+      discovery: '/por/login_auth.csp?apiversion=1',
+      logout: '/por/logout.csp?apiversion=1',
+      password_config: '/public/psw_config?apiversion=1',
+      password_login: '/por/login_psw.csp?anti_replay=1&encrypt=1&type=csp',
+      resource_list: '/por/rclist.csp?rnd=1234',
+      session_config: '/por/conf.csp',
+    }),
+    gateway_connector: Object.freeze({ reviewed_private_gateway_allowed: false }),
+    proxy: Object.freeze({
+      allow_system_dns_fallback: false,
+      vpn_dns_servers: Object.freeze([]),
+    }),
+    target: 'custom-local',
+    timeout_seconds: 15,
+    tunnel: Object.freeze({ mtu: 1400 }),
+    user_agent: 'EasyConnect_windows',
+  });
+}
+
+function serializeCustomEngineConfig(rawProfile) {
+  return Buffer.from(`${JSON.stringify(createCustomEngineConfigDocument(rawProfile), null, 2)}\n`, 'utf8');
+}
+
+function verifyCustomEngineConfigFile({
+  filePath,
+  profile,
+  fileSystem = fs,
+  platform = process.platform,
+  verifyWindowsAcl = verifyWindowsFileOwnerOnly,
+} = {}) {
+  if (typeof filePath !== 'string' || !filePath ||
+      (platform === 'win32' && typeof verifyWindowsAcl !== 'function')) {
+    throw new TypeError('custom Engine config verification inputs are invalid');
+  }
+  if (platform === 'win32' && !verifyWindowsAcl(filePath)) {
+    throw new Error('custom Engine config ACL is invalid');
+  }
+  const { data } = readPrivateFileBounded(filePath, {
+    maxBytes: MAX_CUSTOM_ENGINE_CONFIG_BYTES,
+    minBytes: 2,
+    platform,
+    fileSystem,
+  });
+  try {
+    let parsed;
+    try { parsed = JSON.parse(data.toString('utf8')); }
+    catch (error) { throw new Error('custom Engine config is invalid JSON', { cause: error }); }
+    const expected = createCustomEngineConfigDocument(profile);
+    if (JSON.stringify(parsed) !== JSON.stringify(expected)) {
+      throw new Error('custom Engine config does not match its compiled Profile binding');
+    }
+    return Object.freeze({
+      path: filePath,
+      sha256: crypto.createHash('sha256').update(data).digest('hex'),
+      gatewayOrigin: expected.base_url,
+      protocolFamily: PROTOCOL_FAMILY,
+    });
+  } finally {
+    data.fill(0);
+  }
+}
+
+module.exports = {
+  CUSTOM_ENGINE_CONFIG_VERSION,
+  MAX_CUSTOM_ENGINE_CONFIG_BYTES,
+  createCustomEngineConfigDocument,
+  serializeCustomEngineConfig,
+  verifyCustomEngineConfigFile,
+};

--- a/desktop/lib/custom-profile-provisioning-plan.js
+++ b/desktop/lib/custom-profile-provisioning-plan.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const crypto = require('node:crypto');
+const { createCustomEngineConfigDocument } = require('./custom-engine-config');
 const {
   validateLocalResourcesDocument,
   validateProfileSettingsDocument,
@@ -20,7 +21,7 @@ const {
 
 const CUSTOM_PROFILE_PROVISIONING_VERSION = 1;
 const CUSTOM_PROFILE_FILE_IDS = Object.freeze([
-  'schoolProfile', 'profileSettings', 'profileState', 'account',
+  'schoolProfile', 'engineConfig', 'profileSettings', 'profileState', 'account',
   'workspaceSettings', 'workspaceState', 'localResources', 'favorites',
   'recentResources', 'externalIntegrations',
 ]);
@@ -101,7 +102,7 @@ function createCustomProfileProvisioningPlan({
     throw new TypeError('consumed Gateway confirmation does not match its custom Profile');
   }
   const createdAt = timestamp(now());
-  const accountDocument = validateCampusAccountDocument({
+  const accountSourceDocument = {
     schemaVersion: 1,
     accountKey: keys.accountKey,
     accountRevision: 1,
@@ -116,7 +117,8 @@ function createCustomProfileProvisioningPlan({
     activeCredentialVersion: null,
     createdAt,
     updatedAt: createdAt,
-  });
+  };
+  const accountDocument = validateCampusAccountDocument(accountSourceDocument);
   const workspaceDocument = validateWorkspaceScopeDocument({
     schemaVersion: 1,
     profileId: profile.profileId,
@@ -135,6 +137,7 @@ function createCustomProfileProvisioningPlan({
   });
   const documents = {
     schoolProfile: consumed.profileDocument,
+    engineConfig: createCustomEngineConfigDocument(consumed.profileDocument),
     profileSettings: validateProfileSettingsDocument({
       schemaVersion: 1,
       profileId: profile.profileId,
@@ -150,7 +153,7 @@ function createCustomProfileProvisioningPlan({
       gatewayOrigin: profile.gateway.origin.origin,
       protocolFamily: profile.gateway.protocolFamily,
     }),
-    account: accountDocument,
+    account: accountSourceDocument,
     workspaceSettings: validateWorkspaceSettingsDocument({
       schemaVersion: 1,
       autoReconnect: true,
@@ -166,6 +169,7 @@ function createCustomProfileProvisioningPlan({
   };
   const paths = Object.freeze({
     schoolProfile: layout.profile.document,
+    engineConfig: layout.profile.engineConfig,
     profileSettings: layout.profile.settings,
     profileState: layout.profile.state,
     account: layout.account.document,

--- a/desktop/lib/custom-school-profile-registry.js
+++ b/desktop/lib/custom-school-profile-registry.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { verifyCustomEngineConfigFile } = require('./custom-engine-config');
+const { CustomProfileIndexStore } = require('./custom-profile-index');
+const { verifyPrivateDirectoryChain } = require('./private-directory');
+const { readPrivateFileBounded } = require('./private-file');
+const {
+  loadProfileWorkspaceAuthorityByKeys,
+} = require('./profile-workspace-runtime-authority');
+const { validateProfileSettingsDocument } = require('./profile-workspace-documents');
+const {
+  createSchoolProfileView,
+  validateSchoolProfileDocument,
+} = require('./school-profile-schema');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+const MAX_CUSTOM_PROFILE_DOCUMENT_BYTES = 256 * 1024;
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}
+
+class CustomSchoolProfileRegistry {
+  constructor({
+    userData,
+    indexStore = null,
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+  } = {}) {
+    if (typeof userData !== 'string' || !path.isAbsolute(userData) || path.resolve(userData) !== userData ||
+        !fileSystem || typeof fileSystem.openSync !== 'function' ||
+        !['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' && typeof windowsAcl?.verify !== 'function')) {
+      throw new TypeError('custom school Profile registry dependencies are invalid');
+    }
+    this.userData = userData;
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+    this.indexStore = indexStore || new CustomProfileIndexStore({
+      userData, fileSystem, platform, windowsAcl,
+    });
+    this.records = new Map();
+    this.loaded = false;
+  }
+
+  load() {
+    if (this.loaded) return this;
+    const records = new Map();
+    for (const indexEntry of this.indexStore.read().entries) {
+      const profileRoot = path.join(this.userData, 'profiles', indexEntry.profileKey);
+      verifyPrivateDirectoryChain(this.userData, profileRoot, {
+        fileSystem: this.fileSystem,
+        platform: this.platform,
+      });
+      const sourceDocument = this.#readJson(
+        path.join(profileRoot, 'school-profile.json'),
+        validateSchoolProfileDocument,
+      );
+      const profile = validateSchoolProfileDocument(sourceDocument);
+      if (profile.evidenceClass !== 'custom-local' || profile.profileId !== indexEntry.profileId) {
+        throw new Error('custom Profile document does not match its index');
+      }
+      const profileSettings = this.#readJson(
+        path.join(profileRoot, 'profile-settings.json'),
+        validateProfileSettingsDocument,
+      );
+      const authority = loadProfileWorkspaceAuthorityByKeys({
+        userData: this.userData,
+        profile: sourceDocument,
+        profileKey: indexEntry.profileKey,
+        accountKey: profileSettings.primaryAccountKey,
+        fileSystem: this.fileSystem,
+        platform: this.platform,
+        windowsAcl: this.windowsAcl,
+      });
+      const engineConfig = verifyCustomEngineConfigFile({
+        filePath: authority.layout.profile.engineConfig,
+        profile: sourceDocument,
+        fileSystem: this.fileSystem,
+        platform: this.platform,
+        verifyWindowsAcl: (file) => this.windowsAcl.verify(file),
+      });
+      records.set(profile.profileId, Object.freeze({
+        profile,
+        sourceDocument,
+        authority,
+        engineConfig,
+        indexEntry,
+        context: Object.freeze({
+          profileId: profile.profileId,
+          profileKey: indexEntry.profileKey,
+          profileRevision: profile.profileRevision,
+          profileCredentialBindingRevision: profile.profileCredentialBindingRevision,
+          accountKey: authority.account.accountKey,
+          accountRevision: authority.account.accountRevision,
+          accountCredentialRevision: authority.account.accountCredentialRevision,
+          workspaceKey: authority.account.workspaceKey,
+          activeContextEpoch: authority.workspaceState.activeContextEpoch,
+        }),
+      }));
+    }
+    this.records = records;
+    this.loaded = true;
+    return this;
+  }
+
+  reload() {
+    this.records = new Map();
+    this.loaded = false;
+    return this.load();
+  }
+
+  listViews(options = {}) {
+    this.load();
+    return Object.freeze([...this.records.values()].map((record) => (
+      createSchoolProfileView(record.sourceDocument, { ...options, compatibility: 'candidate' })
+    )));
+  }
+
+  withProfile(profileId, callback) {
+    this.load();
+    if (typeof callback !== 'function') throw new TypeError('custom Profile callback is required');
+    const record = this.records.get(String(profileId || ''));
+    if (!record) throw new Error('custom Profile is unavailable');
+    const result = callback(record);
+    if (result && typeof result.then === 'function') {
+      throw new TypeError('custom Profile callback must be synchronous');
+    }
+    return result;
+  }
+
+  createEngineLaunchBinding(profileId) {
+    return this.withProfile(profileId, (record) => {
+      const stdinFrame = JSON.stringify({
+        type: 'engine_config_binding',
+        apiVersion: 1,
+        configSha256: record.engineConfig.sha256,
+        gatewayOrigin: record.profile.gateway.origin.origin,
+        profileId: record.profile.profileId,
+        profileRevision: record.profile.profileRevision,
+        protocolFamily: record.profile.gateway.protocolFamily,
+      });
+      if (Buffer.byteLength(stdinFrame, 'utf8') > 1024) {
+        throw new Error('custom Engine Profile binding exceeds its private frame bound');
+      }
+      return Object.freeze({ path: record.engineConfig.path, stdinFrame });
+    });
+  }
+
+  #readJson(file, validator) {
+    verifyPrivateDirectoryChain(this.userData, path.dirname(file), {
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+    });
+    if (this.platform === 'win32' && !this.windowsAcl.verify(file)) {
+      throw new Error('custom Profile private file ACL is invalid');
+    }
+    const { data } = readPrivateFileBounded(file, {
+      maxBytes: MAX_CUSTOM_PROFILE_DOCUMENT_BYTES,
+      minBytes: 2,
+      platform: this.platform,
+      fileSystem: this.fileSystem,
+    });
+    try {
+      const value = JSON.parse(data.toString('utf8'));
+      validator(value);
+      return deepFreeze(value);
+    } catch (error) {
+      throw new Error('custom Profile private document is invalid', { cause: error });
+    } finally {
+      data.fill(0);
+    }
+  }
+}
+
+module.exports = { CustomSchoolProfileRegistry, MAX_CUSTOM_PROFILE_DOCUMENT_BYTES };

--- a/desktop/lib/private-directory.js
+++ b/desktop/lib/private-directory.js
@@ -11,9 +11,10 @@ function normalizedRoot(value) {
   return value;
 }
 
-function ensurePrivateDirectoryChain(rootValue, directoryValue, {
+function privateDirectoryChain(rootValue, directoryValue, {
   fileSystem = fs,
   platform = process.platform,
+  create = false,
 } = {}) {
   const root = normalizedRoot(rootValue);
   if (typeof directoryValue !== 'string' || !path.isAbsolute(directoryValue) ||
@@ -24,15 +25,17 @@ function ensurePrivateDirectoryChain(rootValue, directoryValue, {
   if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
     throw new TypeError('private directory escapes its root');
   }
-  try { fileSystem.mkdirSync(root, { recursive: true, mode: 0o700 }); }
-  catch (error) { throw new Error('private directory root could not be created', { cause: error }); }
+  if (create) {
+    try { fileSystem.mkdirSync(root, { recursive: true, mode: 0o700 }); }
+    catch (error) { throw new Error('private directory root could not be created', { cause: error }); }
+  }
   let current = root;
   for (const component of ['', ...relative.split(path.sep).filter(Boolean)]) {
     if (component) current = path.join(current, component);
     let stat;
     try { stat = fileSystem.lstatSync(current); }
     catch (error) {
-      if (error?.code !== 'ENOENT' || !component) throw error;
+      if (!create || error?.code !== 'ENOENT' || !component) throw error;
       fileSystem.mkdirSync(current, { mode: 0o700 });
       stat = fileSystem.lstatSync(current);
     }
@@ -42,6 +45,14 @@ function ensurePrivateDirectoryChain(rootValue, directoryValue, {
     }
   }
   return true;
+}
+
+function ensurePrivateDirectoryChain(root, directory, options = {}) {
+  return privateDirectoryChain(root, directory, { ...options, create: true });
+}
+
+function verifyPrivateDirectoryChain(root, directory, options = {}) {
+  return privateDirectoryChain(root, directory, { ...options, create: false });
 }
 
 function fsyncPrivateDirectory(directory, fileSystem = fs, platform = process.platform) {
@@ -59,4 +70,8 @@ function fsyncPrivateDirectory(directory, fileSystem = fs, platform = process.pl
   }
 }
 
-module.exports = { ensurePrivateDirectoryChain, fsyncPrivateDirectory };
+module.exports = {
+  ensurePrivateDirectoryChain,
+  fsyncPrivateDirectory,
+  verifyPrivateDirectoryChain,
+};

--- a/desktop/lib/profile-workspace-layout.js
+++ b/desktop/lib/profile-workspace-layout.js
@@ -76,6 +76,7 @@ function createProfileAccountRoots(root, keys) {
     profile: {
       root: profileRoot,
       document: path.join(profileRoot, 'school-profile.json'),
+      engineConfig: path.join(profileRoot, 'engine-config.json'),
       settings: path.join(profileRoot, 'profile-settings.json'),
       state: path.join(profileRoot, 'profile-state.json'),
     },

--- a/desktop/lib/profile-workspace-runtime-authority.js
+++ b/desktop/lib/profile-workspace-runtime-authority.js
@@ -256,9 +256,105 @@ function loadActiveProfileWorkspaceAuthority(options = {}) {
   });
 }
 
+function loadProfileWorkspaceAuthorityByKeys({
+  userData,
+  profile: rawProfile,
+  profileKey,
+  accountKey,
+  fileSystem = fs,
+  platform = process.platform,
+  windowsAcl = {
+    protect: protectWindowsFileOwnerOnly,
+    verify: verifyWindowsFileOwnerOnly,
+  },
+} = {}) {
+  const deps = authorityDependencies({
+    userData,
+    profile: rawProfile,
+    fileSystem,
+    platform,
+    windowsAcl,
+  });
+  const { root, profile } = deps;
+  const bootstrap = createProfileAccountBootstrapLayout({
+    userData: root,
+    profileKey,
+    accountKey,
+  });
+  const profileSettings = readDocument(
+    bootstrap.profile.settings,
+    validateProfileSettingsDocument,
+    deps,
+  );
+  const profileState = readDocument(
+    bootstrap.profile.state,
+    validateProfileStateDocument,
+    deps,
+  );
+  const account = readDocument(
+    bootstrap.account.document,
+    validateCampusAccountDocument,
+    deps,
+  );
+  equal(profileSettings.profileId, profile.profileId, 'Profile ID');
+  equal(profileSettings.profileRevision, profile.profileRevision, 'Profile revision');
+  equal(profileSettings.primaryAccountKey, accountKey, 'primary account');
+  equal(profileState.profileId, profile.profileId, 'Profile state ID');
+  equal(profileState.profileRevision, profile.profileRevision, 'Profile state revision');
+  equal(profileState.profileCredentialBindingRevision,
+    profile.profileCredentialBindingRevision, 'Profile credential revision');
+  equal(profileState.gatewayOrigin, profile.gateway.origin.origin, 'Gateway origin');
+  equal(profileState.protocolFamily, profile.gateway.protocolFamily, 'ProtocolFamily');
+  equal(account.accountKey, accountKey, 'account key');
+  equal(account.profileId, profile.profileId, 'account Profile ID');
+  equal(account.profileRevision, profile.profileRevision, 'account Profile revision');
+  equal(account.gatewayOrigin.origin, profile.gateway.origin.origin, 'account Gateway origin');
+  equal(account.protocolFamily, profile.gateway.protocolFamily, 'account ProtocolFamily');
+  if (account.role !== 'primary' || account.state !== 'enabled') {
+    throw new Error('Profile workspace account is not an enabled primary account');
+  }
+  const layout = createProfileAccountWorkspaceLayout({
+    userData: root,
+    profileKey,
+    accountKey,
+    workspaceKey: account.workspaceKey,
+    adoptLegacyHkustBrowserPartition: false,
+  });
+  const workspaceState = readDocument(
+    layout.workspace.state,
+    (value) => validateWorkspaceScopeDocument(value, { account }),
+    deps,
+  );
+  const workspaceSettings = readDocument(
+    layout.workspace.settings,
+    validateWorkspaceSettingsDocument,
+    deps,
+  );
+  const localResources = readDocument(
+    layout.workspace.localResources,
+    validateLocalResourcesDocument,
+    deps,
+  );
+  const observedCredential = credentialReceipt(layout.account.vpnCredential, deps);
+  equal(observedCredential.present, account.activeCredentialVersion !== null, 'credential presence');
+  return Object.freeze({
+    profile,
+    layout,
+    profileSettings,
+    profileState,
+    account,
+    workspaceState,
+    workspaceSettings,
+    localResources,
+    hasCredential: observedCredential.present,
+    credentialBinding: bindingFrom(profile, profileState, account),
+  });
+}
+
 module.exports = {
   MAX_RUNTIME_CREDENTIAL_BYTES,
   MAX_RUNTIME_DOCUMENT_BYTES,
   loadActiveProfileAccountAuthority,
   loadActiveProfileWorkspaceAuthority,
+  loadProfileWorkspaceAuthorityByKeys,
 };

--- a/desktop/test/custom-engine-config.test.js
+++ b/desktop/test/custom-engine-config.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  createCustomEngineConfigDocument,
+  serializeCustomEngineConfig,
+  verifyCustomEngineConfigFile,
+} = require('../lib/custom-engine-config');
+const { customProfileDocument } = require('../lib/custom-gateway-onboarding');
+
+function profile(origin = 'https://vpn.example.edu') {
+  return customProfileDocument({
+    profileId: `custom-${'1'.repeat(32)}`,
+    origin,
+    schoolLabel: 'Example University',
+  });
+}
+
+function directory(t) {
+  const value = fs.mkdtempSync(path.join(os.tmpdir(), 'custom-engine-config-'));
+  fs.chmodSync(value, 0o700);
+  t.after(() => fs.rmSync(value, { recursive: true, force: true }));
+  return value;
+}
+
+test('custom Engine config varies only by confirmed origin and has no reviewed school policy', () => {
+  const first = createCustomEngineConfigDocument(profile());
+  const second = createCustomEngineConfigDocument(profile('https://other.example.edu:444'));
+  assert.equal(first.base_url, 'https://vpn.example.edu');
+  assert.equal(second.base_url, 'https://other.example.edu:444');
+  assert.deepEqual({ ...first, base_url: second.base_url }, second);
+  assert.deepEqual(first.proxy.vpn_dns_servers, []);
+  assert.equal(first.proxy.allow_system_dns_fallback, false);
+  assert.equal(first.gateway_connector.reviewed_private_gateway_allowed, false);
+  assert.deepEqual(Object.keys(first.endpoints).sort(), [
+    'discovery', 'logout', 'password_config', 'password_login', 'resource_list', 'session_config',
+  ]);
+  const encoded = JSON.stringify(first);
+  for (const forbidden of ['10.90.63.2', 'hkust', 'packages', 'windows_installer', 'ca_file']) {
+    assert.equal(encoded.toLowerCase().includes(forbidden), false, forbidden);
+  }
+});
+
+test('owner-only config is re-read and hash-bound before Engine launch', (t) => {
+  const root = directory(t);
+  const file = path.join(root, 'engine-config.json');
+  const source = profile();
+  fs.writeFileSync(file, serializeCustomEngineConfig(source), { mode: 0o600 });
+  const verified = verifyCustomEngineConfigFile({ filePath: file, profile: source });
+  assert.equal(verified.gatewayOrigin, 'https://vpn.example.edu');
+  assert.match(verified.sha256, /^[a-f0-9]{64}$/u);
+
+  const tampered = JSON.parse(fs.readFileSync(file, 'utf8'));
+  tampered.endpoints.password_login = '/attacker-controlled';
+  fs.writeFileSync(file, `${JSON.stringify(tampered)}\n`, { mode: 0o600 });
+  assert.throws(() => verifyCustomEngineConfigFile({ filePath: file, profile: source }),
+    /compiled Profile binding/u);
+});
+
+test('custom Engine config rejects links broad permissions and reviewed Profiles', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const root = directory(t);
+  const source = profile();
+  const file = path.join(root, 'engine-config.json');
+  fs.writeFileSync(file, serializeCustomEngineConfig(source), { mode: 0o644 });
+  assert.throws(() => verifyCustomEngineConfigFile({ filePath: file, profile: source }),
+    /private file/u);
+  fs.unlinkSync(file);
+  const outside = path.join(root, 'outside.json');
+  fs.writeFileSync(outside, serializeCustomEngineConfig(source), { mode: 0o600 });
+  fs.symlinkSync(outside, file);
+  assert.throws(() => verifyCustomEngineConfigFile({ filePath: file, profile: source }),
+    /private file/u);
+
+  const reviewed = JSON.parse(JSON.stringify(source));
+  reviewed.evidenceClass = 'builtin-reviewed';
+  assert.throws(() => createCustomEngineConfigDocument(reviewed));
+});

--- a/desktop/test/custom-profile-provisioning-plan.test.js
+++ b/desktop/test/custom-profile-provisioning-plan.test.js
@@ -68,7 +68,11 @@ test('confirmed custom Gateway produces one credential-free isolated destination
     assert.equal(plan.context.activeContextEpoch, 1);
     assert.equal(plan.layout.browserPartition.startsWith('persist:campus-workspace-'), true);
     assert.notEqual(plan.layout.browserPartition, 'persist:hkustgz-campus-browser');
-    assert.equal(Object.keys(plan.files).length, 10);
+    assert.equal(Object.keys(plan.files).length, 11);
+    const engineConfig = JSON.parse(plan.files.engineConfig.toString('utf8'));
+    assert.equal(engineConfig.base_url, 'https://vpn.example.edu');
+    assert.deepEqual(engineConfig.proxy.vpn_dns_servers, []);
+    assert.equal(engineConfig.gateway_connector.reviewed_private_gateway_allowed, false);
     for (const [name, file] of Object.entries(plan.paths)) {
       assert.equal(path.isAbsolute(file), true, name);
       assert.equal(path.relative(userData, file).startsWith('..'), false, name);

--- a/desktop/test/custom-school-profile-registry.test.js
+++ b/desktop/test/custom-school-profile-registry.test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { CustomGatewayConfirmationOwner } = require('../lib/custom-gateway-onboarding');
+const { CustomProfileProvisioningRuntime } = require('../lib/custom-profile-provisioning-runtime');
+const { CustomSchoolProfileRegistry } = require('../lib/custom-school-profile-registry');
+const { PROTOCOL_FAMILY } = require('../lib/school-profile-schema');
+
+function root(t) {
+  const value = fs.mkdtempSync(path.join(os.tmpdir(), 'custom-school-registry-'));
+  fs.chmodSync(value, 0o700);
+  t.after(() => fs.rmSync(value, { recursive: true, force: true }));
+  return value;
+}
+
+function provision(userData) {
+  let seed = 1;
+  const owner = new CustomGatewayConfirmationOwner({
+    randomBytes: (length) => Buffer.alloc(length, seed++),
+    now: () => 1_800_000_000_000,
+    ttlMs: 10_000,
+  });
+  const context = {
+    profileId: 'hkustgz', profileRevision: 1,
+    accountHandle: `account-${'a'.repeat(36)}`, activeContextEpoch: 7,
+  };
+  const view = owner.issue({
+    probeResult: {
+      schema_version: 1,
+      normalized_origin: 'https://vpn.example.edu',
+      https_identity_valid: true,
+      compatibility: 'recognized_candidate',
+      candidate_family: PROTOCOL_FAMILY,
+      reported_version: 'M7.6.8R2',
+      http_status: 200,
+    },
+    schoolLabel: 'Example University',
+    activeContext: context,
+  });
+  const confirmation = owner.consume({
+    confirmationHandle: view.confirmationHandle,
+    activeContext: context,
+  });
+  let provisionSeed = 50;
+  return new CustomProfileProvisioningRuntime({
+    userData,
+    randomBytes: (length) => Buffer.alloc(length, ++provisionSeed),
+    now: () => 1_800_000_000_100,
+  }).begin(confirmation);
+}
+
+test('registry verifies one inactive custom Profile authority and exposes only a sanitized view', (t) => {
+  const userData = root(t);
+  const provisioned = provision(userData);
+  const registry = new CustomSchoolProfileRegistry({ userData }).load();
+  const views = registry.listViews({ locale: 'en' });
+  assert.equal(views.length, 1);
+  assert.equal(views[0].profileId, provisioned.profileId);
+  assert.equal(views[0].normalizedGatewayOrigin, 'https://vpn.example.edu');
+  assert.equal(views[0].sanitizedCompatibility, 'candidate');
+  assert.equal(views[0].unverified, true);
+  const encodedView = JSON.stringify(views);
+  for (const forbidden of ['profileKey', 'accountKey', 'workspaceKey', 'engine-config.json']) {
+    assert.equal(encodedView.includes(forbidden), false, forbidden);
+  }
+
+  registry.withProfile(provisioned.profileId, (record) => {
+    assert.deepEqual(record.context, provisioned.context);
+    assert.equal(record.authority.hasCredential, false);
+    assert.equal(record.authority.workspaceSettings.autoConnect, false);
+    assert.deepEqual(record.authority.workspaceSettings.routeDomains, []);
+    assert.equal(record.engineConfig.gatewayOrigin, 'https://vpn.example.edu');
+    assert.equal(record.engineConfig.protocolFamily, PROTOCOL_FAMILY);
+  });
+  const launch = registry.createEngineLaunchBinding(provisioned.profileId);
+  const binding = JSON.parse(launch.stdinFrame);
+  assert.equal(binding.profileId, provisioned.profileId);
+  assert.equal(binding.gatewayOrigin, 'https://vpn.example.edu');
+  assert.match(binding.configSha256, /^[a-f0-9]{64}$/u);
+  assert.equal(launch.path.endsWith('engine-config.json'), true);
+  for (const forbidden of ['accountKey', 'workspaceKey', '"password":']) {
+    assert.equal(launch.stdinFrame.includes(forbidden), false, forbidden);
+  }
+});
+
+test('registry fails closed on Profile Engine config and index binding drift', (t) => {
+  for (const target of ['profile', 'engine', 'index']) {
+    const userData = path.join(root(t), target);
+    fs.mkdirSync(userData, { mode: 0o700 });
+    const provisioned = provision(userData);
+    const profileRoot = path.join(userData, 'profiles', provisioned.context.profileKey);
+    if (target === 'profile') {
+      const file = path.join(profileRoot, 'school-profile.json');
+      const value = JSON.parse(fs.readFileSync(file, 'utf8'));
+      value.gateway.origin = 'https://other.example.edu';
+      fs.writeFileSync(file, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+    } else if (target === 'engine') {
+      const file = path.join(profileRoot, 'engine-config.json');
+      const value = JSON.parse(fs.readFileSync(file, 'utf8'));
+      value.endpoints.password_login = '/changed';
+      fs.writeFileSync(file, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+    } else {
+      const file = path.join(userData, 'global', 'custom-profile-index.json');
+      const value = JSON.parse(fs.readFileSync(file, 'utf8'));
+      value.entries[0].profileId = `custom-${'9'.repeat(32)}`;
+      fs.writeFileSync(file, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+    }
+    assert.throws(() => new CustomSchoolProfileRegistry({ userData }).load(),
+      /does not match|binding|active workspace/u, target);
+  }
+});
+
+test('registry callback is synchronous and nested source data is immutable', (t) => {
+  const userData = root(t);
+  const provisioned = provision(userData);
+  const registry = new CustomSchoolProfileRegistry({ userData }).load();
+  registry.withProfile(provisioned.profileId, (record) => {
+    assert.equal(Object.isFrozen(record.sourceDocument.gateway), true);
+    assert.throws(() => { record.sourceDocument.gateway.origin = 'https://changed.invalid'; });
+  });
+  assert.throws(() => registry.withProfile(provisioned.profileId, async () => true), /synchronous/u);
+  assert.throws(() => registry.withProfile('custom-missing', () => true), /unavailable/u);
+});

--- a/docs/adr/0023-custom-profile-provisioning.md
+++ b/docs/adr/0023-custom-profile-provisioning.md
@@ -8,9 +8,10 @@
 
 Consuming a Main-owned Gateway confirmation produces one deterministic plan
 with fresh opaque `profileKey`, `accountKey`, `workspaceKey` and provisioning
-identity. The plan contains exactly ten owner-only JSON targets:
+identity. The plan contains exactly eleven owner-only JSON targets:
 
 - the raw `custom-local` SchoolProfile source document;
+- a compiled-family Engine config bound to the confirmed origin;
 - Profile settings and immutable Profile state;
 - one credential-free primary CampusAccount;
 - Workspace settings and Workspace scope;

--- a/docs/adr/0024-custom-profile-runtime-candidate.md
+++ b/docs/adr/0024-custom-profile-runtime-candidate.md
@@ -1,0 +1,51 @@
+# ADR-0024: Verified inactive custom Profile runtime candidate
+
+- Status: Accepted for 2.0 P6e
+- Scope: persisted custom Profile loading and Engine launch binding
+- Production selection, credential entry and active switch: deferred
+
+## Decision
+
+Every provisioned custom Profile stores a compiled-family Engine config as an
+eleventh receipt-bound owner-only target. User/Profile data selects only the
+confirmed HTTPS root origin. The following remain compiled code:
+
+- EasyConnect password/Modern-L3 protocol family;
+- discovery, password configuration, login, logout, session configuration and
+  resource-list paths;
+- standard user agent, timeout and MTU;
+- disabled environment/system DNS fallback;
+- empty reviewed DNS fallback;
+- disabled private-Gateway exception.
+
+Custom JSON cannot provide endpoint paths, CA files, scripts, package URLs,
+private DNS or transport plugins.
+
+`CustomSchoolProfileRegistry` loads only entries in the owner-only additive
+index. It reopens the raw SchoolProfile, ProfileState, ProfileSettings,
+CampusAccount, WorkspaceScope, WorkspaceSettings, local resources and Engine
+config through link-free owner-only paths. It verifies every Profile revision,
+Gateway origin, ProtocolFamily, Account/Workspace relationship and credential
+presence before returning an internal candidate.
+
+The Engine config is reconstructed from compiled code and compared exactly with
+the persisted JSON. Its SHA-256, origin, Profile ID/revision and family form the
+same private `engine_config_binding` frame already rechecked by Rust before
+credential input.
+
+## Presentation boundary
+
+Renderer-facing enumeration contains only `SchoolProfileView` fields and the
+visible `custom-local`/unverified candidate status. Opaque profile/account/
+workspace keys, Engine config path, endpoint set and credential state remain in
+Main. The registry's internal callback is synchronous and its nested source
+document is immutable.
+
+## Activation boundary
+
+Loading a candidate does not write GlobalSettings, create an
+`ActiveContextLease`, open a Browser partition or start an Engine. The next P6
+slice must compose this candidate with the existing P4 cleanup and two-target
+activation journal. Only after activation may a credential transaction bind a
+username/password envelope to this Profile, Account revision, origin and
+ProtocolFamily.


### PR DESCRIPTION
## Summary

- provision an eleventh receipt-bound custom Engine config generated only from compiled EasyConnect constants plus the confirmed HTTPS origin
- keep system DNS fallback, reviewed DNS fallback and private-Gateway exceptions disabled for every custom Profile
- add an inactive custom Profile registry that reopens and cross-validates Profile, Account, Workspace, credential presence, index authority and Engine config after restart
- generate the same private hash/origin/Profile/family Engine binding frame rechecked by Rust before credential input
- add a key-addressed inactive authority loader without changing the existing HKUST active-authority path
- fix persisted CampusAccount to store the source GatewayOrigin string rather than its in-memory normalized object

## Validation

- Desktop: 825 passed, 0 failed, 1 explicit Windows-only skip
- provision → process-style registry reopen: PASS
- Profile/index/origin/endpoint tamper failures: PASS
- architecture gate: PASS (0 cycles, unchanged Main caps)
- tracked secret and syntax gates: PASS

## Boundary

The custom candidate remains inactive and credential-free. Main composition, active-context switch, probe binary packaging and UI are later P6 slices; persistent context keys never enter the Renderer view or Engine binding frame.