### PR TITLE
2.0 P6h: resolve active Profiles before service binding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,7 @@ jobs:
         working-directory: desktop
         run: |
           npm run test:main-integration
+          npm run test:main-custom-profile
           npm run test:control-renderer-recovery
           npm run test:main-engine-lifecycle
           npm run test:main-network-startup
@@ -102,26 +103,30 @@ jobs:
           cargo build --locked --release --no-default-features --bin ec-engine --target x86_64-apple-darwin
           cargo build --locked --release --no-default-features --bin ec-proxy-command --target aarch64-apple-darwin
           cargo build --locked --release --no-default-features --bin ec-proxy-command --target x86_64-apple-darwin
+          cargo build --locked --release --no-default-features --bin ec-gateway-probe --target aarch64-apple-darwin
+          cargo build --locked --release --no-default-features --bin ec-gateway-probe --target x86_64-apple-darwin
 
       - name: Build independent engine (Windows)
         if: matrix.platform == 'win'
         shell: pwsh
         working-directory: independent
         run: |
-          cargo build --locked --release --no-default-features --bin ec-engine --bin ec-proxy-command
+          cargo build --locked --release --no-default-features --bin ec-engine --bin ec-proxy-command --bin ec-gateway-probe
           New-Item -ItemType Directory -Force -Path ../desktop/engine | Out-Null
           Copy-Item target/release/ec-engine.exe ../desktop/engine/ec-engine-windows-amd64.exe
           Copy-Item target/release/ec-proxy-command.exe ../desktop/engine/ec-proxy-command-windows-amd64.exe
+          Copy-Item target/release/ec-gateway-probe.exe ../desktop/engine/ec-gateway-probe-windows-amd64.exe
           Copy-Item config/hkustgz.json ../desktop/engine/hkustgz.json
 
       - name: Build independent engines (Linux x86_64)
         if: matrix.platform == 'linux'
         working-directory: independent
         run: |
-          cargo build --locked --release --no-default-features --bin ec-engine --bin ec-proxy-command
+          cargo build --locked --release --no-default-features --bin ec-engine --bin ec-proxy-command --bin ec-gateway-probe
           mkdir -p ../desktop/engine
           cp target/release/ec-engine ../desktop/engine/ec-engine-linux-amd64
           cp target/release/ec-proxy-command ../desktop/engine/ec-proxy-command-linux-amd64
+          cp target/release/ec-gateway-probe ../desktop/engine/ec-gateway-probe-linux-amd64
           cp config/hkustgz.json ../desktop/engine/hkustgz.json
 
       # Only export CSC_LINK when a cert secret actually exists — an EMPTY CSC_LINK
@@ -158,12 +163,14 @@ jobs:
             local package_arch="$3"
             mkdir -p engine
             find engine -maxdepth 1 -type f \
-              \( -name 'ec-engine*' -o -name 'ec-proxy-command*' \) \
+              \( -name 'ec-engine*' -o -name 'ec-proxy-command*' -o -name 'ec-gateway-probe*' \) \
               -delete
             cp "../independent/target/${cargo_target}/release/ec-engine" \
               "engine/ec-engine-darwin-${package_arch}"
             cp "../independent/target/${cargo_target}/release/ec-proxy-command" \
               "engine/ec-proxy-command-darwin-${package_arch}"
+            cp "../independent/target/${cargo_target}/release/ec-gateway-probe" \
+              "engine/ec-gateway-probe-darwin-${package_arch}"
             cp ../independent/config/hkustgz.json engine/hkustgz.json
             echo "staged exact macOS ${build_arch} native resources"
           }
@@ -195,6 +202,8 @@ jobs:
           test "$(lipo -archs release/mac/hkustgzconnect.app/Contents/Resources/engine/ec-engine-darwin-amd64)" = "x86_64"
           test "$(lipo -archs release/mac-arm64/hkustgzconnect.app/Contents/Resources/engine/ec-proxy-command-darwin-arm64)" = "arm64"
           test "$(lipo -archs release/mac/hkustgzconnect.app/Contents/Resources/engine/ec-proxy-command-darwin-amd64)" = "x86_64"
+          test "$(lipo -archs release/mac-arm64/hkustgzconnect.app/Contents/Resources/engine/ec-gateway-probe-darwin-arm64)" = "arm64"
+          test "$(lipo -archs release/mac/hkustgzconnect.app/Contents/Resources/engine/ec-gateway-probe-darwin-amd64)" = "x86_64"
 
       - name: Verify packaged macOS applications
         if: matrix.platform == 'mac'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,11 @@ jobs:
         shell: pwsh
         working-directory: independent
         run: |
-          cargo build --locked --release --no-default-features --bin ec-engine --bin ec-proxy-command
+          cargo build --locked --release --no-default-features --bin ec-engine --bin ec-proxy-command --bin ec-gateway-probe
           New-Item -ItemType Directory -Force -Path ../desktop/engine | Out-Null
           Copy-Item target/release/ec-engine.exe ../desktop/engine/ec-engine-windows-amd64.exe
           Copy-Item target/release/ec-proxy-command.exe ../desktop/engine/ec-proxy-command-windows-amd64.exe
+          Copy-Item target/release/ec-gateway-probe.exe ../desktop/engine/ec-gateway-probe-windows-amd64.exe
           Copy-Item config/hkustgz.json ../desktop/engine/hkustgz.json
 
       - name: Build unpacked Linux application
@@ -189,6 +190,8 @@ jobs:
         run: npm ci
       - name: Exercise the real Electron main process
         run: npm run test:main-integration
+      - name: Exercise clean custom Profile startup
+        run: npm run test:main-custom-profile
       - name: Exercise control renderer crash-loop recovery
         run: npm run test:control-renderer-recovery
       - name: Exercise Main with a synthetic Engine lifecycle
@@ -273,4 +276,4 @@ jobs:
             offline_netstack_poll_latency_matrix -- \
             --ignored --nocapture --test-threads=1
       - name: Build shipped native binaries
-        run: cargo build --locked --release --no-default-features --bin ec-engine --bin ec-proxy-command
+        run: cargo build --locked --release --no-default-features --bin ec-engine --bin ec-proxy-command --bin ec-gateway-probe

--- a/desktop/build/afterPack.js
+++ b/desktop/build/afterPack.js
@@ -30,6 +30,12 @@ function requiredProxyCommandName(platform, arch) {
   return `ec-proxy-command-${platformName}-${architectureName(arch)}${extension}`;
 }
 
