### PR TITLE
2.0 P6f: compose restart-safe Profile switching

### DIFF
--- a/desktop/lib/profile-candidate-directory.js
+++ b/desktop/lib/profile-candidate-directory.js
@@ -1,0 +1,181 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { CustomSchoolProfileRegistry } = require('./custom-school-profile-registry');
+const {
+  loadProfileWorkspaceAuthorityByKeys,
+} = require('./profile-workspace-runtime-authority');
+const { ReviewedProfileAnchorStore } = require('./reviewed-profile-anchor-store');
+const { SchoolProfileRegistry } = require('./school-profile-registry');
+const { verifyEngineConfigBinding } = require('./school-profile-runtime');
+const {
+  createSchoolProfileView,
+  validateSchoolProfileDocument,
+} = require('./school-profile-schema');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+function engineLaunchBinding(record) {
+  const stdinFrame = JSON.stringify({
+    type: 'engine_config_binding',
+    apiVersion: 1,
+    configSha256: record.engineConfig.sha256,
+    gatewayOrigin: record.profile.gateway.origin.origin,
+    profileId: record.profile.profileId,
+    profileRevision: record.profile.profileRevision,
+    protocolFamily: record.profile.gateway.protocolFamily,
+  });
+  if (Buffer.byteLength(stdinFrame, 'utf8') > 1024) {
+    throw new Error('Profile candidate Engine binding exceeds its private frame bound');
+  }
+  return Object.freeze({ path: record.engineConfig.path, stdinFrame });
+}
+
+class ProfileCandidateDirectory {
+  constructor({
+    userData,
+    packageRoot,
+    isPackaged = false,
+    resourcesPath = '',
+    desktopDir,
+    packagedRegistry = null,
+    customRegistry = null,
+    anchorStore = null,
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+  } = {}) {
+    if (typeof userData !== 'string' || !path.isAbsolute(userData) || path.resolve(userData) !== userData ||
+        typeof packageRoot !== 'string' || !path.isAbsolute(packageRoot) ||
+        typeof desktopDir !== 'string' || !path.isAbsolute(desktopDir) ||
+        typeof isPackaged !== 'boolean' ||
+        (isPackaged && (typeof resourcesPath !== 'string' || !path.isAbsolute(resourcesPath)))) {
+      throw new TypeError('Profile candidate directory paths are invalid');
+    }
+    this.userData = userData;
+    this.isPackaged = isPackaged;
+    this.resourcesPath = resourcesPath;
+    this.desktopDir = desktopDir;
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+    this.packagedRegistry = packagedRegistry || new SchoolProfileRegistry({
+      packageRoot, fsImpl: fileSystem, platform,
+    }).load();
+    this.customRegistry = customRegistry || new CustomSchoolProfileRegistry({
+      userData, fileSystem, platform, windowsAcl,
+    });
+    this.anchorStore = anchorStore || new ReviewedProfileAnchorStore({
+      userData, fileSystem, platform, windowsAcl,
+    });
+  }
+
+  anchorReviewedCurrent({ profileId, profileKey, accountKey } = {}) {
+    const sourceDocument = this.packagedRegistry.withProfileDocument(profileId, (value) => value);
+    const profile = validateSchoolProfileDocument(sourceDocument);
+    if (profile.evidenceClass !== 'builtin-reviewed') {
+      throw new TypeError('only a packaged reviewed Profile can be anchored');
+    }
+    const authority = loadProfileWorkspaceAuthorityByKeys({
+      userData: this.userData,
+      profile: sourceDocument,
+      profileKey,
+      accountKey,
+      adoptLegacyHkustBrowserPartition: profile.profileId === 'hkustgz',
+      fileSystem: this.fileSystem,
+      platform: this.platform,
+      windowsAcl: this.windowsAcl,
+    });
+    this.anchorStore.ensure({
+      profileId: profile.profileId,
+      profileKey,
+      accountKey,
+      createdAt: authority.account.createdAt,
+    });
+    return this.#reviewedRecord(sourceDocument, authority);
+  }
+
+  listViews(options = {}) {
+    const reviewed = this.anchorStore.read().entries.map((anchor) => (
+      this.packagedRegistry.createView(anchor.profileId, { ...options, compatibility: 'reviewed' })
+    ));
+    const custom = this.customRegistry.reload().listViews(options);
+    return Object.freeze([...reviewed, ...custom]);
+  }
+
+  withCandidate(profileId, callback) {
+    if (typeof callback !== 'function') throw new TypeError('Profile candidate callback is required');
+    const anchor = this.anchorStore.get(profileId);
+    let record;
+    if (anchor) {
+      record = this.packagedRegistry.withProfileDocument(profileId, (sourceDocument) => {
+        const profile = validateSchoolProfileDocument(sourceDocument);
+        const authority = loadProfileWorkspaceAuthorityByKeys({
+          userData: this.userData,
+          profile: sourceDocument,
+          profileKey: anchor.profileKey,
+          accountKey: anchor.accountKey,
+          adoptLegacyHkustBrowserPartition: profile.profileId === 'hkustgz',
+          fileSystem: this.fileSystem,
+          platform: this.platform,
+          windowsAcl: this.windowsAcl,
+        });
+        return this.#reviewedRecord(sourceDocument, authority);
+      });
+    } else {
+      record = this.customRegistry.reload().withProfile(profileId, (custom) => Object.freeze({
+        ...custom,
+        kind: 'custom-local',
+        view: createSchoolProfileView(custom.sourceDocument, {
+          locale: 'en', compatibility: 'candidate',
+        }),
+        engineLaunchBinding: engineLaunchBinding(custom),
+      }));
+    }
+    const result = callback(record);
+    if (result && typeof result.then === 'function') {
+      throw new TypeError('Profile candidate callback must be synchronous');
+    }
+    return result;
+  }
+
+  #reviewedRecord(sourceDocument, authority) {
+    const profile = validateSchoolProfileDocument(sourceDocument);
+    const engineConfig = verifyEngineConfigBinding({
+      registry: this.packagedRegistry,
+      profile,
+      isPackaged: this.isPackaged,
+      resourcesPath: this.resourcesPath,
+      desktopDir: this.desktopDir,
+      fsImpl: this.fileSystem,
+    });
+    const record = Object.freeze({
+      kind: 'builtin-reviewed',
+      profile,
+      sourceDocument,
+      authority,
+      engineConfig,
+      context: Object.freeze({
+        profileId: profile.profileId,
+        profileKey: authority.layout.identity.profileKey,
+        profileRevision: profile.profileRevision,
+        profileCredentialBindingRevision: profile.profileCredentialBindingRevision,
+        accountKey: authority.account.accountKey,
+        accountRevision: authority.account.accountRevision,
+        accountCredentialRevision: authority.account.accountCredentialRevision,
+        workspaceKey: authority.account.workspaceKey,
+        activeContextEpoch: authority.workspaceState.activeContextEpoch,
+      }),
+      view: createSchoolProfileView(sourceDocument, { locale: 'en', compatibility: 'reviewed' }),
+    });
+    return Object.freeze({ ...record, engineLaunchBinding: engineLaunchBinding(record) });
+  }
+}
+
+module.exports = { ProfileCandidateDirectory, engineLaunchBinding };

