### PR TITLE
1.2.4: stop Electron renderer restart loops

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,7 @@ jobs:
         working-directory: desktop
         run: |
           npm run test:main-integration
+          npm run test:control-renderer-recovery
           npm run test:main-engine-lifecycle
           npm run test:main-network-startup
           ./node_modules/.bin/electron e2e/campus-browser-toolbar.electron.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,8 @@ jobs:
         run: npm ci
       - name: Exercise the real Electron main process
         run: npm run test:main-integration
+      - name: Exercise control renderer crash-loop recovery
+        run: npm run test:control-renderer-recovery
       - name: Exercise Main with a synthetic Engine lifecycle
         run: npm run test:main-engine-lifecycle
       - name: Exercise initially-offline Main startup recovery

--- a/desktop/e2e/control-renderer-recovery.electron.js
+++ b/desktop/e2e/control-renderer-recovery.electron.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { app, BrowserWindow, Menu, nativeImage } = require('electron');
+const { DesktopShell } = require('../lib/desktop-shell');
+
+const TIMEOUT_MS = 15_000;
+
+// Match production: losing the control renderer must not terminate the tray
+// owner while the recovery policy decides whether another window is safe.
+app.on('window-all-closed', () => {});
+
+function delay(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
+
+async function waitFor(predicate, message) {
+  const deadline = Date.now() + TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await delay(25);
+  }
+  throw new Error(message);
+}
+
+async function run() {
+  await app.whenReady();
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'control-renderer-recovery-'));
+  const renderer = path.join(directory, 'index.html');
+  const preload = path.join(directory, 'preload.js');
+  fs.writeFileSync(renderer, '<!doctype html><meta charset="utf-8"><title>fixture</title>');
+  fs.writeFileSync(preload, "'use strict';\n");
+  const errors = [];
+  const shell = new DesktopShell({
+    app,
+    BrowserWindow,
+    Tray: class {},
+    Menu,
+    nativeImage,
+    dialog: { showMessageBox: async () => ({ response: 2, checkboxChecked: false }) },
+    baseDirectory: path.join(__dirname, '..'),
+    controlRendererFile: renderer,
+    preloadFile: preload,
+    platform: process.platform,
+    translate: (key) => key,
+    getConnectionState: () => ({ connected: false, connecting: false }),
+    getCloseAction: () => 'minimize',
+    connect: async () => ({ ok: true }),
+    disconnect: async () => ({ ok: true }),
+    openCampusBrowser: async () => ({ ok: true }),
+    rememberCloseAction: async () => {},
+    disposeLifecycle: () => {},
+    cleanupQuit: async () => {},
+    onControlRendererUnavailable: () => {},
+    onWindowError: (error) => errors.push(error),
+  });
+
+  try {
+    const first = shell.createWindow();
+    await waitFor(() => !first.webContents.isLoading(), 'first control renderer did not load');
+    first.webContents.forcefullyCrashRenderer();
+    await waitFor(() => shell.window && shell.window !== first,
+      'the first renderer crash was not recovered');
+    const recovery = shell.window;
+    await waitFor(() => !recovery.webContents.isLoading(), 'recovery renderer did not load');
+    recovery.webContents.forcefullyCrashRenderer();
+    await waitFor(() => shell.window === null, 'the repeated crash kept restarting the renderer');
+
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].code, 'CONTROL_RENDERER_CRASH_LOOP_BLOCKED');
+    process.stdout.write('control renderer recovery: PASS\n');
+  } finally {
+    if (shell.window && !shell.window.isDestroyed()) shell.window.destroy();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+run().then(() => app.quit()).catch((error) => {
+  process.stderr.write(`${error.stack || error}\n`);
+  app.exit(1);
+});

--- a/desktop/lib/desktop-shell.js
+++ b/desktop/lib/desktop-shell.js
@@ -4,6 +4,12 @@ const path = require('node:path');
 const { loadTrayImage } = require('./tray-icon');
 const { CONTROL_WINDOW, clampWindowSize } = require('./window-layout');
 
+// A transient Chromium renderer failure may be recovered once, but a broken
+// preload/renderer must never turn into an unbounded create-crash-create loop.
+// Keep the main/tray process alive so the user can retry after the underlying
+// condition changes.
+const CONTROL_RENDERER_RECOVERY_WINDOW_MS = 30_000;
+
 class DesktopShell {
   constructor({
     app,
@@ -27,11 +33,12 @@ class DesktopShell {
     cleanupQuit,
     onControlRendererUnavailable,
     onWindowError,
+    now = Date.now,
   } = {}) {
     for (const dependency of [
       BrowserWindow, Tray, translate, getConnectionState, getCloseAction, connect, disconnect,
       openCampusBrowser, rememberCloseAction, disposeLifecycle, cleanupQuit,
-      onControlRendererUnavailable, onWindowError,
+      onControlRendererUnavailable, onWindowError, now,
     ]) {
       if (typeof dependency !== 'function') {
         throw new TypeError('desktop shell dependencies are incomplete');
@@ -63,6 +70,7 @@ class DesktopShell {
     this.cleanupQuit = cleanupQuit;
     this.onControlRendererUnavailable = onControlRendererUnavailable;
     this.onWindowError = onWindowError;
+    this.now = now;
     this.window = null;
     this.windowInvalid = false;
     this.tray = null;
@@ -70,6 +78,7 @@ class DesktopShell {
     this.quitAllowed = false;
     this.quitInFlight = null;
     this.closePromptOpen = false;
+    this.lastAutomaticRendererRecoveryAt = null;
   }
 
   get webContents() {
@@ -284,7 +293,17 @@ class DesktopShell {
       this.windowInvalid = true;
       this.window = null;
       try { window.destroy(); } catch {}
-      if (wasVisible && this.app.isReady()) this.createWindow();
+      if (!wasVisible || !this.app.isReady()) return;
+      const observedAt = this.now();
+      const previous = this.lastAutomaticRendererRecoveryAt;
+      if (previous === null || observedAt - previous >= CONTROL_RENDERER_RECOVERY_WINDOW_MS) {
+        this.lastAutomaticRendererRecoveryAt = observedAt;
+        this.createWindow();
+        return;
+      }
+      const error = new Error(this.translate('error.controlRendererCrashLoop'));
+      error.code = 'CONTROL_RENDERER_CRASH_LOOP_BLOCKED';
+      this.onWindowError(error);
     });
     contents.on('destroyed', () => {
       reportRendererUnavailable('destroyed');

--- a/desktop/lib/i18n.js
+++ b/desktop/lib/i18n.js
@@ -82,6 +82,7 @@ const dictionaries = {
     'error.settingsRestored': '检测到设置文件损坏，已从本机备份恢复；请检查端口和偏好设置',
     'error.settingsDefaults': '设置文件损坏且备份不可用，已恢复安全默认值；请重新检查端口和偏好设置',
     'error.startupTitle': 'HKUST(GZ) Connect 启动失败',
+    'error.controlRendererCrashLoop': '控制界面连续异常退出，已停止自动重启。校园连接和托盘仍会保留；请稍后从托盘重新打开窗口。',
 
     'engine.authFailed': '登录处理失败，无法确认是否为密码问题；已停止自动重试',
     'engine.authRejected': '登录未通过：账号或密码未被网关接受，已停止自动重试',
@@ -227,6 +228,7 @@ const dictionaries = {
     'error.settingsRestored': 'The settings file was damaged and restored from a local backup; review the port and preferences',
     'error.settingsDefaults': 'The settings file and backup were unusable; safe defaults were restored. Review the port and preferences',
     'error.startupTitle': 'HKUST(GZ) Connect failed to start',
+    'error.controlRendererCrashLoop': 'The control window exited repeatedly, so automatic restart was stopped. The campus connection and tray remain available; reopen the window from the tray later.',
 
     'engine.authFailed': 'Login processing failed and could not be attributed to the password. Automatic retries stopped.',
     'engine.authRejected': 'Login was rejected: the gateway did not accept the account or password; automatic retries stopped',

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hkustgzconnect",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hkustgzconnect",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "@electron/asar": "^3.4.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hkustgzconnect",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "HKUST(GZ) EasyConnect-compatible client with an independent Rust engine",
   "main": "main.js",
   "author": "heeh02",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -13,6 +13,7 @@
     "test:auth-control-e2e": "node e2e/auth-control-fixture.js",
     "test:campus-mfa-safety": "electron e2e/campus-mfa-safety.electron.js",
     "test:campus-popup-mfa-safety": "electron e2e/campus-popup-mfa-safety.electron.js",
+    "test:control-renderer-recovery": "electron e2e/control-renderer-recovery.electron.js",
     "test:idle-performance": "electron scripts/idle-performance-baseline.js",
     "test:routing-restart": "node e2e/routing-restart.electron.js",
     "test:renderer-layout": "electron e2e/resource-manager-layout.electron.js",

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -113,8 +113,6 @@ button, input, select, a, code { -webkit-app-region: no-drag; }
 .conn-status.on { color: var(--ok); }
 .conn-status.busy { color: var(--gold); }
 .dot { width: 8px; height: 8px; border-radius: 50%; background: currentColor; box-shadow: 0 0 0 0 currentColor; }
-.conn-status.on .dot { animation: ping 2s infinite; }
-@keyframes ping { 0% { box-shadow: 0 0 0 0 rgba(26,165,104,.5); } 70% { box-shadow: 0 0 0 6px rgba(26,165,104,0); } 100% { box-shadow: 0 0 0 0 rgba(26,165,104,0); } }
 .conn-err { color: var(--err); font-size: 12.5px; margin-top: 8px; min-height: 0; line-height: 1.4; }
 .conn-body { display: flex; flex-direction: column; gap: 10px; }
 .collapsible-panel { display: flex; flex-direction: column; gap: 10px; }

--- a/desktop/test/desktop-shell.test.js
+++ b/desktop/test/desktop-shell.test.js
@@ -139,6 +139,28 @@ test('a crashed visible control renderer is destroyed and recreated once', () =>
   assert.equal(f.calls.filter((entry) => entry[0] === 'renderer-lost').length, 1);
 });
 
+test('repeated control renderer crashes trip a recovery circuit breaker', () => {
+  let now = 100_000;
+  const f = fixture({ now: () => now });
+  const first = f.shell.createWindow();
+  first.webContents.emit('render-process-gone');
+  const recovery = f.shell.window;
+
+  recovery.webContents.emit('render-process-gone');
+  assert.equal(f.shell.window, null,
+    'a recovery renderer that also crashes must not be recreated indefinitely');
+  assert.deepEqual(f.calls.filter((entry) => entry[0] === 'error'), [
+    ['error', 'error.controlRendererCrashLoop'],
+  ]);
+
+  now += 30_000;
+  assert.equal(f.shell.showWindow(), true);
+  const later = f.shell.window;
+  later.webContents.emit('render-process-gone');
+  assert.notEqual(f.shell.window, later,
+    'a later isolated crash may receive one automatic recovery');
+});
+
 test('a crashed hidden renderer is recreated on the next show request', () => {
   const f = fixture();
   const first = f.shell.createWindow();

--- a/desktop/test/renderer-contract.test.js
+++ b/desktop/test/renderer-contract.test.js
@@ -41,6 +41,12 @@ test('control panel has responsive wide and compact layout rules', () => {
   assert.match(css, /\.page\[data-page="connect"\][^{]*\{/);
 });
 
+test('connected status remains static instead of continuously repainting Electron', () => {
+  assert.match(css, /\.conn-status\.on\s*\{[^}]*color:\s*var\(--ok\)/);
+  assert.doesNotMatch(css, /\.conn-status\.on\s+\.dot\s*\{[^}]*animation:/);
+  assert.doesNotMatch(css, /@keyframes\s+ping/);
+});
+
 test('update download uses one stable delegated listener', () => {
   assert.match(appJs, /\$\('updateHint'\)\.addEventListener\('click'/);
   assert.match(appJs, /event\.target\?\.closest\?\.\('#updateDownload'\)/);


### PR DESCRIPTION
## 问题 / Problem

已确认 1.2.3 的控制窗口 Renderer 在崩溃后会立即重建；如果新 Renderer 因同一条件再次崩溃，就会进入无上限的创建—崩溃—重启循环，造成 Electron 严重卡顿。

The 1.2.3 control renderer was recreated immediately after every crash. A persistent renderer failure therefore caused an unbounded create-crash-restart loop and severe Electron stalls.

## 修复 / Fix

- 一个 30 秒恢复窗口内最多自动重建一次控制窗口。
- 恢复后的 Renderer 再次崩溃时触发熔断，不再自动重启。
- Engine、校园隧道和托盘进程保持可用；用户稍后可从托盘手动重新打开控制窗口。
- 加入单元测试及真实 Electron 双崩溃 E2E，并纳入普通 CI 与云端构建门禁。
- 将维护版本推进到 1.2.4。

- Allow at most one automatic control-window recovery per 30-second window.
- A second renderer crash trips a circuit breaker instead of restarting forever.
- The Engine, tunnel, and tray stay available; the user may reopen the control window later.
- Add unit and real-Electron double-crash regression tests to CI and cloud builds.
- Prepare maintenance version 1.2.4.

## 验证 / Verification

- Desktop: 610 passed, 0 failed, 1 Windows-only skip.
- Real Electron forced double-crash recovery: PASS.
- Architecture: 214 files, 277 edges, 0 cycles; Main 1595 lines / 35 direct dependencies.
- JavaScript syntax: PASS.
- Secret gate on committed tree: PASS.
- No Engine, authentication, DNS, routing, or credential behavior changed.
