### PR TITLE
2.0 P6g: bootstrap multi-school startup authority

### DIFF
--- a/desktop/lib/app-data-dir.js
+++ b/desktop/lib/app-data-dir.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { assertActiveContextSwitchStartupClear } = require('./active-context-switch-startup');
 const { DesktopPersistenceRuntime } = require('./desktop-persistence-runtime');
 const { LegacyMigrationCredentialOwner } = require('./legacy-migration-inputs');
+const { MultiSchoolStartupRuntime } = require('./multi-school-startup-runtime');
 const { selectProfileWorkspacePreReadyStorage } =
   require('./profile-workspace-pre-ready-selection');
 const { ProfileWorkspaceStartupRuntime } = require('./profile-workspace-startup-runtime');
@@ -20,9 +21,19 @@ function resolveUserDataOverride(rawValue) {
   return path.resolve(candidate);
 }
 
+function createMultiSchoolStartupInitializer(options) {
+  const runtime = new MultiSchoolStartupRuntime(options);
+  return (persistenceRuntime, activeSchoolProfile) => runtime.initialize({
+    mode: persistenceRuntime.mode,
+    authority: persistenceRuntime.authority,
+    withProfileDocument: (callback) => activeSchoolProfile.withProfileDocument(callback),
+  });
+}
+
 module.exports = {
   assertActiveContextSwitchStartupClear,
   createLegacyRuntimeStoragePaths,
+  createMultiSchoolStartupInitializer,
   DesktopPersistenceRuntime,
   LegacyMigrationCredentialOwner,
   ProfileWorkspaceStartupRuntime,

--- a/desktop/lib/multi-school-startup-runtime.js
+++ b/desktop/lib/multi-school-startup-runtime.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const { CustomProfileProvisioningRuntime } = require('./custom-profile-provisioning-runtime');
+const { ProfileCandidateDirectory } = require('./profile-candidate-directory');
+const { validateSchoolProfileDocument } = require('./school-profile-schema');
+
+class MultiSchoolStartupRuntime {
+  constructor({
+    userData,
+    packageRoot,
+    isPackaged,
+    resourcesPath,
+    desktopDir,
+    ProvisioningRuntimeClass = CustomProfileProvisioningRuntime,
+    CandidateDirectoryClass = ProfileCandidateDirectory,
+  } = {}) {
+    if (typeof ProvisioningRuntimeClass !== 'function' ||
+        typeof CandidateDirectoryClass !== 'function') {
+      throw new TypeError('multi-school startup runtime dependencies are invalid');
+    }
+    this.options = { userData, packageRoot, isPackaged, resourcesPath, desktopDir };
+    this.ProvisioningRuntimeClass = ProvisioningRuntimeClass;
+    this.CandidateDirectoryClass = CandidateDirectoryClass;
+    this.state = null;
+    this.directory = null;
+  }
+
+  initialize({ mode, authority, withProfileDocument } = {}) {
+    if (this.state) return this.state;
+    if (mode === 'legacy-flat') {
+      this.state = Object.freeze({
+        ready: true,
+        mode,
+        provisioningStatus: 'not_applicable',
+        profileCount: 0,
+      });
+      return this.state;
+    }
+    if (mode !== 'profile-workspace' || !authority ||
+        typeof withProfileDocument !== 'function') {
+      throw new TypeError('multi-school startup authority is invalid');
+    }
+    const provisioning = new this.ProvisioningRuntimeClass({
+      userData: this.options.userData,
+    }).recover();
+    let sourceDocument = null;
+    const access = withProfileDocument((value) => { sourceDocument = value; });
+    if (access && typeof access.then === 'function' || !sourceDocument) {
+      throw new TypeError('active reviewed Profile access must be synchronous');
+    }
+    const profile = validateSchoolProfileDocument(sourceDocument);
+    if (profile.evidenceClass !== 'builtin-reviewed' ||
+        authority.profile?.profileId !== profile.profileId ||
+        authority.profile?.profileRevision !== profile.profileRevision) {
+      throw new Error('startup reviewed Profile does not match persistence authority');
+    }
+    const directory = new this.CandidateDirectoryClass(this.options);
+    directory.anchorReviewedCurrent({
+      profileId: profile.profileId,
+      profileKey: authority.globalSettings.activeProfileKey,
+      accountKey: authority.globalSettings.activeAccountKey,
+    });
+    this.directory = directory;
+    this.state = Object.freeze({
+      ready: true,
+      mode,
+      provisioningStatus: provisioning.status,
+      profileCount: directory.listViews({ locale: 'en' }).length,
+    });
+    return this.state;
+  }
+
+  listViews(options) {
+    if (!this.directory) return Object.freeze([]);
+    return this.directory.listViews(options);
+  }
+}
+
+module.exports = { MultiSchoolStartupRuntime };

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -20,7 +20,7 @@ const {
   recoverCredentialSettingsTransaction,
   runCredentialSettingsMutation,
 } = require('./lib/credential-settings-transaction');
-const { assertActiveContextSwitchStartupClear, createLegacyRuntimeStoragePaths, DesktopPersistenceRuntime, LegacyMigrationCredentialOwner, ProfileWorkspaceStartupRuntime, relaunchAfterPersistenceMigration, resolveUserDataOverride, selectProfileWorkspacePreReadyStorage, writePersistenceE2EMarker } = require('./lib/app-data-dir');
+const { assertActiveContextSwitchStartupClear, createLegacyRuntimeStoragePaths, createMultiSchoolStartupInitializer, DesktopPersistenceRuntime, LegacyMigrationCredentialOwner, ProfileWorkspaceStartupRuntime, relaunchAfterPersistenceMigration, resolveUserDataOverride, selectProfileWorkspacePreReadyStorage, writePersistenceE2EMarker } = require('./lib/app-data-dir');
 const {
   classifyEngineCode,
   classifyEngineOutput,
@@ -86,7 +86,6 @@ app.commandLine.appendSwitch(
   'force-webrtc-ip-handling-policy',
   'disable_non_proxied_udp',
 );
-
 // ---------- profile override & single instance ----------
 // Automated package checks need to isolate every app-owned file, not merely
 // Chromium's cache. The override is deliberately private to the current
@@ -94,7 +93,6 @@ app.commandLine.appendSwitch(
 // an unexpected working directory.
 const userDataOverride = resolveUserDataOverride(process.env.HKUSTGZ_USER_DATA_DIR);
 if (userDataOverride) app.setPath('userData', userDataOverride);
-
 // ---------- single instance (avoid the app fighting its own session) ----------
 // `app.quit()` does not stop the rest of this module from running, so return
 // before a second instance touches the shared settings, credential, and log
@@ -264,6 +262,7 @@ const persistenceRuntime = new DesktopPersistenceRuntime({
     hasCredential: () => hasStoredPassword(CRED, process.platform),
   },
 });
+const initializeMultiSchoolStartup = createMultiSchoolStartupInitializer({ userData: DATA, packageRoot: __dirname, isPackaged: app.isPackaged, resourcesPath: process.resourcesPath, desktopDir: __dirname });
 function loadSettings() { return persistenceRuntime.loadSettings(); }
 function reportSettingsReadFailure(cause, { emitState = true } = {}) {
   if (cause?.code === 'SETTINGS_READ_FAILED') return cause;
@@ -1582,6 +1581,7 @@ app.whenReady().then(() => {
       isPackaged: app.isPackaged, developmentEntry: __dirname });
     return;
   }
+  initializeMultiSchoolStartup(persistenceRuntime, activeSchoolProfile);
   initializeLogWriter();
   writePersistenceE2EMarker({ application: app, environment: process.env, userData: DATA, mode: persistenceRuntime.mode });
   try {

--- a/desktop/test/multi-school-startup-runtime.test.js
+++ b/desktop/test/multi-school-startup-runtime.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const { MultiSchoolStartupRuntime } = require('../lib/multi-school-startup-runtime');
+
+const PROFILE = require('../assets/profiles/hkustgz/school-profile.json');
+
+function authority() {
+  return {
+    profile: { profileId: 'hkustgz', profileRevision: 1 },
+    globalSettings: {
+      activeProfileKey: `profile-${'11'.repeat(16)}`,
+      activeAccountKey: `account-${'22'.repeat(16)}`,
+    },
+  };
+}
+
+test('Profile Workspace startup recovers provisioning before anchoring and enumeration', () => {
+  const calls = [];
+  class Provisioning {
+    recover() { calls.push('recover'); return { ok: true, status: 'provisioned' }; }
+  }
+  class Directory {
+    constructor(options) { calls.push(['directory', options.userData]); }
+    anchorReviewedCurrent(value) { calls.push(['anchor', value]); }
+    listViews() { calls.push('list'); return [{ profileId: 'hkustgz' }, { profileId: 'custom-a' }]; }
+  }
+  const runtime = new MultiSchoolStartupRuntime({
+    userData: '/tmp/multi-school-startup',
+    packageRoot: '/repo/desktop',
+    isPackaged: false,
+    resourcesPath: '/unused',
+    desktopDir: '/repo/desktop',
+    ProvisioningRuntimeClass: Provisioning,
+    CandidateDirectoryClass: Directory,
+  });
+  const result = runtime.initialize({
+    mode: 'profile-workspace',
+    authority: authority(),
+    withProfileDocument: (callback) => callback(PROFILE),
+  });
+  assert.deepEqual(result, {
+    ready: true, mode: 'profile-workspace', provisioningStatus: 'provisioned', profileCount: 2,
+  });
+  assert.deepEqual(calls.map((value) => Array.isArray(value) ? value[0] : value), [
+    'recover', 'directory', 'anchor', 'list',
+  ]);
+  assert.equal(runtime.initialize({}).profileCount, 2, 'startup ownership is idempotent');
+});
+
+test('legacy first-run remains behavior-compatible and does not construct multi-school stores', () => {
+  class Forbidden { constructor() { throw new Error('must not construct'); } }
+  const runtime = new MultiSchoolStartupRuntime({
+    ProvisioningRuntimeClass: Forbidden,
+    CandidateDirectoryClass: Forbidden,
+  });
+  assert.deepEqual(runtime.initialize({ mode: 'legacy-flat' }), {
+    ready: true, mode: 'legacy-flat', provisioningStatus: 'not_applicable', profileCount: 0,
+  });
+  assert.deepEqual(runtime.listViews(), []);
+});
+
+test('startup rejects asynchronous wrong or custom authority before ordinary services', () => {
+  const options = {
+    ProvisioningRuntimeClass: class { recover() { return { status: 'none' }; } },
+    CandidateDirectoryClass: class {},
+  };
+  assert.throws(() => new MultiSchoolStartupRuntime(options).initialize({
+    mode: 'profile-workspace', authority: authority(),
+    withProfileDocument: async () => PROFILE,
+  }), /synchronous/u);
+  assert.throws(() => new MultiSchoolStartupRuntime(options).initialize({
+    mode: 'profile-workspace', authority: { ...authority(), profile: { profileId: 'other', profileRevision: 1 } },
+    withProfileDocument: (callback) => callback(PROFILE),
+  }), /does not match/u);
+});
+
+test('production startup orders provisioning recovery before logs tray and network', () => {
+  const main = fs.readFileSync(path.join(__dirname, '..', 'main.js'), 'utf8');
+  const start = main.indexOf('app.whenReady().then(() => {');
+  const end = main.indexOf("app.on('window-all-closed'", start);
+  const source = main.slice(start, end);
+  const persistence = source.indexOf('persistenceRuntime.initialize()');
+  const multiSchool = source.indexOf('initializeMultiSchoolStartup(');
+  const log = source.indexOf('initializeLogWriter()');
+  const tray = source.indexOf('desktopShell.createTray()');
+  const network = source.indexOf('networkStartupCoordinator.start()');
+  assert.ok(persistence >= 0 && multiSchool > persistence && log > multiSchool &&
+    tray > log && network > tray);
+});

--- a/docs/adr/0026-multi-school-startup-bootstrap.md
+++ b/docs/adr/0026-multi-school-startup-bootstrap.md
@@ -1,0 +1,42 @@
+# ADR-0026: Multi-school startup recovery and reviewed anchor bootstrap
+
+- Status: Accepted for 2.0 P6g
+- Scope: production startup while HKUST remains the only active pre-ready Profile
+- Custom Profile activation and selector IPC: deferred
+
+## Decision
+
+After `DesktopPersistenceRuntime` finishes P3 migration and before log, tray,
+Browser or network services start, production Main now executes one
+`MultiSchoolStartupRuntime` boundary.
+
+In `profile-workspace` mode it performs this exact order:
+
+1. recover or complete any owner-only custom Profile provisioning journal;
+2. synchronously obtain the current packaged reviewed Profile source document;
+3. verify that document matches the active persistence authority;
+4. reopen the exact reviewed Profile/Account/Workspace by GlobalSettings keys;
+5. persist or verify the immutable reviewed Profile anchor;
+6. build the restart-safe candidate directory and verify enumeration.
+
+Any unreadable journal, partial destination, index conflict, wrong Profile,
+authority mismatch, link, permission or Engine-config drift aborts startup before
+ordinary services can read credentials or open network state.
+
+Legacy first-run mode remains behavior-compatible and constructs no multi-school
+stores. A successful P3 migration still performs its bounded one-time relaunch;
+the successor then executes this bootstrap. Real Electron main integration,
+synthetic Engine lifecycle and two-process persistence migration remain green.
+
+## Current limitation
+
+Pre-ready Profile selection still begins from the packaged HKUST controller.
+Therefore this slice deliberately refuses a custom active authority at startup
+and does not expose Profile switching IPC. The next slice must resolve the
+active Profile from GlobalSettings/profile directory before creating path-bound
+services, then rotate the controller, persistence adapter, Browser session and
+active-context lease after a committed switch.
+
+The composition remains behind the existing `app-data-dir` facade, so
+`main.js` stays at its architecture ratchet of 35 direct dependencies and 1644
+lines.


### PR DESCRIPTION
## Summary

- run custom provisioning recovery after P3 persistence initialization but before log, tray, Browser and network services
- synchronously verify the current packaged reviewed Profile against active persistence authority
- persist/verify the exact HKUST reviewed anchor and build the restart-safe candidate directory during production startup
- leave legacy first-run behavior unchanged and refuse custom active authority until pre-ready resolution is implemented
- keep composition behind app-data-dir so Main stays at 35 direct dependencies and 1644 lines

## Validation

- Desktop: 836 passed, 0 failed, 1 explicit Windows-only skip
- real Electron main integration: PASS
- two-process persistence migration/relaunch: PASS
- synthetic Engine lifecycle: PASS
- architecture gate: PASS (0 cycles, Main ratchet unchanged)
- tracked secret and syntax gates: PASS

## Boundary

No selector or Profile-switch IPC is exposed. The next slice must resolve a custom active Profile before path-bound service construction and rotate controller/persistence/Browser/context owners after a committed P4 switch.