--- a/desktop/lib/profile-switch-runtime.js
+++ b/desktop/lib/profile-switch-runtime.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const { ActiveContextSwitchSystem } = require('./active-context-switch-system');
+
+function requiredFunction(value, name) {
+  if (typeof value !== 'function') throw new TypeError(`${name} must be a function`);
+  return value;
+}
+
+function sameContext(left, right) {
+  return Boolean(left && right && [
+    'profileId', 'profileKey', 'profileRevision', 'profileCredentialBindingRevision',
+    'accountKey', 'accountRevision', 'accountCredentialRevision', 'workspaceKey',
+    'activeContextEpoch',
+  ].every((key) => left[key] === right[key]));
+}
+
+class ProfileSwitchRuntime {
+  constructor({
+    directory,
+    journalStore,
+    activationStore,
+    barrier,
+    getActivePersistentContext,
+    getEngineGeneration,
+    activateRuntime,
+    SwitchSystemClass = ActiveContextSwitchSystem,
+  } = {}) {
+    if (!directory || typeof directory.withCandidate !== 'function' ||
+        !activationStore || typeof activationStore.plan !== 'function' ||
+        typeof SwitchSystemClass !== 'function') {
+      throw new TypeError('Profile switch runtime dependencies are invalid');
+    }
+    this.directory = directory;
+    this.activationStore = activationStore;
+    this.getActivePersistentContext = requiredFunction(
+      getActivePersistentContext,
+      'getActivePersistentContext',
+    );
+    this.getEngineGeneration = requiredFunction(getEngineGeneration, 'getEngineGeneration');
+    this.activateRuntime = requiredFunction(activateRuntime, 'activateRuntime');
+    this.system = new SwitchSystemClass({
+      journalStore,
+      activationStore,
+      barrier,
+      validateSource: (journal) => this.#validateSource(journal),
+      validateDestination: (journal) => this.#validateDestination(journal),
+      activateRuntime: (journal) => this.#activate(journal),
+    });
+  }
+
+  switchTo(profileId) {
+    const from = this.getActivePersistentContext();
+    const record = this.#candidate(profileId);
+    const to = record.context;
+    if (sameContext(from, to) || from.profileId === to.profileId) {
+      throw new Error('requested Profile is already active');
+    }
+    const nextActiveContextEpoch = Math.max(
+      from.activeContextEpoch,
+      to.activeContextEpoch,
+    ) + 1;
+    if (!Number.isSafeInteger(nextActiveContextEpoch)) {
+      throw new Error('next active context epoch is invalid');
+    }
+    const engineGeneration = this.getEngineGeneration();
+    if (engineGeneration !== null &&
+        (!Number.isSafeInteger(engineGeneration) || engineGeneration <= 0)) {
+      throw new TypeError('active Engine generation is invalid');
+    }
+    const activation = this.activationStore.plan({
+      from,
+      to,
+      nextActiveContextEpoch,
+    });
+    return this.system.begin({
+      from,
+      to,
+      nextActiveContextEpoch,
+      engineGeneration,
+      activation,
+    });
+  }
+
+  recover() { return this.system.recover(); }
+
+  #validateSource(journal) {
+    if (!sameContext(this.getActivePersistentContext(), journal.from)) return false;
+    return this.directory.withCandidate(journal.from.profileId, (record) => (
+      sameContext(record.context, journal.from)
+    ));
+  }
+
+  #validateDestination(journal) {
+    return this.directory.withCandidate(journal.to.profileId, (record) => (
+      sameContext(record.context, journal.to)
+    ));
+  }
+
+  #activate(journal) {
+    return this.activateRuntime(this.#candidate(journal.to.profileId), journal);
+  }
+
+  #candidate(profileId) {
+    let candidate = null;
+    this.directory.withCandidate(profileId, (record) => { candidate = record; });
+    if (!candidate) throw new Error('Profile candidate is unavailable');
+    return candidate;
+  }
+}
+
+module.exports = { ProfileSwitchRuntime, samePersistentContext: sameContext };