+function requiredGatewayProbeName(platform, arch) {
+  const platformName = platform === 'win32' ? 'windows' : platform === 'darwin' ? 'darwin' : 'linux';
+  const extension = platformName === 'windows' ? '.exe' : '';
+  return `ec-gateway-probe-${platformName}-${architectureName(arch)}${extension}`;
+}
+
 function assertEnginePresent(resourcesDir, platform, arch) {
   const name = requiredEngineName(platform, arch);
   const enginePath = path.join(resourcesDir, name);
@@ -52,11 +58,22 @@ function assertProxyCommandPresent(resourcesDir, platform, arch) {
   return helperPath;
 }
 
+function assertGatewayProbePresent(resourcesDir, platform, arch) {
+  const name = requiredGatewayProbeName(platform, arch);
+  const probePath = path.join(resourcesDir, name);
+  if (!fs.existsSync(probePath) || !fs.statSync(probePath).isFile() || fs.statSync(probePath).size === 0) {
+    throw new Error(`missing packaged Gateway probe: ${probePath}`);
+  }
+  return probePath;
+}
+
 exports.architectureName = architectureName;
 exports.requiredEngineName = requiredEngineName;
 exports.assertEnginePresent = assertEnginePresent;
 exports.requiredProxyCommandName = requiredProxyCommandName;
 exports.assertProxyCommandPresent = assertProxyCommandPresent;
+exports.requiredGatewayProbeName = requiredGatewayProbeName;
+exports.assertGatewayProbePresent = assertGatewayProbePresent;
 
 function discoverLocalAppleIdentity() {
   try {
@@ -103,6 +120,9 @@ exports.default = async function afterPack(context) {
   const proxyCommandPath = assertProxyCommandPresent(
     packagedEngineDirectory, context.electronPlatformName, context.arch,
   );
+  const gatewayProbePath = assertGatewayProbePresent(
+    packagedEngineDirectory, context.electronPlatformName, context.arch,
+  );
   assertPackagedSchoolProfile(
     path.join(resourcesDir, 'app.asar'),
     path.join(packagedEngineDirectory, 'hkustgz.json'),
@@ -113,6 +133,6 @@ exports.default = async function afterPack(context) {
     return;
   }
   const identity = discoverLocalAppleIdentity();
-  signMacPackage(appPath, [enginePath, proxyCommandPath], identity);
+  signMacPackage(appPath, [enginePath, proxyCommandPath, gatewayProbePath], identity);
   console.log(`[afterPack] ${identity ? identity.kind : 'ad-hoc'} signed + verified:`, appPath);
 };

--- a/desktop/build/verify-package.js
+++ b/desktop/build/verify-package.js
@@ -450,14 +450,19 @@ function verifyPackage({ resourcesArgument, platform = process.platform, archite
   const extension = platformName === 'windows' ? '.exe' : '';
   const engineName = `ec-engine-${platformName}-${architectureName}${extension}`;
   const proxyCommandName = `ec-proxy-command-${platformName}-${architectureName}${extension}`;
+  const gatewayProbeName = `ec-gateway-probe-${platformName}-${architectureName}${extension}`;
   const engine = path.join(resources, 'engine', engineName);
   const proxyCommand = path.join(resources, 'engine', proxyCommandName);
+  const gatewayProbe = path.join(resources, 'engine', gatewayProbeName);
   assertExactNativeResources(path.join(resources, 'engine'), [
     engineName,
     proxyCommandName,
+    gatewayProbeName,
     'hkustgz.json',
   ]);
-  for (const [label, executable] of [['engine', engine], ['SSH proxy helper', proxyCommand]]) {
+  for (const [label, executable] of [
+    ['engine', engine], ['SSH proxy helper', proxyCommand], ['Gateway probe', gatewayProbe],
+  ]) {
     if (!fs.existsSync(executable) || !fs.statSync(executable).isFile() || fs.statSync(executable).size === 0) {
       throw new Error(`missing packaged ${label}: ${executable}`);
     }
@@ -466,7 +471,7 @@ function verifyPackage({ resourcesArgument, platform = process.platform, archite
   assertPackagedSchoolProfile(archive, path.join(resources, 'engine', 'hkustgz.json'));
 
   if (platformName === 'windows') {
-    for (const executable of [engine, proxyCommand]) {
+    for (const executable of [engine, proxyCommand, gatewayProbe]) {
       const header = fs.readFileSync(executable);
       const peOffset = header.length >= 0x40 ? header.readUInt32LE(0x3c) : -1;
       const signature = peOffset >= 0 && peOffset + 6 <= header.length
@@ -481,11 +486,11 @@ function verifyPackage({ resourcesArgument, platform = process.platform, archite
       }
     }
   } else if (platformName === 'linux') {
-    for (const executable of [engine, proxyCommand]) {
+    for (const executable of [engine, proxyCommand, gatewayProbe]) {
       assertLinuxElfArchitecture(executable, architectureName);
     }
   } else if (platformName === 'darwin') {
-    for (const executable of [engine, proxyCommand]) {
+    for (const executable of [engine, proxyCommand, gatewayProbe]) {
       assertMacSystemOnlyDylibs(executable);
     }
   }

--- a/desktop/e2e/auth-control-fixture.js
+++ b/desktop/e2e/auth-control-fixture.js
@@ -18,6 +18,7 @@ const fixturePath = process.env.EC_AUTH_FIXTURE || path.join(
   'debug',
   fixtureName,
 );
+let activeChild = null;
 
 function nextPublished(published, startIndex) {
   const deadline = Date.now() + 3_000;
@@ -37,6 +38,7 @@ async function main() {
     stdio: ['pipe', 'pipe', 'pipe'],
     windowsHide: true,
   });
+  activeChild = child;
   const exitPromise = new Promise((resolve, reject) => {
     child.once('error', reject);
     child.once('exit', (code) => (code === 0 ? resolve() : reject(new Error(`fixture exit ${code}`))));
@@ -44,11 +46,20 @@ async function main() {
   let stdout = '';
   let stderr = '';
   const published = [];
+  const contextToken = Object.freeze({
+    profileId: 'synthetic-profile',
+    profileRevision: 1,
+    accountHandle: `account-${'a'.repeat(36)}`,
+    activeContextEpoch: 1,
+    connectionIntent: 1,
+    engineGeneration: 9,
+  });
   const coordinator = new AuthChallengeCoordinator({
     publish: (challenge) => published.push(challenge),
+    isContextCurrent: (candidate) => candidate === contextToken,
   });
   const registry = new EngineControlRegistry({ authChallenges: coordinator });
-  const controls = registry.bind(9, child.stdin);
+  const controls = registry.bind(9, child.stdin, contextToken);
   child.stdout.on('data', (chunk) => {
     stdout += chunk.toString('utf8');
     controls.feed(chunk);
@@ -84,6 +95,7 @@ async function main() {
   await coordinator.respond(accepted);
   assert.equal(accepted.response, '');
   await exitPromise;
+  activeChild = null;
   clearTimeout(timeout);
   registry.clear(9);
   assert.equal(published.at(-1), null);
@@ -95,6 +107,8 @@ async function main() {
 }
 
 main().catch((error) => {
+  try { activeChild?.kill(); } catch {}
+  activeChild = null;
   process.stderr.write(`auth control fixture e2e: FAIL (${error.message})\n`);
   process.exitCode = 1;
 });

--- a/desktop/e2e/main-custom-profile.electron.js
+++ b/desktop/e2e/main-custom-profile.electron.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { app, BrowserWindow, dialog, session, webContents } = require('electron');
+const { CustomGatewayConfirmationOwner } = require('../lib/custom-gateway-onboarding');
+const { CustomProfileProvisioningRuntime } = require('../lib/custom-profile-provisioning-runtime');
+const { PROTOCOL_FAMILY } = require('../lib/school-profile-schema');
+
+const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-custom-main-e2e-'));
+fs.chmodSync(userData, 0o700);
+process.env.HKUSTGZ_USER_DATA_DIR = userData;
+dialog.showErrorBox = (title, message) => {
+  process.stderr.write(`custom-main-startup-error: ${title}: ${message}\n`);
+};
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+}
+
+function provision() {
+  let seed = 1;
+  const owner = new CustomGatewayConfirmationOwner({
+    randomBytes: (length) => Buffer.alloc(length, seed++),
+    now: () => 1_800_000_000_000,
+    ttlMs: 10_000,
+  });
+  const active = {
+    profileId: 'hkustgz', profileRevision: 1,
+    accountHandle: `account-${'a'.repeat(36)}`, activeContextEpoch: 7,
+  };
+  const view = owner.issue({
+    probeResult: {
+      schema_version: 1, normalized_origin: 'https://vpn.example.edu',
+      https_identity_valid: true, compatibility: 'recognized_candidate',
+      candidate_family: PROTOCOL_FAMILY, reported_version: 'M7.6.8R2', http_status: 200,
+    },
+    schoolLabel: 'Example University',
+    activeContext: active,
+  });
+  const confirmation = owner.consume({ confirmationHandle: view.confirmationHandle,
+    activeContext: active });
+  let provisionSeed = 80;
+  return new CustomProfileProvisioningRuntime({
+    userData,
+    randomBytes: (length) => Buffer.alloc(length, ++provisionSeed),
+    now: () => 1_800_000_000_100,
+  }).begin(confirmation);
+}
+
+const custom = provision();
+writeJson(path.join(userData, 'global', 'settings.json'), {
+  schemaVersion: 1,
+  activeProfileKey: custom.context.profileKey,
+  activeAccountKey: custom.context.accountKey,
+  port: 6180,
+  strictProxyAuth: true,
+  proxySecurityVersion: 3,
+  proxyAuthMigrationPending: false,
+  closeAction: 'minimize',
+  language: 'en',
+  startAtLogin: false,
+});
+writeJson(path.join(userData, 'global', 'update-state.json'), { schemaVersion: 1, checkedAt: 0 });
+
+require('../main');
+
+async function waitFor(predicate, message) {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const value = predicate();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(message);
+}
+
+async function run() {
+  await app.whenReady();
+  const control = await waitFor(() => BrowserWindow.getAllWindows().find((window) => (
+    window.webContents.getURL().endsWith('/renderer/index.html') && !window.webContents.isLoading()
+  )), 'custom Profile control window did not start');
+  const state = await control.webContents.executeJavaScript('window.api.getState()');
+  assert.equal(state.schoolProfile.profileId, custom.profileId);
+  assert.equal(state.schoolProfile.unverified, true);
+  assert.equal(state.schoolProfile.normalizedGatewayOrigin, 'https://vpn.example.edu');
+  assert.equal(state.hasPassword, false);
+  assert.equal(state.loggedIn, false);
+  assert.equal(state.connected, false);
+  assert.deepEqual(state.campusResources, []);
+  assert.deepEqual(state.settings.routeDomains, []);
+
+  const opened = await control.webContents.executeJavaScript('window.api.openCampusBrowser({})');
+  assert.deepEqual(opened, { ok: true, url: 'about:blank', route: 'direct' });
+  await waitFor(() => BrowserWindow.getAllWindows().some((window) => (
+    window.webContents.getURL().includes('/renderer/campus-browser.html')
+  )), 'custom Profile Campus Browser did not open');
+  const expectedPartition = custom.context.workspaceKey;
+  const partitionName = `persist:campus-workspace-${require('node:crypto').createHash('sha256')
+    .update('campus-connect-workspace-partition-v1\0', 'utf8')
+    .update(expectedPartition, 'utf8').digest('hex').slice(0, 32)}`;
+  const expectedSession = session.fromPartition(partitionName);
+  const page = await waitFor(() => webContents.getAllWebContents().find((contents) => (
+    contents !== control.webContents && contents.getURL() === 'about:blank' &&
+    contents.session === expectedSession
+  )), 'custom Profile page did not use its Workspace-derived Session');
+  assert.equal(page.session.getStoragePath().includes('hkustgz-campus-browser'), false);
+  assert.equal(BrowserWindow.getAllWindows().length >= 2, true);
+  process.stdout.write('main custom Profile startup: PASS\n');
+}
+
+run().then(() => app.quit()).catch((error) => {
+  process.stderr.write(`${error.stack || error}\n`);
+  app.exit(1);
+});
+
+app.on('quit', () => {
+  try { fs.rmSync(userData, { recursive: true, force: true }); } catch {}
+});

--- a/desktop/e2e/main-integration.electron.js
+++ b/desktop/e2e/main-integration.electron.js
@@ -132,7 +132,7 @@ async function run() {
     route: 'direct',
   })`);
   assert.equal(directWithoutTunnel.ok, false,
-    'even a DIRECT first page must establish the tunnel before preserving a later SAML return');
+    'a remote DIRECT first page still establishes the tunnel for a later SAML return');
   assert.equal(BrowserWindow.getAllWindows().some((candidate) => (
     candidate.webContents.getURL().includes('/renderer/campus-browser.html')
   )), false);

--- a/desktop/lib/browser-session-manager.js
+++ b/desktop/lib/browser-session-manager.js
@@ -136,6 +136,10 @@ class BrowserSessionManager {
     partition = CAMPUS_PARTITION,
     onSessionReady,
   } = {}) {
+    if (typeof partition !== 'string' || partition.length > 96 ||
+        !/^persist:[a-z0-9-]+$/u.test(partition)) {
+      throw new TypeError('校园浏览器存储分区无效');
+    }
     this.electronSession = session;
     this.routingPolicy = routingPolicy;
     this.partition = partition;

--- a/desktop/lib/campus-browser-manager.js
+++ b/desktop/lib/campus-browser-manager.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { CampusBrowser, DEFAULT_CAMPUS_HOME } = require('./campus-browser');
+const { BLANK_CAMPUS_HOME, CampusBrowser, DEFAULT_CAMPUS_HOME } = require('./campus-browser');
+const { CAMPUS_PARTITION } = require('./campus-route');
 const { CampusCredentialVault } = require('./campus-credential-vault');
 const { normalizeOpenRequest } = require('./campus-open-policy');
 
@@ -19,6 +20,7 @@ class CampusBrowserManager {
     toolbarPreload,
     campusPreload,
     homeUrl = DEFAULT_CAMPUS_HOME,
+    browserPartition = CAMPUS_PARTITION,
     routingPolicy,
     ensureCampusReady,
     resolveRoute,
@@ -41,14 +43,16 @@ class CampusBrowserManager {
       }
     }
     if (!session || !dialog || !safeStorage || !certificateTrust || !routingPolicy ||
-        ![credentialFile, toolbarFile, toolbarPreload, campusPreload, homeUrl]
+        ![credentialFile, toolbarFile, toolbarPreload, campusPreload, browserPartition]
           .every((value) => typeof value === 'string' && value)) {
       throw new TypeError('Campus Browser manager environment is incomplete');
     }
     Object.assign(this, {
       BrowserWindow, WebContentsView, session, dialog, safeStorage, platform,
       credentialFile, certificateTrust, parentWindow, toolbarFile, toolbarPreload,
-      campusPreload, homeUrl, routingPolicy, ensureCampusReady, resolveRoute, ensureConnected,
+      campusPreload, homeUrl: homeUrl || BLANK_CAMPUS_HOME,
+      routingPolicy, ensureCampusReady, resolveRoute, ensureConnected,
+      browserPartition,
       getSocksPort, getLocale, getTranslator, showRoutingRules, reportError,
       CampusBrowserClass, CredentialVaultClass,
     });
@@ -80,6 +84,7 @@ class CampusBrowserManager {
       toolbarPreload: this.toolbarPreload,
       campusPreload: this.campusPreload,
       homeUrl: this.homeUrl,
+      partition: this.browserPartition,
       routingPolicy: this.routingPolicy,
       ensureCampusReady: this.ensureCampusReady,
       onManageRoutingRules: this.showRoutingRules,
@@ -94,23 +99,31 @@ class CampusBrowserManager {
     const translate = this.getTranslator();
     let request;
     try {
-      request = normalizeOpenRequest(rawRequest, translate);
+      request = normalizeOpenRequest(rawRequest, translate, this.homeUrl);
     } catch (error) {
       this.reportError(error.message);
       return { ok: false, error: error.message };
     }
-    try {
-      request.route = this.resolveRoute(request.url).route;
-    } catch (error) {
-      const message = error.userMessage || error.message;
-      this.reportError(message);
-      return { ok: false, error: message };
+    if (request.url !== BLANK_CAMPUS_HOME) {
+      try {
+        request.route = this.resolveRoute(request.url).route;
+      } catch (error) {
+        const message = error.userMessage || error.message;
+        this.reportError(message);
+        return { ok: false, error: message };
+      }
     }
-    const connection = await this.ensureConnected();
-    if (!connection?.ok) {
-      const error = connection?.error || translate('error.connectTimeout');
-      this.reportError(error);
-      return { ok: false, error };
+    // The local custom-Profile landing page has no network request and must be
+    // usable before credentials exist. Real HTTP(S) pages still establish the
+    // tunnel up front until the request-boundary on-demand barrier can preserve
+    // an original cross-origin SSO redirect without replaying it as a GET.
+    if (request.url !== BLANK_CAMPUS_HOME) {
+      const connection = await this.ensureConnected();
+      if (!connection?.ok) {
+        const error = connection?.error || translate('error.connectTimeout');
+        this.reportError(error);
+        return { ok: false, error };
+      }
     }
     try {
       await this.getOrCreate().open(request.url, this.getSocksPort(), request.route);

--- a/desktop/lib/campus-browser.js
+++ b/desktop/lib/campus-browser.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const DEFAULT_CAMPUS_HOME = 'https://www.hkust-gz.edu.cn/';
+const BLANK_CAMPUS_HOME = 'about:blank';
 const {
   CAMPUS_PARTITION,
   ROUTE_CAMPUS,
@@ -31,6 +32,7 @@ const MAX_TABS = DEFAULT_MAX_TABS;
 
 function normalizeCampusUrl(input, fallback = DEFAULT_CAMPUS_HOME, t = createT('zh')) {
   let value = String(input || '').trim() || fallback;
+  if (value === BLANK_CAMPUS_HOME && fallback === BLANK_CAMPUS_HOME) return BLANK_CAMPUS_HOME;
   if (value.length > MAX_URL_LENGTH) throw new Error(t('url.tooLong'));
   if (!/^[a-z][a-z0-9+.-]*:/i.test(value)) value = `https://${value}`;
 
@@ -70,6 +72,7 @@ function campusWindowChrome(platform) {
 }
 
 function safePopupUrl(value) {
+  if (value === BLANK_CAMPUS_HOME) return true;
   try {
     const parsed = new URL(value);
     return ['http:', 'https:'].includes(parsed.protocol);
@@ -168,6 +171,7 @@ class CampusBrowser {
     locale,
     t,
     onError,
+    partition = CAMPUS_PARTITION,
   }) {
     this.BrowserWindow = BrowserWindow;
     this.WebContentsView = WebContentsView;
@@ -185,7 +189,9 @@ class CampusBrowser {
     this.onManageRoutingRules = onManageRoutingRules;
     this.locale = locale === 'en' ? 'en' : 'zh';
     this.t = typeof t === 'function' ? t : createT(this.locale);
-    this.homeUrl = normalizeCampusUrl(homeUrl, DEFAULT_CAMPUS_HOME, this.t);
+    this.homeUrl = homeUrl === BLANK_CAMPUS_HOME
+      ? BLANK_CAMPUS_HOME
+      : normalizeCampusUrl(homeUrl, DEFAULT_CAMPUS_HOME, this.t);
     this.onError = onError;
     this.certificateController = new CertificateController({
       trustStore: certificateTrust,
@@ -207,6 +213,7 @@ class CampusBrowser {
     this.tabManager = new TabManager({ maxTabs: MAX_TABS });
     this.browserSessionManager = new BrowserSessionManager({
       session,
+      partition,
       routingPolicy: this.routingPolicy,
       onSessionReady: (browserSession) => this.applyDownloadHandler(browserSession),
     });
@@ -368,6 +375,9 @@ class CampusBrowser {
   }
 
   resolveRoute(rawUrl, inheritedRoute = null, requestedRoute = null) {
+    if (rawUrl === BLANK_CAMPUS_HOME) {
+      return { route: ROUTE_DIRECT, source: 'local-blank', matchedRule: null };
+    }
     let resolution;
     try {
       resolution = this.routingPolicy.resolve(rawUrl, inheritedRoute);
@@ -479,7 +489,7 @@ class CampusBrowser {
     const active = this.activeTab();
     const navigation = navigationForContents(active?.view.webContents);
 
-    if (command === 'new-tab') this.createTab(this.homeUrl, ROUTE_CAMPUS);
+    if (command === 'new-tab') this.createTab(this.homeUrl);
     else if (command === 'switch-tab') this.switchTab(Number(value));
     else if (command === 'close-tab') this.closeTab(Number(value));
     else if (command === 'set-route' && active) {
@@ -1034,6 +1044,7 @@ module.exports = {
   CAMPUS_PARTITION,
   CampusBrowser,
   DEFAULT_CAMPUS_HOME,
+  BLANK_CAMPUS_HOME,
   FIND_BAR_HEIGHT,
   MAX_TABS,
   SLOW_LOADING_HINT_MS,

--- a/desktop/lib/campus-open-policy.js
+++ b/desktop/lib/campus-open-policy.js
@@ -1,12 +1,14 @@
 'use strict';
 
 const { ROUTE_CAMPUS, ROUTE_DIRECT, routeForUrl } = require('./campus-route');
-const { normalizeCampusUrl } = require('./campus-browser');
+const { BLANK_CAMPUS_HOME, normalizeCampusUrl } = require('./campus-browser');
 
-function normalizeOpenRequest(input, t) {
+function normalizeOpenRequest(input, t, fallback) {
   const source = input && typeof input === 'object' ? input : { url: input };
-  const url = normalizeCampusUrl(source.url, undefined, t);
-  const route = [ROUTE_CAMPUS, ROUTE_DIRECT].includes(source.route)
+  const url = normalizeCampusUrl(source.url, fallback, t);
+  const route = url === BLANK_CAMPUS_HOME
+    ? ROUTE_DIRECT
+    : [ROUTE_CAMPUS, ROUTE_DIRECT].includes(source.route)
     ? source.route
     : routeForUrl(url);
   return { url, route };

--- a/desktop/lib/connection-telemetry-coordinator.js
+++ b/desktop/lib/connection-telemetry-coordinator.js
@@ -27,7 +27,7 @@ function tcpPing(host, port) {
 }
 
 function validHealthTargets(value) {
-  return Array.isArray(value) && value.length >= 2 && value.every((target) => (
+  return Array.isArray(value) && (value.length === 0 || value.length >= 2) && value.every((target) => (
     target && typeof target.host === 'string' && target.host &&
     Number.isInteger(target.port) && target.port >= 1 && target.port <= 65535
   ));
@@ -147,6 +147,9 @@ class ConnectionTelemetryCoordinator {
   async checkHealth(generation) {
     if (!this.current(generation) ||
         this.recoveryInFlight?.generation === generation) return undefined;
+    if (this.healthTargets?.length === 0) {
+      return { kind: 'unknown', failedTargets: [] };
+    }
     let proxyPort;
     try { proxyPort = Number(this.getSocksPort()); }
     catch { return { kind: 'settings-unavailable', failedTargets: [] }; }

--- a/desktop/lib/multi-school-startup-runtime.js
+++ b/desktop/lib/multi-school-startup-runtime.js
@@ -49,17 +49,27 @@ class MultiSchoolStartupRuntime {
       throw new TypeError('active reviewed Profile access must be synchronous');
     }
     const profile = validateSchoolProfileDocument(sourceDocument);
-    if (profile.evidenceClass !== 'builtin-reviewed' ||
-        authority.profile?.profileId !== profile.profileId ||
+    if (authority.profile?.profileId !== profile.profileId ||
         authority.profile?.profileRevision !== profile.profileRevision) {
-      throw new Error('startup reviewed Profile does not match persistence authority');
+      throw new Error('startup Profile does not match persistence authority');
     }
     const directory = new this.CandidateDirectoryClass(this.options);
-    directory.anchorReviewedCurrent({
-      profileId: profile.profileId,
-      profileKey: authority.globalSettings.activeProfileKey,
-      accountKey: authority.globalSettings.activeAccountKey,
-    });
+    if (profile.evidenceClass === 'builtin-reviewed') {
+      directory.anchorReviewedCurrent({
+        profileId: profile.profileId,
+        profileKey: authority.globalSettings.activeProfileKey,
+        accountKey: authority.globalSettings.activeAccountKey,
+      });
+    } else {
+      let matched = false;
+      directory.withCandidate(profile.profileId, (record) => {
+        matched = record.context.profileKey === authority.layout.identity.profileKey &&
+          record.context.accountKey === authority.account.accountKey &&
+          record.context.workspaceKey === authority.account.workspaceKey &&
+          record.context.activeContextEpoch === authority.workspaceState.activeContextEpoch;
+      });
+      if (!matched) throw new Error('startup custom Profile candidate does not match authority');
+    }
     this.directory = directory;
     this.state = Object.freeze({
       ready: true,

--- a/desktop/lib/pac.js
+++ b/desktop/lib/pac.js
@@ -47,7 +47,7 @@ function normalizeRouteDomains(input, defaultDomains = DEFAULT_ROUTE_DOMAINS) {
 }
 
 function buildPac(routeDomains, port, options = {}) {
-  const domains = normalizeRouteDomains(routeDomains);
+  const domains = normalizeRouteDomains(routeDomains, options.schoolDomains);
   const proxyPort = Number.isInteger(port) && port >= 1025 && port <= 65535 ? port : 1080;
   return buildDomainRoutePac({ ...options, schoolDomains: domains }, proxyPort, {
     defaultRoute: ROUTE_DIRECT,

--- a/desktop/lib/profile-candidate-directory.js
+++ b/desktop/lib/profile-candidate-directory.js
@@ -11,6 +11,7 @@ const { SchoolProfileRegistry } = require('./school-profile-registry');
 const { verifyEngineConfigBinding } = require('./school-profile-runtime');
 const {
   createSchoolProfileView,
+  validateOpaqueKey,
   validateSchoolProfileDocument,
 } = require('./school-profile-schema');
 const {
@@ -109,6 +110,21 @@ class ProfileCandidateDirectory {
     return Object.freeze([...reviewed, ...custom]);
   }
 
+  resolveProfileIdByKey(profileKey) {
+    const key = validateOpaqueKey(profileKey, 'active profileKey');
+    const matches = [
+      ...this.anchorStore.read().entries,
+      ...this.customRegistry.indexStore.read().entries,
+    ].filter((entry) => entry.profileKey === key);
+    if (matches.length > 1) throw new Error('active profileKey has ambiguous ownership');
+    return matches[0]?.profileId || null;
+  }
+
+  hasAnyCandidates() {
+    return this.anchorStore.read().entries.length > 0 ||
+      this.customRegistry.indexStore.read().entries.length > 0;
+  }
+
   withCandidate(profileId, callback) {
     if (typeof callback !== 'function') throw new TypeError('Profile candidate callback is required');
     const anchor = this.anchorStore.get(profileId);
@@ -132,6 +148,7 @@ class ProfileCandidateDirectory {
       record = this.customRegistry.reload().withProfile(profileId, (custom) => Object.freeze({
         ...custom,
         kind: 'custom-local',
+        builtInResources: Object.freeze([]),
         view: createSchoolProfileView(custom.sourceDocument, {
           locale: 'en', compatibility: 'candidate',
         }),
@@ -161,6 +178,7 @@ class ProfileCandidateDirectory {
       sourceDocument,
       authority,
       engineConfig,
+      builtInResources: this.packagedRegistry.getBuiltinResources(profile.profileId),
       context: Object.freeze({
         profileId: profile.profileId,
         profileKey: authority.layout.identity.profileKey,

--- a/desktop/lib/profile-workspace-runtime-authority.js
+++ b/desktop/lib/profile-workspace-runtime-authority.js
@@ -193,7 +193,8 @@ function loadActiveProfileAccountAuthority({
     profileKey: globalSettings.activeProfileKey,
     accountKey: globalSettings.activeAccountKey,
     workspaceKey: account.workspaceKey,
-    adoptLegacyHkustBrowserPartition: true,
+    adoptLegacyHkustBrowserPartition: profile.evidenceClass === 'builtin-reviewed' &&
+      profile.profileId === 'hkustgz',
   });
   const workspaceState = readDocument(
     layout.workspace.state,

--- a/desktop/lib/profile-workspace-settings-bundle.js
+++ b/desktop/lib/profile-workspace-settings-bundle.js
@@ -20,14 +20,20 @@ function plainObject(value, name) {
   return value;
 }
 
-function exactLegacySettings(value) {
+function profileRouteDomains(authority) {
+  return Array.isArray(authority?.profile?.browser?.campusDomains)
+    ? authority.profile.browser.campusDomains
+    : DEFAULTS.routeDomains;
+}
+
+function exactLegacySettings(value, defaultRouteDomains) {
   const source = plainObject(value, 'runtime settings projection');
   const keys = Object.keys(source).sort();
   if (keys.length !== LEGACY_SETTINGS_KEYS.length ||
       keys.some((key, index) => key !== LEGACY_SETTINGS_KEYS[index])) {
     throw new TypeError('runtime settings projection has an invalid schema');
   }
-  const normalized = normalizeSettings(source);
+  const normalized = normalizeSettings(source, { defaultRouteDomains });
   if (!isDeepStrictEqual(source, normalized)) {
     throw new TypeError('runtime settings projection is not canonical');
   }
@@ -71,12 +77,12 @@ function projectRuntimeSettings(authorityValue, { accountLabel = '' } = {}) {
     updateCheckedAt: update.checkedAt,
     routeDomains: workspace.routeDomains,
     customResources: local.resources,
-  }));
+  }, { defaultRouteDomains: profileRouteDomains(authority) }));
 }
 
 function splitRuntimeSettings(authorityValue, settingsValue) {
   const authority = validateAuthority(authorityValue);
-  const settings = exactLegacySettings(settingsValue);
+  const settings = exactLegacySettings(settingsValue, profileRouteDomains(authority));
   return Object.freeze({
     globalSettings: validateGlobalSettingsDocument({
       ...authority.globalSettings,

--- a/desktop/lib/profile-workspace-startup-runtime.js
+++ b/desktop/lib/profile-workspace-startup-runtime.js
@@ -159,11 +159,15 @@ class ProfileWorkspaceStartupRuntime {
 
   #recoverRuntimeTransactions() {
     let accountAuthority = this.#accountAuthority();
-    this.#rollbackStore(accountAuthority).reconcile();
+    const ownsLegacyHkustRollback = this.profile.evidenceClass === 'builtin-reviewed' &&
+      this.profile.profileId === 'hkustgz';
+    if (ownsLegacyHkustRollback) this.#rollbackStore(accountAuthority).reconcile();
     const credentialStore = new ProfileWorkspaceCredentialStore({
       loadAccountAuthority: () => this.#accountAuthority(),
       loadWorkspaceAuthority: () => this.#workspaceAuthority(),
-      retireRollback: ({ authority, reason }) => this.#rollbackStore(authority).retire({ reason }),
+      retireRollback: ({ authority, reason }) => ownsLegacyHkustRollback
+        ? this.#rollbackStore(authority).retire({ reason })
+        : true,
       safeStorage: this.safeStorage,
       fileSystem: this.fileSystem,
       platform: this.platform,

--- a/desktop/lib/school-profile-controller.js
+++ b/desktop/lib/school-profile-controller.js
@@ -1,9 +1,25 @@
 'use strict';
 
 const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { CAMPUS_PARTITION } = require('./campus-route');
 const { mergeCampusResources, projectCampusResources } = require('./campus-resources');
 const { createActiveSchoolProfileContext } = require('./school-profile-runtime');
-const { createCapabilitySnapshot } = require('./school-profile-schema');
+const { ProfileCandidateDirectory } = require('./profile-candidate-directory');
+const { verifyPrivateDirectoryChain } = require('./private-directory');
+const { validateGlobalSettingsDocument } = require('./profile-workspace-documents');
+const { readPrivateFileBounded } = require('./private-file');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
+const {
+  createCapabilitySnapshot,
+  createLegacyPrimaryAccountView,
+  createLegacyWorkspaceView,
+  createSchoolProfileView,
+} = require('./school-profile-schema');
 
 const CURRENT_PROFILE_CAPABILITIES = new Set(['auth.password', 'transport.l3']);
 
@@ -15,7 +31,117 @@ function selectedCapabilityLayer(keys) {
 }
 
 function createSchoolProfileController(options = {}) {
-  const context = createActiveSchoolProfileContext(options);
+  const source = createActiveSchoolProfileContext(options);
+  const context = {
+    ...source,
+    activeContextEpoch: 1,
+    browserPartition: CAMPUS_PARTITION,
+    compatibility: 'reviewed',
+    withProfileDocument: (callback) => source.registry.withDefaultProfileDocument(callback),
+    createProfileView: (options) => source.createProfileView(options),
+  };
+  return createController(context, options);
+}
+
+function createSchoolProfileControllerFromCandidate({ directory, profileId, ...options } = {}) {
+  if (!directory || typeof directory.withCandidate !== 'function') {
+    throw new TypeError('candidate Profile directory is invalid');
+  }
+  const load = () => {
+    let record = null;
+    directory.withCandidate(profileId, (value) => { record = value; });
+    if (!record) throw new Error('candidate Profile is unavailable');
+    return record;
+  };
+  const record = load();
+  const profile = record.profile;
+  const context = {
+    profile,
+    builtinResources: record.builtInResources || Object.freeze([]),
+    gatewayHost: profile.gateway.origin.hostname.replace(/^\[|\]$/gu, ''),
+    gatewayPort: profile.gateway.origin.port,
+    engineConfigPath: record.engineConfig.path,
+    activeContextEpoch: record.context.activeContextEpoch,
+    browserPartition: record.authority.layout.browserPartition,
+    compatibility: record.kind === 'builtin-reviewed' ? 'reviewed' : 'candidate',
+    verifyEngineConfig: () => load().engineConfig,
+    verifyEngineLaunchBinding: () => load().engineLaunchBinding,
+    withProfileDocument: (callback) => {
+      if (typeof callback !== 'function') throw new TypeError('Profile document callback is required');
+      const result = callback(load().sourceDocument);
+      if (result && typeof result.then === 'function') {
+        throw new TypeError('Profile document callback must be synchronous');
+      }
+      return result;
+    },
+    createProfileView: (viewOptions) => createSchoolProfileView(
+      load().sourceDocument,
+      { ...viewOptions, compatibility: record.kind === 'builtin-reviewed' ? 'reviewed' : 'candidate' },
+    ),
+  };
+  return createController(context, options);
+}
+
+function createPreReadySchoolProfileController({
+  userData,
+  fileSystem = fs,
+  platform = process.platform,
+  windowsAcl = {
+    protect: protectWindowsFileOwnerOnly,
+    verify: verifyWindowsFileOwnerOnly,
+  },
+  ...options
+} = {}) {
+  const globalSettings = path.join(userData, 'global', 'settings.json');
+  try { fileSystem.lstatSync(globalSettings); }
+  catch (error) {
+    if (error?.code === 'ENOENT') return createSchoolProfileController({ ...options, fsImpl: fileSystem });
+    throw new Error('pre-ready active Profile authority is unreadable', { cause: error });
+  }
+  verifyPrivateDirectoryChain(userData, path.dirname(globalSettings), { fileSystem, platform });
+  if (platform === 'win32' && !windowsAcl.verify(globalSettings)) {
+    throw new Error('pre-ready GlobalSettings ACL is invalid');
+  }
+  let data;
+  try {
+    ({ data } = readPrivateFileBounded(globalSettings, {
+      maxBytes: 512 * 1024,
+      minBytes: 2,
+      platform,
+      fileSystem,
+    }));
+  } catch (error) {
+    throw new Error('pre-ready active Profile authority is unreadable', { cause: error });
+  }
+  let settings;
+  try { settings = validateGlobalSettingsDocument(JSON.parse(data.toString('utf8'))); }
+  catch (error) { throw new Error('pre-ready GlobalSettings is invalid', { cause: error }); }
+  finally { data.fill(0); }
+
+  const directory = new ProfileCandidateDirectory({
+    userData,
+    packageRoot: options.packageRoot,
+    isPackaged: options.isPackaged,
+    resourcesPath: options.resourcesPath,
+    desktopDir: options.desktopDir,
+    fileSystem,
+    platform,
+    windowsAcl,
+  });
+  const profileId = directory.resolveProfileIdByKey(settings.activeProfileKey);
+  if (profileId === null) {
+    if (directory.hasAnyCandidates()) {
+      throw new Error('pre-ready active profileKey is not owned by a candidate');
+    }
+    // One-time compatibility for the first P6 startup after P3 migration:
+    // prior builds could only create the reviewed HKUST authority, and P6g
+    // persists its anchor after this fallback succeeds.
+    return createSchoolProfileController({ ...options, fsImpl: fileSystem });
+  }
+  return createSchoolProfileControllerFromCandidate({ directory, profileId, ...options });
+}
+
+function createController(context, options) {
   const { profile } = context;
   const builtInResources = context.builtinResources;
   const randomBytes = typeof options.randomBytes === 'function' ? options.randomBytes : crypto.randomBytes;
@@ -27,7 +153,7 @@ function createSchoolProfileController(options = {}) {
   // "-" or "_", which the bounded handle schema rejects at random.
   const accountHandle = `account-${accountEntropy.toString('hex')}`;
   accountEntropy.fill(0);
-  const activeContextEpoch = 1;
+  const activeContextEpoch = context.activeContextEpoch;
   let currentCapabilitySnapshot = null;
 
   function capabilitySnapshotFromReport(report) {
@@ -58,6 +184,7 @@ function createSchoolProfileController(options = {}) {
     directPartnerDomains: profile.browser.directPartnerDomains,
     browserHomeUrl: profile.browser.homeUrl,
     healthTargets: profile.browser.healthTargets,
+    browserPartition: context.browserPartition,
     builtInResourceCount: builtInResources.length,
     activeContextBinding: () => Object.freeze({
       profileId: profile.profileId,
@@ -65,9 +192,12 @@ function createSchoolProfileController(options = {}) {
       accountHandle,
       activeContextEpoch,
     }),
-    withProfileDocument: (callback) => context.registry.withDefaultProfileDocument(callback),
+    withProfileDocument: context.withProfileDocument,
     verifyEngineConfig: context.verifyEngineConfig,
     verifyEngineLaunchBinding() {
+      if (typeof context.verifyEngineLaunchBinding === 'function') {
+        return context.verifyEngineLaunchBinding();
+      }
       const verified = context.verifyEngineConfig();
       const stdinFrame = JSON.stringify({
         type: 'engine_config_binding',
@@ -115,16 +245,20 @@ function createSchoolProfileController(options = {}) {
       resourceCount = builtInResources.length,
     } = {}) {
       return Object.freeze({
-        schoolProfile: context.createProfileView({ locale, compatibility: 'reviewed' }),
-        campusAccount: context.createLegacyPrimaryAccountView({
+        schoolProfile: context.createProfileView({ locale, compatibility: context.compatibility }),
+        campusAccount: createLegacyPrimaryAccountView({
           accountHandle,
           hasCredential,
           isActive: true,
         }),
-        workspace: context.createLegacyWorkspaceView({ accountHandle, resourceCount }),
+        workspace: createLegacyWorkspaceView({ accountHandle, resourceCount }),
       });
     },
   });
 }
 
-module.exports = { createSchoolProfileController };
+module.exports = {
+  createPreReadySchoolProfileController,
+  createSchoolProfileController,
+  createSchoolProfileControllerFromCandidate,
+};

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -45,7 +45,7 @@ const { DomainRoutePolicyStore } = require('./lib/domain-route-policy');
 const { savePacFile } = require('./lib/pac-file');
 const { pacDataUrl } = require('./lib/browser-session-manager');
 const { CampusBrowserManager } = require('./lib/campus-browser-manager');
-const { createSchoolProfileController } = require('./lib/school-profile-controller');
+const { createPreReadySchoolProfileController } = require('./lib/school-profile-controller');
 const {
   createControlStateSnapshot,
   registerControlDataIpc,
@@ -108,7 +108,8 @@ const legacyRuntimeStoragePaths = createLegacyRuntimeStoragePaths(DATA);
 try { fs.unlinkSync(legacyRuntimeStoragePaths.proxyHelperCredential); } catch (error) {
   if (error?.code !== 'ENOENT') { /* strict access fails closed if replacement is unsafe */ }
 }
-const activeSchoolProfile = createSchoolProfileController({
+const activeSchoolProfile = createPreReadySchoolProfileController({
+  userData: DATA,
   packageRoot: __dirname, isPackaged: app.isPackaged,
   resourcesPath: process.resourcesPath, desktopDir: __dirname,
 });
@@ -131,7 +132,6 @@ const ACTIVE_CONTEXT_SWITCH = runtimeStoragePaths.activeContextSwitch;
 const PROXY_CREDENTIAL = runtimeStoragePaths.proxyCredential;
 const PROXY_HELPER_CREDENTIAL = runtimeStoragePaths.proxyHelperCredential;
 const syntheticEngineE2e = !app.isPackaged && process.env[SYNTHETIC_ENGINE_E2E_ENV] === '1';
-
 // The helper sidecar is a short-lived, owner-only plaintext projection of the
 // encrypted stable credential. It is valid only while this app owns (or is
 // about to start) the loopback listener, so never carry it across launches.
@@ -440,7 +440,6 @@ const domainRoutePolicy = new DomainRoutePolicyStore({
   directPartnerDomains: () => activeSchoolProfile.directPartnerDomains,
   serverResources: () => serverCampusResources,
 });
-
 // ---------- engine ----------
 function enginePath() {
   const plat = process.platform === 'win32' ? 'windows' : process.platform === 'darwin' ? 'darwin' : 'linux';
@@ -1272,6 +1271,7 @@ campusBrowserManager = new CampusBrowserManager({
   toolbarPreload: path.join(__dirname, 'lib', 'campus-toolbar-contract.js'),
   campusPreload: path.join(__dirname, 'campus-preload.js'),
   homeUrl: activeSchoolProfile.browserHomeUrl,
+  browserPartition: preReadyStorage.authority?.layout?.browserPartition || activeSchoolProfile.browserPartition,
   routingPolicy: browserRoutingPolicy,
   ensureCampusReady,
   resolveRoute: (url) => domainRoutePolicy.resolve(url),

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -18,6 +18,7 @@
     "test:routing-restart": "node e2e/routing-restart.electron.js",
     "test:renderer-layout": "electron e2e/resource-manager-layout.electron.js",
     "test:main-integration": "electron e2e/main-integration.electron.js",
+    "test:main-custom-profile": "electron e2e/main-custom-profile.electron.js",
     "test:main-engine-lifecycle": "electron e2e/main-engine-lifecycle.electron.js",
     "test:main-network-startup": "electron e2e/main-network-startup.electron.js",
     "test:persistence-migration": "electron e2e/persistence-migration.electron.js",
@@ -66,6 +67,8 @@
           "ec-engine.exe",
           "ec-proxy-command-*",
           "ec-proxy-command.exe",
+          "ec-gateway-probe-*",
+          "ec-gateway-probe.exe",
           "hkustgz.json"
         ]
       }

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -113,8 +113,6 @@ button, input, select, a, code { -webkit-app-region: no-drag; }
 .conn-status.on { color: var(--ok); }
 .conn-status.busy { color: var(--gold); }
 .dot { width: 8px; height: 8px; border-radius: 50%; background: currentColor; box-shadow: 0 0 0 0 currentColor; }
-.conn-status.on .dot { animation: ping 2s infinite; }
-@keyframes ping { 0% { box-shadow: 0 0 0 0 rgba(26,165,104,.5); } 70% { box-shadow: 0 0 0 6px rgba(26,165,104,0); } 100% { box-shadow: 0 0 0 0 rgba(26,165,104,0); } }
 .conn-err { color: var(--err); font-size: 12.5px; margin-top: 8px; min-height: 0; line-height: 1.4; }
 .conn-body { display: flex; flex-direction: column; gap: 10px; }
 .collapsible-panel { display: flex; flex-direction: column; gap: 10px; }

--- a/desktop/scripts/build-engine.sh
+++ b/desktop/scripts/build-engine.sh
@@ -28,11 +28,13 @@ run_cargo() {
 }
 
 cd "$ROOT/independent"
-run_cargo build --locked --release --no-default-features --bin ec-engine --bin ec-proxy-command
+run_cargo build --locked --release --no-default-features --bin ec-engine --bin ec-proxy-command --bin ec-gateway-probe
 mkdir -p "$HERE/engine"
 cp target/release/ec-engine "$HERE/engine/ec-engine-$PLATFORM-$ARCH"
 cp target/release/ec-proxy-command "$HERE/engine/ec-proxy-command-$PLATFORM-$ARCH"
+cp target/release/ec-gateway-probe "$HERE/engine/ec-gateway-probe-$PLATFORM-$ARCH"
 cp config/hkustgz.json "$HERE/engine/hkustgz.json"
 chmod 755 "$HERE/engine/ec-engine-$PLATFORM-$ARCH"
 chmod 755 "$HERE/engine/ec-proxy-command-$PLATFORM-$ARCH"
-echo "staged independent binaries: engine/ec-engine-$PLATFORM-$ARCH, engine/ec-proxy-command-$PLATFORM-$ARCH"
+chmod 755 "$HERE/engine/ec-gateway-probe-$PLATFORM-$ARCH"
+echo "staged independent binaries: engine/ec-engine-$PLATFORM-$ARCH, engine/ec-proxy-command-$PLATFORM-$ARCH, engine/ec-gateway-probe-$PLATFORM-$ARCH"

--- a/desktop/test/auth-control-fixture-contract.test.js
+++ b/desktop/test/auth-control-fixture-contract.test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const source = fs.readFileSync(path.join(__dirname, '..', 'e2e', 'auth-control-fixture.js'), 'utf8');
+
+test('synthetic auth fixture binds one current context and kills its child on harness failure', () => {
+  assert.match(source, /isContextCurrent:\s*\(candidate\)\s*=>\s*candidate === contextToken/u);
+  assert.match(source, /registry\.bind\(9, child\.stdin, contextToken\)/u);
+  assert.match(source, /main\(\)\.catch[\s\S]*activeChild\?\.kill\(\)/u);
+  assert.doesNotMatch(source, /registry\.bind\(9, child\.stdin\);/u);
+});

--- a/desktop/test/campus-browser-manager.test.js
+++ b/desktop/test/campus-browser-manager.test.js
@@ -68,6 +68,22 @@ test('manager creates one browser with Engine-neutral injected policies', async 
   assert.equal(Object.hasOwn(browser.options, 'gatewayToken'), false);
 });
 
+test('custom Profile uses its isolated partition and a local blank home without network fallback', async () => {
+  const partition = `persist:campus-workspace-${'1'.repeat(32)}`;
+  let connectionCalls = 0;
+  const f = fixture({
+    homeUrl: null,
+    browserPartition: partition,
+    ensureConnected: async () => { connectionCalls += 1; return { ok: true }; },
+  });
+  const result = await f.manager.open();
+  assert.equal(result.url, 'about:blank');
+  assert.equal(f.manager.browser.options.homeUrl, 'about:blank');
+  assert.equal(f.manager.browser.options.partition, partition);
+  assert.deepEqual(f.manager.browser.opens, [['about:blank', 6180, 'direct']]);
+  assert.equal(connectionCalls, 0);
+});
+
 test('route, connection and browser failures return bounded UI results', async () => {
   const route = fixture({ resolveRoute: () => { throw new Error('route-failed'); } });
   assert.deepEqual(await route.manager.open('https://x.test'), {

--- a/desktop/test/campus-browser.test.js
+++ b/desktop/test/campus-browser.test.js
@@ -602,6 +602,16 @@ function loadingState(scripts) {
   return { loading: state.loading, slow: state.slow };
 }
 
+test('a custom local blank home keeps every new tab on the non-network direct route', async () => {
+  const { browser } = createFakeBrowser({ homeUrl: 'about:blank' });
+  await browser.open('about:blank', 1080, ROUTE_DIRECT);
+  assert.equal(browser.activeTab().route, ROUTE_DIRECT);
+  browser.handleToolbarCommand({ command: 'new-tab', value: '' });
+  assert.equal(browser.tabs.length, 2);
+  assert.equal(browser.activeTab().view.webContents.getURL(), 'about:blank');
+  assert.equal(browser.activeTab().route, ROUTE_DIRECT);
+});
+
 test('a load slower than ten seconds is flagged per tab', async (t) => {
   t.mock.timers.enable({ apis: ['setTimeout'] });
   const { browser, scripts } = createFakeBrowser();

--- a/desktop/test/connection-telemetry-coordinator.test.js
+++ b/desktop/test/connection-telemetry-coordinator.test.js
@@ -116,6 +116,17 @@ test('disabled recovery and stale generations never restart the Engine', async (
   assert.equal(await stale.coordinator.checkHealth(7), undefined);
 });
 
+test('an unreviewed custom Profile with no health targets performs no invented probe', async () => {
+  const f = fixture({
+    healthTargets: [],
+    runHealthRound: async () => { throw new Error('health probe must stay disabled'); },
+  });
+  f.coordinator.start(7, CONTEXT_TOKEN);
+  assert.deepEqual(await f.coordinator.checkHealth(7), { kind: 'unknown', failedTargets: [] });
+  assert.equal(f.calls.some(([name]) => name === 'health'), false);
+  assert.equal(f.calls.some(([name]) => name === 'reconnect'), false);
+});
+
 test('telemetry requires and forwards the exact active context token', async () => {
   const observed = [];
   const f = fixture({

--- a/desktop/test/main-active-context-contract.test.js
+++ b/desktop/test/main-active-context-contract.test.js
@@ -15,7 +15,7 @@ function section(start, end) {
 }
 
 test('Main creates one Profile-bound lease before persistence and connection services', () => {
-  const profile = source.indexOf('const activeSchoolProfile = createSchoolProfileController(');
+  const profile = source.indexOf('const activeSchoolProfile = createPreReadySchoolProfileController(');
   const lease = source.indexOf(
     'new ActiveContextLease(activeSchoolProfile.activeContextBinding())',
   );

--- a/desktop/test/main-persistence-activation-contract.test.js
+++ b/desktop/test/main-persistence-activation-contract.test.js
@@ -16,7 +16,7 @@ function section(start, end) {
 
 test('pre-ready selection binds every service path before recovery or construction', () => {
   const legacyCleanup = source.indexOf('fs.unlinkSync(legacyRuntimeStoragePaths.proxyHelperCredential)');
-  const profile = source.indexOf('const activeSchoolProfile = createSchoolProfileController(');
+  const profile = source.indexOf('const activeSchoolProfile = createPreReadySchoolProfileController(');
   const selection = source.indexOf('selectProfileWorkspacePreReadyStorage({ userData: DATA, profile })');
   const paths = source.indexOf('const runtimeStoragePaths = preReadyStorage.paths;');
   const recovery = source.indexOf('recoverCredentialSettingsTransaction(CREDENTIAL_TRANSACTION');

--- a/desktop/test/pac.test.js
+++ b/desktop/test/pac.test.js
@@ -41,3 +41,9 @@ test('PAC routes only explicit suffixes and literal private addresses', () => {
   assert.equal(context.FindProxyForURL('http://192.168.1.1/', '192.168.1.1'), 'SOCKS5 127.0.0.1:6180');
   assert.equal(context.FindProxyForURL('https://example.com/', 'example.com'), 'DIRECT');
 });
+
+test('custom Profile PAC does not inherit HKUST domains from an empty authority', () => {
+  const source = buildPac([], 6180, { schoolDomains: [], directPartnerDomains: [] });
+  assert.equal(source.includes('hkust-gz.edu.cn'), false);
+  assert.equal(source.includes('hkust.edu.hk'), false);
+});

--- a/desktop/test/package-engine.test.js
+++ b/desktop/test/package-engine.test.js
@@ -8,7 +8,9 @@ const test = require('node:test');
 const {
   assertEnginePresent,
   assertProxyCommandPresent,
+  assertGatewayProbePresent,
   requiredEngineName,
+  requiredGatewayProbeName,
   requiredProxyCommandName,
 } = require('../build/afterPack');
 const {
@@ -43,6 +45,8 @@ test('packaging maps each target to its required engine name', () => {
   assert.equal(requiredProxyCommandName('darwin', 'arm64'), 'ec-proxy-command-darwin-arm64');
   assert.equal(requiredProxyCommandName('win32', 'x64'), 'ec-proxy-command-windows-amd64.exe');
   assert.equal(requiredProxyCommandName('linux', 'x64'), 'ec-proxy-command-linux-amd64');
+  assert.equal(requiredGatewayProbeName('darwin', 'arm64'), 'ec-gateway-probe-darwin-arm64');
+  assert.equal(requiredGatewayProbeName('win32', 'x64'), 'ec-gateway-probe-windows-amd64.exe');
 });
 
 test('the synthetic auth fixture is never a packaged native resource', () => {
@@ -111,6 +115,7 @@ test('package verifier accepts only the exact target engine, helper and configur
   const expected = [
     'ec-engine-darwin-arm64',
     'ec-proxy-command-darwin-arm64',
+    'ec-gateway-probe-darwin-arm64',
     'hkustgz.json',
   ];
   for (const name of expected) fs.writeFileSync(path.join(directory, name), 'fixture');
@@ -196,6 +201,14 @@ test('packaging fails before signing when the SSH proxy helper is absent', () =>
   assert.throws(
     () => assertProxyCommandPresent(directory, 'darwin', 'arm64'),
     /missing packaged SSH proxy helper:.*ec-proxy-command-darwin-arm64/,
+  );
+});
+
+test('packaging fails before signing when the credential-free Gateway probe is absent', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'hkustgz-gateway-probe-'));
+  assert.throws(
+    () => assertGatewayProbePresent(directory, 'darwin', 'arm64'),
+    /missing packaged Gateway probe:.*ec-gateway-probe-darwin-arm64/u,
   );
 });
 

--- a/desktop/test/pre-ready-profile-resolution.test.js
+++ b/desktop/test/pre-ready-profile-resolution.test.js
@@ -1,0 +1,151 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { CustomGatewayConfirmationOwner } = require('../lib/custom-gateway-onboarding');
+const { CustomProfileProvisioningRuntime } = require('../lib/custom-profile-provisioning-runtime');
+const { MultiSchoolStartupRuntime } = require('../lib/multi-school-startup-runtime');
+const { loadProfileWorkspaceAuthorityByKeys } =
+  require('../lib/profile-workspace-runtime-authority');
+const { selectProfileWorkspacePreReadyStorage } =
+  require('../lib/profile-workspace-pre-ready-selection');
+const { createPreReadySchoolProfileController } = require('../lib/school-profile-controller');
+const { PROTOCOL_FAMILY } = require('../lib/school-profile-schema');
+
+const DESKTOP = path.join(__dirname, '..');
+
+function root(t) {
+  const value = fs.mkdtempSync(path.join(os.tmpdir(), 'pre-ready-profile-resolution-'));
+  fs.chmodSync(value, 0o700);
+  t.after(() => fs.rmSync(value, { recursive: true, force: true }));
+  return value;
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+}
+
+function provisionCustom(userData) {
+  let seed = 1;
+  const owner = new CustomGatewayConfirmationOwner({
+    randomBytes: (length) => Buffer.alloc(length, seed++),
+    now: () => 1_800_000_000_000,
+    ttlMs: 10_000,
+  });
+  const active = {
+    profileId: 'hkustgz', profileRevision: 1,
+    accountHandle: `account-${'a'.repeat(36)}`, activeContextEpoch: 7,
+  };
+  const view = owner.issue({
+    probeResult: {
+      schema_version: 1, normalized_origin: 'https://vpn.example.edu',
+      https_identity_valid: true, compatibility: 'recognized_candidate',
+      candidate_family: PROTOCOL_FAMILY, reported_version: 'M7.6.8R2', http_status: 200,
+    },
+    activeContext: active,
+  });
+  const confirmation = owner.consume({ confirmationHandle: view.confirmationHandle,
+    activeContext: active });
+  let provisionSeed = 70;
+  return new CustomProfileProvisioningRuntime({
+    userData,
+    randomBytes: (length) => Buffer.alloc(length, ++provisionSeed),
+    now: () => 1_800_000_000_100,
+  }).begin(confirmation);
+}
+
+function activateGlobal(userData, context) {
+  writeJson(path.join(userData, 'global', 'settings.json'), {
+    schemaVersion: 1,
+    activeProfileKey: context.profileKey,
+    activeAccountKey: context.accountKey,
+    port: 6180,
+    strictProxyAuth: true,
+    proxySecurityVersion: 3,
+    proxyAuthMigrationPending: false,
+    closeAction: 'minimize',
+    language: 'en',
+    startAtLogin: false,
+  });
+  writeJson(path.join(userData, 'global', 'update-state.json'), {
+    schemaVersion: 1, checkedAt: 0,
+  });
+}
+
+function controller(userData) {
+  return createPreReadySchoolProfileController({
+    userData,
+    packageRoot: DESKTOP,
+    desktopDir: DESKTOP,
+    resourcesPath: '/unused',
+    isPackaged: false,
+    randomBytes: (length) => Buffer.alloc(length, 9),
+  });
+}
+
+test('clean custom authority resolves before path-bound services and survives startup verification', (t) => {
+  const userData = root(t);
+  const custom = provisionCustom(userData);
+  activateGlobal(userData, custom.context);
+  const active = controller(userData);
+  assert.deepEqual(active.defaultRouteDomains, []);
+  assert.equal(active.browserHomeUrl, null);
+  assert.equal(active.browserPartition.startsWith('persist:campus-workspace-'), true);
+  assert.equal(active.activeContextBinding().activeContextEpoch, 1);
+  assert.equal(JSON.parse(active.verifyEngineLaunchBinding().stdinFrame).profileId, custom.profileId);
+
+  let preReady;
+  active.withProfileDocument((profile) => {
+    preReady = selectProfileWorkspacePreReadyStorage({ userData, profile });
+  });
+  assert.equal(preReady.mode, 'profile-workspace');
+  assert.equal(preReady.authority.profile.profileId, custom.profileId);
+  assert.equal(preReady.authority.layout.browserPartition, active.browserPartition);
+  assert.equal(preReady.authority.layout.browserPartition.startsWith('persist:campus-workspace-'), true);
+  assert.equal(preReady.paths.vpnCredential, preReady.authority.layout.account.vpnCredential);
+  assert.equal(preReady.authority.account.activeCredentialVersion, null);
+
+  let fullAuthority;
+  active.withProfileDocument((profile) => {
+    fullAuthority = loadProfileWorkspaceAuthorityByKeys({
+      userData,
+      profile,
+      profileKey: custom.context.profileKey,
+      accountKey: custom.context.accountKey,
+    });
+  });
+
+  const startup = new MultiSchoolStartupRuntime({
+    userData,
+    packageRoot: DESKTOP,
+    desktopDir: DESKTOP,
+    resourcesPath: '/unused',
+    isPackaged: false,
+  }).initialize({
+    mode: preReady.mode,
+    authority: fullAuthority,
+    withProfileDocument: (callback) => active.withProfileDocument(callback),
+  });
+  assert.equal(startup.ready, true);
+  assert.equal(startup.profileCount, 1);
+});
+
+test('unknown active profileKey cannot fall back to HKUST once candidate authority exists', (t) => {
+  const userData = root(t);
+  const custom = provisionCustom(userData);
+  activateGlobal(userData, {
+    ...custom.context,
+    profileKey: `profile-${'9'.repeat(32)}`,
+  });
+  assert.throws(() => controller(userData), /not owned by a candidate/u);
+});
+
+test('missing GlobalSettings retains the reviewed first-run controller', (t) => {
+  const active = controller(root(t));
+  assert.deepEqual(active.defaultRouteDomains, ['hkust-gz.edu.cn', 'hkust.edu.hk']);
+  assert.equal(active.browserPartition, 'persist:hkustgz-campus-browser');
+});

--- a/desktop/test/profile-candidate-directory.test.js
+++ b/desktop/test/profile-candidate-directory.test.js
@@ -12,6 +12,9 @@ const { ActiveContextSwitchJournalStore } = require('../lib/active-context-switc
 const { CustomProfileProvisioningRuntime } = require('../lib/custom-profile-provisioning-runtime');
 const { ProfileCandidateDirectory } = require('../lib/profile-candidate-directory');
 const { ProfileSwitchRuntime } = require('../lib/profile-switch-runtime');
+const {
+  createSchoolProfileControllerFromCandidate,
+} = require('../lib/school-profile-controller');
 const { createProfileAccountWorkspaceLayout } = require('../lib/profile-workspace-layout');
 const { ReviewedProfileAnchorStore } = require('../lib/reviewed-profile-anchor-store');
 const { PROTOCOL_FAMILY } = require('../lib/school-profile-schema');
@@ -142,6 +145,27 @@ test('reviewed anchor and custom index form one restart-safe candidate directory
     assert.deepEqual(record.context, custom.context);
     assert.equal(JSON.parse(record.engineLaunchBinding.stdinFrame).profileId, custom.profileId);
   });
+
+  const customController = createSchoolProfileControllerFromCandidate({
+    directory: candidates,
+    profileId: custom.profileId,
+    randomBytes: (length) => Buffer.alloc(length, 7),
+  });
+  assert.equal(customController.browserHomeUrl, null);
+  assert.deepEqual(customController.defaultRouteDomains, []);
+  assert.equal(customController.browserPartition.startsWith('persist:campus-workspace-'), true);
+  assert.equal(customController.activeContextBinding().activeContextEpoch, 1);
+  assert.equal(JSON.parse(customController.verifyEngineLaunchBinding().stdinFrame).profileId,
+    custom.profileId);
+  assert.equal(customController.createPresentation({ locale: 'en' }).schoolProfile.unverified, true);
+
+  const reviewedController = createSchoolProfileControllerFromCandidate({
+    directory: candidates,
+    profileId: 'hkustgz',
+    randomBytes: (length) => Buffer.alloc(length, 8),
+  });
+  assert.equal(reviewedController.browserPartition, 'persist:hkustgz-campus-browser');
+  assert.equal(reviewedController.builtInResourceCount > 0, true);
 
   const restarted = directory(userData);
   assert.deepEqual(restarted.listViews({ locale: 'en' }).map((view) => view.profileId),

--- a/desktop/test/profile-workspace-settings-bundle.test.js
+++ b/desktop/test/profile-workspace-settings-bundle.test.js
@@ -33,6 +33,14 @@ function authority() {
   };
 }
 
+function customAuthority() {
+  return {
+    ...authority(),
+    profile: { browser: { campusDomains: [] } },
+    workspaceSettings: { ...authority().workspaceSettings, routeDomains: [] },
+  };
+}
+
 test('runtime settings projection round-trips without persisting the account label', () => {
   const current = projectRuntimeSettings(authority(), { accountLabel: 'synthetic-user' });
   assert.equal(current.username, 'synthetic-user');
@@ -66,4 +74,11 @@ test('runtime settings reject password fields unknown fields and noncanonical va
   assert.throws(() => splitRuntimeSettings(authority(), { ...current, port: 80 }), /canonical/u);
   assert.throws(() => projectRuntimeSettings(authority(), { accountLabel: 'bad\nlabel' }),
     /控制字符|control/u);
+});
+
+test('custom Profile projection and save preserve an explicitly empty campus-domain authority', () => {
+  const current = projectRuntimeSettings(customAuthority());
+  assert.deepEqual(current.routeDomains, []);
+  const split = splitRuntimeSettings(customAuthority(), current);
+  assert.deepEqual(split.workspaceSettings.routeDomains, []);
 });

--- a/desktop/test/release-assets.test.js
+++ b/desktop/test/release-assets.test.js
@@ -46,6 +46,8 @@ test('cloud release policy publishes only macOS DMGs, Windows EXEs, and Linux Ap
     /ec-proxy-command-linux-amd64/,
     'the Linux SSH proxy helper must use the packaged name',
   );
+  assert.match(workflow, /ec-gateway-probe-linux-amd64/,
+    'the credential-free Gateway probe must use the packaged Linux name');
   assert.match(workflow, /Build \(Linux AppImage x86_64\)/, 'cloud build needs a required AppImage step');
   assert.match(workflow, /release\/linux-unpacked\/resources linux x64/, 'the unpacked Linux package must be verified');
   assert.deepEqual(

--- a/desktop/test/renderer-contract.test.js
+++ b/desktop/test/renderer-contract.test.js
@@ -41,6 +41,12 @@ test('control panel has responsive wide and compact layout rules', () => {
   assert.match(css, /\.page\[data-page="connect"\][^{]*\{/);
 });
 
+test('connected status remains static instead of continuously repainting Electron', () => {
+  assert.match(css, /\.conn-status\.on\s*\{[^}]*color:\s*var\(--ok\)/);
+  assert.doesNotMatch(css, /\.conn-status\.on\s+\.dot\s*\{[^}]*animation:/);
+  assert.doesNotMatch(css, /@keyframes\s+ping/);
+});
+
 test('update download uses one stable delegated listener', () => {
   assert.match(appJs, /\$\('updateHint'\)\.addEventListener\('click'/);
   assert.match(appJs, /event\.target\?\.closest\?\.\('#updateDownload'\)/);

--- a/desktop/test/school-profile-main-contract.test.js
+++ b/desktop/test/school-profile-main-contract.test.js
@@ -16,9 +16,9 @@ function section(startText, endText) {
   return main.slice(start, end);
 }
 
-test('composition root loads one reviewed profile before credential recovery', () => {
+test('composition root resolves one active Profile before credential recovery', () => {
   const sidecarCleanup = main.indexOf('fs.unlinkSync(legacyRuntimeStoragePaths.proxyHelperCredential)');
-  const profile = main.indexOf('const activeSchoolProfile = createSchoolProfileController(');
+  const profile = main.indexOf('const activeSchoolProfile = createPreReadySchoolProfileController(');
   const recovery = main.indexOf('recoverCredentialSettingsTransaction(');
   assert.ok(sidecarCleanup >= 0 && profile > sidecarCleanup && recovery > profile);
   assert.match(

--- a/docs/adr/0027-pre-ready-active-profile-resolution.md
+++ b/docs/adr/0027-pre-ready-active-profile-resolution.md
@@ -1,0 +1,59 @@
+# ADR-0027: Resolve the active Profile before path-bound services
+
+- Status: Accepted for 2.0 P6h
+- Scope: clean restart into reviewed or provisioned custom Profile authority
+- Interactive onboarding and live switch IPC: deferred
+
+## Decision
+
+When owner-only GlobalSettings exists, Main resolves its opaque
+`activeProfileKey` before constructing the active SchoolProfile controller,
+credential adapter, logs, routing stores, certificate trust or Campus Browser.
+
+Resolution order is exact:
+
+1. read and validate owner-only GlobalSettings without credential access;
+2. match `activeProfileKey` against reviewed anchors and the custom index;
+3. reject ambiguous or unknown ownership;
+4. reopen the candidate Profile/Account/Workspace and compiled Engine config;
+5. create a candidate-backed controller;
+6. run the existing pre-ready Profile Workspace authority/path selection.
+
+The only fallback is the first P6 startup after a historical P3 migration, when
+both candidate stores are empty and older builds could only have created HKUST.
+P6g anchors that reviewed authority before ordinary services. Once any
+candidate authority exists, an unknown key can never fall back to HKUST.
+
+## Browser and routing isolation
+
+The Campus Browser receives the exact Workspace-derived persistent partition.
+HKUST retains its adopted legacy partition; each custom Workspace uses its
+opaque-key-derived partition. A custom Profile has no reviewed homepage, so its
+internal home is the local non-network `about:blank` page. It carries a DIRECT
+route and does not start the Engine. Every real HTTP(S) page retains the existing
+connection barrier in P6h: removing it before an asynchronous request-boundary
+barrier exists would break an original DIRECT-to-campus SSO redirect.
+
+Custom empty campus domains remain empty through settings projection and PAC
+generation; they never inherit HKUST domains. Empty custom health targets
+disable website health probes instead of inventing HKUST targets. True on-demand
+connection for a DIRECT first page remains a P8 requirement and must preserve
+the original request rather than replaying it as a GET.
+
+## Native probe packaging
+
+The credential-free `ec-gateway-probe` is built and staged with the Engine and
+OpenSSH helper for macOS arm64/x86_64, Windows x86_64 and Linux x86_64. The
+package verifier requires the exact architecture-specific binary set, and
+macOS local/release signing seals all three executables. Test-only fixtures and
+private material remain excluded.
+
+## Evidence
+
+- clean custom Profile pre-ready authority and path selection;
+- unknown-key fail-closed behavior;
+- first-run reviewed fallback;
+- real Electron custom Main startup with no credential or Engine;
+- isolated custom Browser partition and local blank home;
+- real Electron HKUST Main integration preserving its SSO connection barrier;
+- package naming, exact-resource and multi-platform workflow gates.


### PR DESCRIPTION
## Scope

Resolve the active reviewed or provisioned custom Profile before Main constructs path-bound credential, routing, browser, certificate, log, and Engine services.

## Delivered

- Read owner-only GlobalSettings pre-ready and map `activeProfileKey` through the reviewed anchor/custom index directory.
- Fail closed on ambiguous or unknown ownership once candidate authority exists; retain only the one-time historical HKUST migration fallback.
- Construct Main from the active Profile's exact Profile/Account/Workspace and consumption-time Engine config binding.
- Bind the Campus Browser to the actual Workspace-derived persistent Session. HKUST retains its adopted legacy partition; custom Profiles receive distinct opaque partitions.
- Give unreviewed custom Profiles a local `about:blank` home with no credential or Engine requirement, no HKUST resources, no HKUST route defaults, no invented health targets, and no system-DNS policy inheritance.
- Preserve the existing real-page connection barrier until the later request-boundary on-demand implementation can retain an original DIRECT-to-campus SSO request.
- Package and verify `ec-gateway-probe` beside the Engine and OpenSSH helper on macOS arm64/x64, Windows x64, and Linux x64.
- Remove the persistent connected-status box-shadow animation that caused continuous Electron Renderer/GPU repaint on macOS.

## Bugs found during review

- The initial custom Profile E2E only created the expected partition; it did not prove page ownership. Runtime authority was still unconditionally adopting the HKUST partition. The authority and E2E now verify the real `WebContents.session`.
- Opening all DIRECT pages without an Engine would break a later SAML redirect into a campus domain. P6h now limits the Engine-free exception to the non-network blank custom landing page.
- Custom blank tabs could be relabeled as Campus on Cmd/Ctrl+T. Route resolution now keeps every local blank tab DIRECT.

## Verification

- Desktop: 845 passed, 0 failed, 1 explicit Windows-only skip before the final repaint contract; the added repaint contract passes separately.
- Real Electron HKUST Main integration: PASS.
- Real Electron clean custom Profile Main startup and actual Workspace Session ownership: PASS.
- Real Electron persistence migration and synthetic Engine lifecycle: PASS.
- Architecture: 306 files, 598 edges, 0 cycles; Main 1644 lines / 35 direct dependencies; Renderer 524 lines.
- Secret gate on committed tree: PASS.
- `ec-gateway-probe` cargo check: PASS.

## Deferred boundary

This PR does not add the school selector, custom Gateway probe launcher/confirmation IPC, or live switch UI. It establishes the restart-safe active authority those flows must consume.