--- a/desktop/lib/profile-workspace-runtime-authority.js
+++ b/desktop/lib/profile-workspace-runtime-authority.js
@@ -261,6 +261,7 @@ function loadProfileWorkspaceAuthorityByKeys({
   profile: rawProfile,
   profileKey,
   accountKey,
+  adoptLegacyHkustBrowserPartition = false,
   fileSystem = fs,
   platform = process.platform,
   windowsAcl = {
@@ -318,7 +319,7 @@ function loadProfileWorkspaceAuthorityByKeys({
     profileKey,
     accountKey,
     workspaceKey: account.workspaceKey,
-    adoptLegacyHkustBrowserPartition: false,
+    adoptLegacyHkustBrowserPartition,
   });
   const workspaceState = readDocument(
     layout.workspace.state,

--- a/desktop/lib/reviewed-profile-anchor-store.js
+++ b/desktop/lib/reviewed-profile-anchor-store.js
@@ -1,0 +1,186 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { atomicWritePrivateFile } = require('./credential-store');
+const { ensurePrivateDirectoryChain } = require('./private-directory');
+const { readPrivateFileBounded } = require('./private-file');
+const {
+  validateOpaqueKey,
+  validateProfileId,
+} = require('./school-profile-schema');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+
+const REVIEWED_PROFILE_ANCHOR_VERSION = 1;
+const MAX_REVIEWED_PROFILE_ANCHORS = 16;
+const MAX_REVIEWED_PROFILE_ANCHOR_BYTES = 256 * 1024;
+
+function plainObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+  return value;
+}
+
+function exactKeys(value, keys, name) {
+  const source = plainObject(value, name);
+  const actual = Object.keys(source).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${name} has an invalid schema`);
+  }
+  return source;
+}
+
+function anchor(value) {
+  const source = exactKeys(value, [
+    'profileId', 'profileKey', 'accountKey', 'createdAt',
+  ], 'reviewed Profile anchor');
+  if (!Number.isSafeInteger(source.createdAt) || source.createdAt <= 0) {
+    throw new TypeError('reviewed Profile anchor timestamp is invalid');
+  }
+  const result = Object.freeze({
+    profileId: validateProfileId(source.profileId),
+    profileKey: validateOpaqueKey(source.profileKey, 'reviewed Profile profileKey'),
+    accountKey: validateOpaqueKey(source.accountKey, 'reviewed Profile accountKey'),
+    createdAt: source.createdAt,
+  });
+  if (result.profileKey === result.accountKey) {
+    throw new TypeError('reviewed Profile anchor keys must be distinct');
+  }
+  return result;
+}
+
+function document(value) {
+  const source = exactKeys(value, ['schemaVersion', 'entries'], 'reviewed Profile anchors');
+  if (source.schemaVersion !== REVIEWED_PROFILE_ANCHOR_VERSION || !Array.isArray(source.entries) ||
+      source.entries.length > MAX_REVIEWED_PROFILE_ANCHORS) {
+    throw new TypeError('reviewed Profile anchors have an invalid version or count');
+  }
+  const entries = source.entries.map(anchor);
+  if (new Set(entries.map((value) => value.profileId)).size !== entries.length ||
+      new Set(entries.map((value) => value.profileKey)).size !== entries.length ||
+      new Set(entries.map((value) => value.accountKey)).size !== entries.length) {
+    throw new TypeError('reviewed Profile anchors contain duplicate authority');
+  }
+  return Object.freeze({ schemaVersion: REVIEWED_PROFILE_ANCHOR_VERSION, entries: Object.freeze(entries) });
+}
+
+function serialize(value) {
+  const data = Buffer.from(`${JSON.stringify(document(value))}\n`, 'utf8');
+  if (data.length < 2 || data.length > MAX_REVIEWED_PROFILE_ANCHOR_BYTES) {
+    data.fill(0);
+    throw new TypeError('reviewed Profile anchors exceed their storage bound');
+  }
+  return data;
+}
+
+class ReviewedProfileAnchorStore {
+  constructor({
+    userData,
+    fileSystem = fs,
+    platform = process.platform,
+    windowsAcl = {
+      protect: protectWindowsFileOwnerOnly,
+      verify: verifyWindowsFileOwnerOnly,
+    },
+  } = {}) {
+    if (typeof userData !== 'string' || !path.isAbsolute(userData) || path.resolve(userData) !== userData ||
+        !fileSystem || typeof fileSystem.openSync !== 'function' ||
+        !['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' && (typeof windowsAcl?.protect !== 'function' ||
+          typeof windowsAcl?.verify !== 'function'))) {
+      throw new TypeError('reviewed Profile anchor store dependencies are invalid');
+    }
+    this.userData = userData;
+    this.filePath = path.join(userData, 'global', 'reviewed-profile-anchors.json');
+    this.fileSystem = fileSystem;
+    this.platform = platform;
+    this.windowsAcl = windowsAcl;
+  }
+
+  read() {
+    try { this.fileSystem.lstatSync(this.filePath); }
+    catch (error) {
+      if (error?.code === 'ENOENT') {
+        return document({ schemaVersion: REVIEWED_PROFILE_ANCHOR_VERSION, entries: [] });
+      }
+      throw error;
+    }
+    if (this.platform === 'win32' && !this.windowsAcl.verify(this.filePath)) {
+      throw new Error('reviewed Profile anchor ACL is invalid');
+    }
+    const { data } = readPrivateFileBounded(this.filePath, {
+      maxBytes: MAX_REVIEWED_PROFILE_ANCHOR_BYTES,
+      minBytes: 2,
+      platform: this.platform,
+      fileSystem: this.fileSystem,
+    });
+    try { return document(JSON.parse(data.toString('utf8'))); }
+    catch (error) { throw new Error('reviewed Profile anchors are invalid', { cause: error }); }
+    finally { data.fill(0); }
+  }
+
+  ensure(value) {
+    const next = anchor(value);
+    const current = this.read();
+    const existing = current.entries.find((entry) => entry.profileId === next.profileId);
+    if (existing) {
+      if (JSON.stringify(existing) !== JSON.stringify(next)) {
+        throw new Error('reviewed Profile anchor identity changed');
+      }
+      return false;
+    }
+    if (current.entries.some((entry) => entry.profileKey === next.profileKey ||
+        entry.accountKey === next.accountKey) || current.entries.length >= MAX_REVIEWED_PROFILE_ANCHORS) {
+      throw new Error('reviewed Profile anchor authority is already owned');
+    }
+    const updated = document({
+      schemaVersion: REVIEWED_PROFILE_ANCHOR_VERSION,
+      entries: [...current.entries, next].sort((left, right) => (
+        left.createdAt - right.createdAt || left.profileId.localeCompare(right.profileId)
+      )),
+    });
+    const data = serialize(updated);
+    try {
+      ensurePrivateDirectoryChain(this.userData, path.dirname(this.filePath), {
+        fileSystem: this.fileSystem,
+        platform: this.platform,
+      });
+      const options = this.platform === 'win32' ? {
+        protectTemporary: (file) => this.windowsAcl.protect(file) === true,
+        verifyCommitted: (file) => this.windowsAcl.verify(file) === true,
+        removeCommittedOnFailure: true,
+      } : {};
+      const written = atomicWritePrivateFile(this.filePath, data, this.fileSystem, options);
+      const observed = this.read();
+      if (JSON.stringify(observed) !== JSON.stringify(updated)) {
+        throw new Error('reviewed Profile anchor commit was not confirmed');
+      }
+      if (!written) {
+        const result = new Error('reviewed Profile anchor durability is unconfirmed');
+        result.commitApplied = true;
+        throw result;
+      }
+      return true;
+    } finally {
+      data.fill(0);
+    }
+  }
+
+  get(profileId) {
+    const id = validateProfileId(profileId);
+    return this.read().entries.find((entry) => entry.profileId === id) || null;
+  }
+}
+
+module.exports = {
+  MAX_REVIEWED_PROFILE_ANCHORS,
+  REVIEWED_PROFILE_ANCHOR_VERSION,
+  ReviewedProfileAnchorStore,
+  validateReviewedProfileAnchorDocument: document,
+};

--- a/desktop/test/profile-candidate-directory.test.js
+++ b/desktop/test/profile-candidate-directory.test.js
@@ -1,0 +1,247 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { CustomGatewayConfirmationOwner } = require('../lib/custom-gateway-onboarding');
+const { ActiveContextActivationStore } = require('../lib/active-context-activation-store');
+const { ActiveContextSwitchBarrier } = require('../lib/active-context-switch-barrier');
+const { ActiveContextSwitchJournalStore } = require('../lib/active-context-switch-store');
+const { CustomProfileProvisioningRuntime } = require('../lib/custom-profile-provisioning-runtime');
+const { ProfileCandidateDirectory } = require('../lib/profile-candidate-directory');
+const { ProfileSwitchRuntime } = require('../lib/profile-switch-runtime');
+const { createProfileAccountWorkspaceLayout } = require('../lib/profile-workspace-layout');
+const { ReviewedProfileAnchorStore } = require('../lib/reviewed-profile-anchor-store');
+const { PROTOCOL_FAMILY } = require('../lib/school-profile-schema');
+
+const DESKTOP = path.join(__dirname, '..');
+const PROFILE_KEY = `profile-${'11'.repeat(16)}`;
+const ACCOUNT_KEY = `account-${'22'.repeat(16)}`;
+const WORKSPACE_KEY = `workspace-${'33'.repeat(16)}`;
+
+function root(t) {
+  const value = fs.mkdtempSync(path.join(os.tmpdir(), 'profile-candidate-directory-'));
+  fs.chmodSync(value, 0o700);
+  t.after(() => fs.rmSync(value, { recursive: true, force: true }));
+  return value;
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+}
+
+function reviewedAuthority(userData) {
+  const layout = createProfileAccountWorkspaceLayout({
+    userData,
+    profileKey: PROFILE_KEY,
+    accountKey: ACCOUNT_KEY,
+    workspaceKey: WORKSPACE_KEY,
+    adoptLegacyHkustBrowserPartition: true,
+  });
+  const createdAt = 1_700_000_000_000;
+  writeJson(layout.profile.settings, {
+    schemaVersion: 1, profileId: 'hkustgz', profileRevision: 1,
+    primaryAccountKey: ACCOUNT_KEY,
+  });
+  writeJson(layout.profile.state, {
+    schemaVersion: 1, migrationId: `migration-${'44'.repeat(16)}`,
+    profileId: 'hkustgz', profileRevision: 1, profileCredentialBindingRevision: 1,
+    gatewayOrigin: 'https://remote.hkust-gz.edu.cn', protocolFamily: PROTOCOL_FAMILY,
+  });
+  writeJson(layout.account.document, {
+    schemaVersion: 1, accountKey: ACCOUNT_KEY, accountRevision: 1,
+    accountCredentialRevision: 1, role: 'primary', state: 'enabled', profileId: 'hkustgz',
+    profileRevision: 1, gatewayOrigin: 'https://remote.hkust-gz.edu.cn',
+    protocolFamily: PROTOCOL_FAMILY, workspaceKey: WORKSPACE_KEY,
+    activeCredentialVersion: null, createdAt, updatedAt: createdAt,
+  });
+  writeJson(layout.workspace.state, {
+    schemaVersion: 1, profileId: 'hkustgz', profileRevision: 1,
+    accountKey: ACCOUNT_KEY, accountRevision: 1, workspaceKey: WORKSPACE_KEY,
+    activeContextEpoch: 2,
+  });
+  writeJson(layout.workspace.settings, {
+    schemaVersion: 1, autoReconnect: true, maxAttempts: 3, autoConnect: false,
+    routeDomains: ['hkust-gz.edu.cn', 'hkust.edu.hk'],
+  });
+  writeJson(layout.workspace.localResources, { schemaVersion: 1, resources: [] });
+  return { layout, createdAt };
+}
+
+function provisionCustom(userData) {
+  let seed = 1;
+  const owner = new CustomGatewayConfirmationOwner({
+    randomBytes: (length) => Buffer.alloc(length, seed++),
+    now: () => 1_800_000_000_000,
+    ttlMs: 10_000,
+  });
+  const context = {
+    profileId: 'hkustgz', profileRevision: 1,
+    accountHandle: `account-${'a'.repeat(36)}`, activeContextEpoch: 2,
+  };
+  const view = owner.issue({
+    probeResult: {
+      schema_version: 1, normalized_origin: 'https://vpn.example.edu',
+      https_identity_valid: true, compatibility: 'recognized_candidate',
+      candidate_family: PROTOCOL_FAMILY, reported_version: 'M7.6.8R2', http_status: 200,
+    },
+    activeContext: context,
+  });
+  const confirmation = owner.consume({ confirmationHandle: view.confirmationHandle,
+    activeContext: context });
+  let provisionSeed = 60;
+  return new CustomProfileProvisioningRuntime({
+    userData,
+    randomBytes: (length) => Buffer.alloc(length, ++provisionSeed),
+    now: () => 1_800_000_000_100,
+  }).begin(confirmation);
+}
+
+function directory(userData) {
+  return new ProfileCandidateDirectory({
+    userData,
+    packageRoot: DESKTOP,
+    desktopDir: DESKTOP,
+    isPackaged: false,
+  });
+}
+
+test('reviewed anchor and custom index form one restart-safe candidate directory', (t) => {
+  const userData = root(t);
+  const reviewed = reviewedAuthority(userData);
+  const custom = provisionCustom(userData);
+  const candidates = directory(userData);
+  const anchored = candidates.anchorReviewedCurrent({
+    profileId: 'hkustgz', profileKey: PROFILE_KEY, accountKey: ACCOUNT_KEY,
+  });
+  assert.equal(anchored.authority.account.createdAt, reviewed.createdAt);
+  assert.equal(candidates.anchorReviewedCurrent({
+    profileId: 'hkustgz', profileKey: PROFILE_KEY, accountKey: ACCOUNT_KEY,
+  }).context.profileKey, PROFILE_KEY);
+
+  const views = candidates.listViews({ locale: 'zh' });
+  assert.deepEqual(views.map((view) => view.profileId), ['hkustgz', custom.profileId]);
+  assert.equal(views[0].sanitizedCompatibility, 'reviewed');
+  assert.equal(views[1].unverified, true);
+  const encoded = JSON.stringify(views);
+  for (const forbidden of [PROFILE_KEY, ACCOUNT_KEY, WORKSPACE_KEY, 'engine-config.json']) {
+    assert.equal(encoded.includes(forbidden), false, forbidden);
+  }
+
+  candidates.withCandidate('hkustgz', (record) => {
+    assert.equal(record.kind, 'builtin-reviewed');
+    assert.equal(record.context.profileKey, PROFILE_KEY);
+    assert.equal(record.authority.layout.browserPartition, 'persist:hkustgz-campus-browser');
+    assert.equal(JSON.parse(record.engineLaunchBinding.stdinFrame).profileId, 'hkustgz');
+  });
+  candidates.withCandidate(custom.profileId, (record) => {
+    assert.equal(record.kind, 'custom-local');
+    assert.deepEqual(record.context, custom.context);
+    assert.equal(JSON.parse(record.engineLaunchBinding.stdinFrame).profileId, custom.profileId);
+  });
+
+  const restarted = directory(userData);
+  assert.deepEqual(restarted.listViews({ locale: 'en' }).map((view) => view.profileId),
+    ['hkustgz', custom.profileId]);
+});
+
+test('reviewed anchor is additive immutable owner-only and link-free', {
+  skip: process.platform === 'win32',
+}, (t) => {
+  const userData = root(t);
+  const store = new ReviewedProfileAnchorStore({ userData });
+  const value = {
+    profileId: 'hkustgz', profileKey: PROFILE_KEY, accountKey: ACCOUNT_KEY,
+    createdAt: 1_700_000_000_000,
+  };
+  assert.equal(store.ensure(value), true);
+  assert.equal(store.ensure(value), false);
+  assert.deepEqual(store.get('hkustgz'), value);
+  assert.equal(fs.lstatSync(store.filePath).mode & 0o077, 0);
+  assert.throws(() => store.ensure({ ...value, accountKey: `account-${'55'.repeat(16)}` }),
+    /identity changed/u);
+
+  fs.unlinkSync(store.filePath);
+  const outside = path.join(userData, 'outside-anchor.json');
+  fs.writeFileSync(outside, '{"schemaVersion":1,"entries":[]}\n', { mode: 0o600 });
+  fs.symlinkSync(outside, store.filePath);
+  assert.throws(() => store.read(), /private file/u);
+});
+
+test('candidate directory rejects wrong reviewed keys and unknown Profile IDs', (t) => {
+  const userData = root(t);
+  reviewedAuthority(userData);
+  const candidates = directory(userData);
+  assert.throws(() => candidates.anchorReviewedCurrent({
+    profileId: 'hkustgz', profileKey: PROFILE_KEY, accountKey: `account-${'55'.repeat(16)}`,
+  }), /unavailable|could not be read/u);
+  assert.throws(() => candidates.withCandidate('custom-missing', () => true), /unavailable/u);
+  assert.throws(() => candidates.withCandidate('hkustgz', () => true), /unavailable/u,
+    'a packaged Profile is not switchable until its exact local authority is anchored');
+});
+
+test('real P4 authority alternates reviewed and custom Profiles without residue', async (t) => {
+  const userData = root(t);
+  reviewedAuthority(userData);
+  const custom = provisionCustom(userData);
+  writeJson(path.join(userData, 'global', 'settings.json'), {
+    schemaVersion: 1,
+    activeProfileKey: PROFILE_KEY,
+    activeAccountKey: ACCOUNT_KEY,
+    port: 6180,
+    strictProxyAuth: true,
+    proxySecurityVersion: 3,
+    proxyAuthMigrationPending: false,
+    closeAction: 'minimize',
+    language: 'en',
+    startAtLogin: false,
+  });
+  const candidates = directory(userData);
+  const reviewed = candidates.anchorReviewedCurrent({
+    profileId: 'hkustgz', profileKey: PROFILE_KEY, accountKey: ACCOUNT_KEY,
+  });
+  let active = reviewed.context;
+  const journalStore = new ActiveContextSwitchJournalStore({
+    filePath: path.join(userData, 'global', 'active-context-switch.json'),
+  });
+  const activationStore = new ActiveContextActivationStore({ userData });
+  const barrier = new ActiveContextSwitchBarrier({
+    invalidateContext: () => {},
+    suspendBrowser: async () => {},
+    browserBoundaryClosed: () => true,
+    cancelAuth: () => {},
+    cancelConnectivity: () => {},
+    cancelMutations: async () => true,
+    closeBrowser: async () => {},
+    browserClosed: () => true,
+    stopEngine: async () => ({ ok: true, cleanExit: true }),
+    revokeProxyAccess: async () => true,
+    clearServerState: async () => true,
+  });
+  const switching = new ProfileSwitchRuntime({
+    directory: candidates,
+    journalStore,
+    activationStore,
+    barrier,
+    getActivePersistentContext: () => active,
+    getEngineGeneration: () => null,
+    activateRuntime: (record) => { active = record.context; return true; },
+  });
+
+  for (let round = 0; round < 20; round += 1) {
+    const target = active.profileId === 'hkustgz' ? custom.profileId : 'hkustgz';
+    const result = await switching.switchTo(target);
+    assert.equal(result.status, 'activated');
+    assert.equal(active.profileId, target);
+    assert.equal(journalStore.read(), null);
+    const global = JSON.parse(fs.readFileSync(path.join(userData, 'global', 'settings.json')));
+    assert.equal(global.activeProfileKey, active.profileKey);
+    assert.equal(global.activeAccountKey, active.accountKey);
+  }
+  assert.equal(active.activeContextEpoch, 22);
+  assert.equal(candidates.listViews({ locale: 'en' }).length, 2);
+  assert.equal(new ReviewedProfileAnchorStore({ userData }).read().entries.length, 1);
+});

--- a/desktop/test/profile-switch-runtime.test.js
+++ b/desktop/test/profile-switch-runtime.test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { ProfileSwitchRuntime } = require('../lib/profile-switch-runtime');
+
+function context(profileId, seed, epoch) {
+  return Object.freeze({
+    profileId,
+    profileKey: `profile-${seed.repeat(32)}`,
+    profileRevision: 1,
+    profileCredentialBindingRevision: 1,
+    accountKey: `account-${seed.repeat(32)}`,
+    accountRevision: 1,
+    accountCredentialRevision: 1,
+    workspaceKey: `workspace-${seed.repeat(32)}`,
+    activeContextEpoch: epoch,
+  });
+}
+
+class CapturingSystem {
+  constructor(options) {
+    this.options = options;
+    this.requests = [];
+    this.recoveries = 0;
+    CapturingSystem.instance = this;
+  }
+  begin(request) { this.requests.push(request); return Promise.resolve({ ok: true, status: 'activated' }); }
+  recover() { this.recoveries += 1; return Promise.resolve({ ok: true, status: 'none' }); }
+}
+
+function fixture() {
+  const from = context('hkustgz', '1', 7);
+  const to = context(`custom-${'a'.repeat(32)}`, '2', 2);
+  let active = from;
+  const records = new Map([
+    [from.profileId, { context: from, kind: 'builtin-reviewed' }],
+    [to.profileId, { context: to, kind: 'custom-local' }],
+  ]);
+  const activations = [];
+  const activated = [];
+  const directory = {
+    withCandidate(profileId, callback) {
+      const record = records.get(profileId);
+      if (!record) throw new Error('candidate unavailable');
+      return callback(record);
+    },
+  };
+  const runtime = new ProfileSwitchRuntime({
+    directory,
+    journalStore: {},
+    activationStore: {
+      plan(request) {
+        activations.push(request);
+        return {
+          globalSettings: {
+            before: { present: true, bytes: 2, sha256: '1'.repeat(64) },
+            after: { present: true, bytes: 3, sha256: '2'.repeat(64) },
+          },
+          destinationWorkspace: {
+            before: { present: true, bytes: 2, sha256: '3'.repeat(64) },
+            after: { present: true, bytes: 3, sha256: '4'.repeat(64) },
+          },
+        };
+      },
+    },
+    barrier: {},
+    getActivePersistentContext: () => active,
+    getEngineGeneration: () => 19,
+    activateRuntime: (record, journal) => {
+      activated.push([record, journal]);
+      active = { ...record.context, activeContextEpoch: journal.nextActiveContextEpoch };
+      return true;
+    },
+    SwitchSystemClass: CapturingSystem,
+  });
+  return { runtime, from, to, records, activations, activated, get active() { return active; } };
+}
+
+test('switch request binds exact candidates Engine generation epoch and activation receipts', async () => {
+  const f = fixture();
+  assert.deepEqual(await f.runtime.switchTo(f.to.profileId), { ok: true, status: 'activated' });
+  assert.equal(f.activations.length, 1);
+  assert.deepEqual(f.activations[0], {
+    from: f.from,
+    to: f.to,
+    nextActiveContextEpoch: 8,
+  });
+  const request = CapturingSystem.instance.requests[0];
+  assert.equal(request.from, f.from);
+  assert.equal(request.to, f.to);
+  assert.equal(request.nextActiveContextEpoch, 8);
+  assert.equal(request.engineGeneration, 19);
+  assert.deepEqual(Object.keys(request.activation).sort(), [
+    'destinationWorkspace', 'globalSettings',
+  ]);
+  assert.deepEqual(await f.runtime.recover(), { ok: true, status: 'none' });
+});
+
+test('coordinator callbacks revalidate source destination and activate only the journal target', () => {
+  const f = fixture();
+  const system = CapturingSystem.instance;
+  const journal = { from: f.from, to: f.to, nextActiveContextEpoch: 8 };
+  assert.equal(system.options.validateSource(journal), true);
+  assert.equal(system.options.validateDestination(journal), true);
+  assert.equal(system.options.activateRuntime(journal), true);
+  assert.equal(f.activated.length, 1);
+  assert.equal(f.active.profileId, f.to.profileId);
+
+  const stale = { ...journal, from: { ...f.from, activeContextEpoch: 6 } };
+  assert.equal(system.options.validateSource(stale), false);
+  const drift = { ...journal, to: { ...f.to, accountRevision: 2 } };
+  assert.equal(system.options.validateDestination(drift), false);
+});
+
+test('same Profile unknown destination and invalid Engine generation fail before a journal begins', () => {
+  const f = fixture();
+  assert.throws(() => f.runtime.switchTo(f.from.profileId), /already active/u);
+  assert.throws(() => f.runtime.switchTo('custom-missing'), /unavailable/u);
+  const invalid = new ProfileSwitchRuntime({
+    directory: { withCandidate: (_id, callback) => callback({ context: f.to }) },
+    journalStore: {}, activationStore: { plan: () => ({}) }, barrier: {},
+    getActivePersistentContext: () => f.from,
+    getEngineGeneration: () => 0,
+    activateRuntime: () => true,
+    SwitchSystemClass: CapturingSystem,
+  });
+  assert.throws(() => invalid.switchTo(f.to.profileId), /Engine generation/u);
+  assert.equal(CapturingSystem.instance.requests.length, 0);
+});

--- a/docs/adr/0025-profile-candidate-directory-and-switch.md
+++ b/docs/adr/0025-profile-candidate-directory-and-switch.md
@@ -1,0 +1,64 @@
+# ADR-0025: Restart-safe Profile candidate directory and P4 switch
+
+- Status: Accepted for 2.0 P6f
+- Scope: reviewed/custom candidate discovery and persistent authority switching
+- Main/Renderer activation: deferred to the next P6 slice
+
+## Decision
+
+Before leaving a reviewed Profile, Main persists one owner-only immutable
+anchor containing only its reviewed `profileId`, opaque `profileKey`, opaque
+primary `accountKey` and Account creation time. The anchor is accepted only
+after the packaged Profile and its local Profile/Account/Workspace authority
+are revalidated. It contains no Gateway, username, credential, Cookie, route or
+Browser data.
+
+The `ProfileCandidateDirectory` combines:
+
+- packaged reviewed Profiles that have an exact local anchor;
+- provisioned `custom-local` Profiles from the owner-only custom index.
+
+For every candidate it reopens authority by opaque keys, verifies the Profile,
+Account, Workspace and Engine config, and constructs an internal persistent
+context. Renderer enumeration receives only `SchoolProfileView`; no persistent
+key or config path crosses that boundary.
+
+## Switch composition
+
+`ProfileSwitchRuntime` consumes the exact current persistent context and one
+directory candidate. It calculates a monotonic epoch, obtains the two-target
+activation receipts, binds the current Engine generation when present, and
+submits the request to the existing P4 `ActiveContextSwitchSystem`.
+
+The coordinator sequence remains:
+
+```text
+gate old Browser/context
+→ validate source
+→ cancel MFA/connectivity/mutations
+→ close old Browser workspace
+→ stop exact Engine generation
+→ revoke proxy access and server state
+→ revalidate destination
+→ commit destination Workspace epoch + GlobalSettings pair
+→ clear journal
+→ activate new runtime
+```
+
+Source and destination callbacks reopen the candidate directory rather than
+trusting a prior Renderer selection. Runtime activation receives the exact
+post-commit directory record. Switching back to HKUST uses its reviewed anchor
+and preserves the adopted legacy Campus Browser partition; custom workspaces
+retain their derived isolated partitions.
+
+## Evidence
+
+The real-filesystem integration alternates reviewed HKUST and a custom Profile
+twenty times using actual GlobalSettings, destination Workspace files, P4
+journal, activation store, cleanup barrier and candidate directory. Every round
+advances the epoch, updates the exact active Profile/Account pair and leaves no
+journal residue.
+
+This slice does not yet compose the switch runtime into production Main or
+expose selection IPC. That integration must invalidate the Main-owned Gateway
+confirmation and every old `ActiveContextLease` token before its first await.


### PR DESCRIPTION
## Summary

- persist an immutable owner-only reviewed Profile anchor before leaving HKUST so its opaque local authority remains recoverable
- combine anchored packaged Profiles and provisioned custom Profiles into one restart-safe internal candidate directory
- expose only sanitized SchoolProfile views while retaining Profile/Account/Workspace keys inside Main
- bind exact source, destination, monotonic epoch, Engine generation and activation receipts into the existing P4 switch system
- revalidate both candidates after cleanup and activate only the post-commit destination record
- preserve HKUST's adopted Browser partition and each custom Workspace's isolated derived partition

## Validation

- Desktop: 832 passed, 0 failed, 1 explicit Windows-only skip
- real-filesystem HKUST ↔ custom P4 switching: 20/20 rounds, epoch 2 → 22, no journal residue
- reviewed-anchor restart, immutability, permissions and link tests: PASS
- architecture gate: PASS (0 cycles, unchanged Main caps)
- tracked secret and syntax gates: PASS

## Boundary

This PR does not yet instantiate the directory/switch runtime in production Main or expose selector IPC. The next P6 slice must perform startup recovery before ordinary services, rotate the active controller/persistence/browser owners after commit, and invalidate every prior ActiveContextLease token.