### PR TITLE
2.0 P6i: own custom Gateway onboarding in Main

### DIFF
--- a/desktop/e2e/main-custom-profile.electron.js
+++ b/desktop/e2e/main-custom-profile.electron.js
@@ -92,6 +92,12 @@ async function run() {
   assert.equal(state.connected, false);
   assert.deepEqual(state.campusResources, []);
   assert.deepEqual(state.settings.routeDomains, []);
+  const profiles = await control.webContents.executeJavaScript('window.api.listSchoolProfiles()');
+  assert.equal(profiles.ok, true);
+  assert.equal(profiles.profiles.length, 1);
+  assert.equal(profiles.profiles[0].profileId, custom.profileId);
+  assert.equal(profiles.profiles[0].active, true);
+  assert.equal(Object.hasOwn(profiles.profiles[0], 'accountKey'), false);
 
   const opened = await control.webContents.executeJavaScript('window.api.openCampusBrowser({})');
   assert.deepEqual(opened, { ok: true, url: 'about:blank', route: 'direct' });

--- a/desktop/e2e/main-integration.electron.js
+++ b/desktop/e2e/main-integration.electron.js
@@ -93,6 +93,12 @@ async function run() {
     includeSubdomains: false,
     route: 'direct',
   }]);
+  const profiles = await invoke(control, 'window.api.listSchoolProfiles()');
+  assert.equal(profiles.ok, true);
+  assert.equal(profiles.profiles.length, 1);
+  assert.equal(profiles.profiles[0].profileId, 'hkustgz');
+  assert.equal(profiles.profiles[0].active, true);
+  assert.equal(Object.hasOwn(profiles.profiles[0], 'profileKey'), false);
 
   const savedResource = await invoke(control, `window.api.saveResource({
     name: '测试 IP 服务',

--- a/desktop/lib/app-data-dir.js
+++ b/desktop/lib/app-data-dir.js
@@ -23,11 +23,13 @@ function resolveUserDataOverride(rawValue) {
 
 function createMultiSchoolStartupInitializer(options) {
   const runtime = new MultiSchoolStartupRuntime(options);
-  return (persistenceRuntime, activeSchoolProfile) => runtime.initialize({
+  const initialize = (persistenceRuntime, activeSchoolProfile) => runtime.initialize({
     mode: persistenceRuntime.mode,
     authority: persistenceRuntime.authority,
     withProfileDocument: (callback) => activeSchoolProfile.withProfileDocument(callback),
   });
+  initialize.listViews = (viewOptions) => runtime.listViews(viewOptions);
+  return Object.freeze(initialize);
 }
 
 module.exports = {

--- a/desktop/lib/control-data-ipc.js
+++ b/desktop/lib/control-data-ipc.js
@@ -3,11 +3,13 @@
 const { registerCampusResourceIpc } = require('./campus-resource-ipc');
 const { registerCertificatePinIpc } = require('./certificate-pin-ipc');
 const { registerRoutingRuleIpc } = require('./routing-rule-ipc');
+const { registerSchoolProfileOnboardingIpc } = require('./school-profile-onboarding-ipc');
 
-function registerControlDataIpc({ register, routing, certificates, resources } = {}) {
+function registerControlDataIpc({ register, routing, certificates, resources, schools } = {}) {
   registerRoutingRuleIpc({ register, ...routing });
   registerCertificatePinIpc({ register, ...certificates });
   registerCampusResourceIpc({ register, ...resources });
+  registerSchoolProfileOnboardingIpc({ register, ...schools });
 }
 
 module.exports = {

--- a/desktop/lib/control-ipc-suite.js
+++ b/desktop/lib/control-ipc-suite.js
@@ -4,9 +4,13 @@ const { registerControlDataIpc } = require('./control-data-ipc');
 const { registerCoreControlIpc } = require('./core-control-ipc');
 const { registerSettingsCredentialIpc } = require('./settings-credential-ipc');
 const { createControlStateSnapshot } = require('./control-state-snapshot');
+const {
+  createSchoolProfileOnboardingRuntime,
+} = require('./school-profile-onboarding-suite');
 
 module.exports = {
   createControlStateSnapshot,
+  createSchoolProfileOnboardingRuntime,
   registerControlDataIpc,
   registerCoreControlIpc,
   registerSettingsCredentialIpc,

--- a/desktop/lib/engine-process.js
+++ b/desktop/lib/engine-process.js
@@ -5,11 +5,49 @@ const path = require('node:path');
 
 const SYNTHETIC_ENGINE_E2E_ENV = 'HKUSTGZ_SYNTHETIC_ENGINE_E2E';
 const SYNTHETIC_ENGINE_FIXTURE = 'main-engine-fixture.js';
+const NATIVE_RESOURCE_KINDS = new Set([
+  'ec-engine',
+  'ec-gateway-probe',
+  'ec-proxy-command',
+]);
 
 function exactExecutablePattern(executablePath) {
   if (typeof executablePath !== 'string' || !executablePath.length) return '';
   const escaped = executablePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   return `^${escaped}( |$)`;
+}
+
+function resolveNativeResourcePath({
+  kind,
+  appIsPackaged,
+  baseDirectory,
+  resourcesPath,
+  platform = process.platform,
+  architecture = process.arch,
+  fileSystem = fs,
+} = {}) {
+  if (!NATIVE_RESOURCE_KINDS.has(kind) || typeof appIsPackaged !== 'boolean' ||
+      typeof baseDirectory !== 'string' || !path.isAbsolute(baseDirectory) ||
+      typeof resourcesPath !== 'string' || !path.isAbsolute(resourcesPath) ||
+      !['darwin', 'linux', 'win32'].includes(platform) ||
+      !['arm64', 'x64'].includes(architecture) ||
+      !fileSystem || typeof fileSystem.existsSync !== 'function') {
+    throw new TypeError('native resource path inputs are invalid');
+  }
+  const platformName = platform === 'win32' ? 'windows' : platform;
+  const archName = architecture === 'arm64' ? 'arm64' : 'amd64';
+  const extension = platform === 'win32' ? '.exe' : '';
+  const named = `${kind}-${platformName}-${archName}${extension}`;
+  const generic = `${kind}${extension}`;
+  const directory = appIsPackaged
+    ? path.join(resourcesPath, 'engine')
+    : path.join(baseDirectory, 'engine');
+  const candidates = [
+    path.join(directory, named),
+    path.join(directory, generic),
+    path.join(baseDirectory, '..', 'independent', 'target', 'release', generic),
+  ];
+  return candidates.find((candidate) => fileSystem.existsSync(candidate)) || candidates[0];
 }
 
 function resolveEngineLaunch({
@@ -57,5 +95,6 @@ module.exports = {
   SYNTHETIC_ENGINE_E2E_ENV,
   SYNTHETIC_ENGINE_FIXTURE,
   exactExecutablePattern,
+  resolveNativeResourcePath,
   resolveEngineLaunch,
 };

--- a/desktop/lib/gateway-probe-runner.js
+++ b/desktop/lib/gateway-probe-runner.js
@@ -1,0 +1,168 @@
+'use strict';
+
+const path = require('node:path');
+const { normalizeGatewayOrigin } = require('./school-profile-schema');
+
+const DEFAULT_GATEWAY_PROBE_TIMEOUT_MS = 12_000;
+const MAX_GATEWAY_PROBE_OUTPUT_BYTES = 64 * 1024;
+
+class GatewayProbeError extends Error {
+  constructor(code, cause = null) {
+    super(code, cause ? { cause } : undefined);
+    this.name = 'GatewayProbeError';
+    this.code = code;
+  }
+}
+
+function privateProbeEnvironment(environment = process.env, platform = process.platform) {
+  if (!environment || typeof environment !== 'object') {
+    throw new TypeError('Gateway probe environment is invalid');
+  }
+  const result = {};
+  if (platform === 'win32') {
+    for (const key of ['SYSTEMROOT', 'WINDIR', 'TEMP', 'TMP']) {
+      if (typeof environment[key] === 'string' && environment[key]) result[key] = environment[key];
+    }
+  } else if (typeof environment.TMPDIR === 'string' && environment.TMPDIR) {
+    result.TMPDIR = environment.TMPDIR;
+  }
+  return Object.freeze(result);
+}
+
+class GatewayProbeRunner {
+  #active = null;
+
+  constructor({
+    executablePath,
+    spawnProcess,
+    environment = process.env,
+    platform = process.platform,
+    timeoutMs = DEFAULT_GATEWAY_PROBE_TIMEOUT_MS,
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout,
+  } = {}) {
+    if (typeof executablePath !== 'string' || !path.isAbsolute(executablePath) ||
+        typeof spawnProcess !== 'function' || !['darwin', 'linux', 'win32'].includes(platform) ||
+        !Number.isSafeInteger(timeoutMs) || timeoutMs < 1_000 || timeoutMs > 30_000 ||
+        typeof setTimeoutFn !== 'function' || typeof clearTimeoutFn !== 'function') {
+      throw new TypeError('Gateway probe runner dependencies are invalid');
+    }
+    this.executablePath = executablePath;
+    this.spawnProcess = spawnProcess;
+    this.environment = privateProbeEnvironment(environment, platform);
+    this.platform = platform;
+    this.timeoutMs = timeoutMs;
+    this.setTimeoutFn = setTimeoutFn;
+    this.clearTimeoutFn = clearTimeoutFn;
+  }
+
+  probe(rawOrigin) {
+    if (this.#active) {
+      return Promise.reject(new GatewayProbeError('GATEWAY_PROBE_ALREADY_RUNNING'));
+    }
+    const origin = normalizeGatewayOrigin(rawOrigin).origin;
+    return new Promise((resolve, reject) => {
+      let child;
+      try {
+        child = this.spawnProcess(this.executablePath, ['--origin', origin], {
+          cwd: path.dirname(this.executablePath),
+          env: this.environment,
+          shell: false,
+          detached: false,
+          windowsHide: true,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+      } catch (cause) {
+        reject(new GatewayProbeError('GATEWAY_PROBE_START_FAILED', cause));
+        return;
+      }
+      if (!child || typeof child.once !== 'function' ||
+          typeof child.kill !== 'function' || !child.stdout || !child.stderr) {
+        try { child?.kill?.(); } catch {}
+        reject(new GatewayProbeError('GATEWAY_PROBE_START_FAILED'));
+        return;
+      }
+
+      let stdout = Buffer.alloc(0);
+      let diagnosticBytes = 0;
+      let outputTooLarge = false;
+      let settled = false;
+      let timer = null;
+      const finish = (error, value) => {
+        if (settled) return;
+        settled = true;
+        this.clearTimeoutFn(timer);
+        if (this.#active?.child === child) this.#active = null;
+        stdout.fill(0);
+        stdout = Buffer.alloc(0);
+        if (error) reject(error); else resolve(value);
+      };
+      const append = (chunk) => {
+        if (settled || outputTooLarge) return;
+        const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+        if (stdout.length + value.length > MAX_GATEWAY_PROBE_OUTPUT_BYTES) {
+          outputTooLarge = true;
+          try { child.kill(); } catch {}
+          finish(new GatewayProbeError('GATEWAY_PROBE_OUTPUT_INVALID'));
+          return;
+        }
+        stdout = Buffer.concat([stdout, value]);
+      };
+      child.stdout.on('data', append);
+      // Drain but never retain human diagnostics: paths and platform details
+      // are not part of the Renderer contract. Bound the stream even though
+      // it is discarded so a faulty native child cannot write indefinitely.
+      child.stderr.on('data', (chunk) => {
+        diagnosticBytes += Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk));
+        if (!settled && diagnosticBytes > MAX_GATEWAY_PROBE_OUTPUT_BYTES) {
+          outputTooLarge = true;
+          try { child.kill(); } catch {}
+          finish(new GatewayProbeError('GATEWAY_PROBE_OUTPUT_INVALID'));
+        }
+      });
+      child.once('error', (cause) => finish(
+        new GatewayProbeError('GATEWAY_PROBE_START_FAILED', cause),
+      ));
+      child.once('close', (code, signal) => {
+        if (outputTooLarge) {
+          finish(new GatewayProbeError('GATEWAY_PROBE_OUTPUT_INVALID'));
+          return;
+        }
+        if (code !== 0 || signal) {
+          finish(new GatewayProbeError('GATEWAY_PROBE_FAILED'));
+          return;
+        }
+        try {
+          const text = stdout.toString('utf8').trim();
+          if (!text || text.includes('\n')) throw new Error('probe output is not one JSON line');
+          const result = JSON.parse(text);
+          finish(null, result);
+        } catch (cause) {
+          finish(new GatewayProbeError('GATEWAY_PROBE_OUTPUT_INVALID', cause));
+        }
+      });
+      timer = this.setTimeoutFn(() => {
+        try { child.kill(); } catch {}
+        finish(new GatewayProbeError('GATEWAY_PROBE_TIMEOUT'));
+      }, this.timeoutMs);
+      timer?.unref?.();
+      this.#active = { child, finish };
+    });
+  }
+
+  cancel() {
+    const active = this.#active;
+    if (!active) return false;
+    try { active.child.kill(); } catch {}
+    active.finish(new GatewayProbeError('GATEWAY_PROBE_CANCELLED'));
+    return true;
+  }
+}
+
+module.exports = {
+  DEFAULT_GATEWAY_PROBE_TIMEOUT_MS,
+  GatewayProbeError,
+  GatewayProbeRunner,
+  MAX_GATEWAY_PROBE_OUTPUT_BYTES,
+  privateProbeEnvironment,
+};

--- a/desktop/lib/school-profile-onboarding-ipc.js
+++ b/desktop/lib/school-profile-onboarding-ipc.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const { allowedKeys, boundedString } = require('./ipc-guard');
+
+function probeRequest(value) {
+  const source = allowedKeys(value, ['origin', 'schoolLabel']);
+  return Object.freeze({
+    origin: boundedString(source.origin, {
+      minLength: 1,
+      maxLength: 2048,
+      trim: true,
+      message: 'Gateway 地址无效',
+    }),
+    schoolLabel: boundedString(source.schoolLabel ?? '', {
+      maxLength: 96,
+      trim: true,
+      message: '学校名称无效',
+    }),
+  });
+}
+
+function confirmationRequest(value) {
+  const source = allowedKeys(value, ['confirmationHandle']);
+  return Object.freeze({
+    confirmationHandle: boundedString(source.confirmationHandle, {
+      minLength: 1,
+      maxLength: 64,
+      trim: true,
+      message: 'Gateway 确认句柄无效',
+    }),
+  });
+}
+
+function registerSchoolProfileOnboardingIpc({ register, onboarding, getLocale } = {}) {
+  if (typeof register !== 'function' || !onboarding ||
+      typeof onboarding.list !== 'function' || typeof onboarding.probe !== 'function' ||
+      typeof onboarding.confirm !== 'function' || typeof onboarding.cancel !== 'function' ||
+      typeof getLocale !== 'function') {
+    throw new TypeError('school Profile onboarding IPC dependencies are incomplete');
+  }
+  register('list-school-profiles', () => {
+    try { return { ok: true, profiles: onboarding.list({ locale: getLocale() }) }; }
+    catch { return { ok: false, code: 'PROFILE_LIST_FAILED', profiles: [] }; }
+  });
+  register('probe-custom-gateway', (_event, value) => onboarding.probe(probeRequest(value)));
+  register('confirm-custom-gateway', (_event, value) => (
+    onboarding.confirm(confirmationRequest(value))
+  ));
+  register('cancel-custom-gateway', () => ({ ok: true, cancelled: onboarding.cancel() }));
+}
+
+module.exports = {
+  confirmationRequest,
+  probeRequest,
+  registerSchoolProfileOnboardingIpc,
+};

--- a/desktop/lib/school-profile-onboarding-suite.js
+++ b/desktop/lib/school-profile-onboarding-suite.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { CustomGatewayConfirmationOwner } = require('./custom-gateway-onboarding');
+const { CustomProfileProvisioningRuntime } = require('./custom-profile-provisioning-runtime');
+const { GatewayProbeRunner } = require('./gateway-probe-runner');
+const { SchoolProfileOnboardingCoordinator } = require('./school-profile-onboarding');
+
+function createSchoolProfileOnboardingRuntime({
+  userData,
+  executablePath,
+  spawnProcess,
+  environment = process.env,
+  platform = process.platform,
+  getActiveContext,
+  listProfiles,
+  onDiagnostic,
+} = {}) {
+  const probeRunner = new GatewayProbeRunner({
+    executablePath,
+    spawnProcess,
+    environment,
+    platform,
+  });
+  return new SchoolProfileOnboardingCoordinator({
+    probeRunner,
+    confirmationOwner: new CustomGatewayConfirmationOwner(),
+    provisioningRuntime: new CustomProfileProvisioningRuntime({ userData }),
+    getActiveContext,
+    listProfiles,
+    onDiagnostic,
+  });
+}
+
+module.exports = { createSchoolProfileOnboardingRuntime };

--- a/desktop/lib/school-profile-onboarding.js
+++ b/desktop/lib/school-profile-onboarding.js
@@ -1,0 +1,214 @@
+'use strict';
+
+const {
+  normalizeGatewayOrigin,
+  validateAccountHandle,
+  validateProfileId,
+} = require('./school-profile-schema');
+
+const ONBOARDING_ERROR_CODES = new Set([
+  'GATEWAY_PROBE_ALREADY_RUNNING',
+  'GATEWAY_PROBE_CANCELLED',
+  'GATEWAY_PROBE_FAILED',
+  'GATEWAY_PROBE_OUTPUT_INVALID',
+  'GATEWAY_PROBE_START_FAILED',
+  'GATEWAY_PROBE_TIMEOUT',
+  'GATEWAY_PROBE_UNSUPPORTED',
+  'PROFILE_CONFIRMATION_STALE',
+  'PROFILE_LIST_FAILED',
+  'PROFILE_ONBOARDING_NOT_READY',
+  'PROFILE_PROVISIONING_FAILED',
+]);
+
+function activeContext(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new TypeError('active onboarding context is invalid');
+  }
+  const keys = Object.keys(value).sort();
+  const expected = [
+    'profileId', 'profileRevision', 'accountHandle', 'activeContextEpoch',
+  ].sort();
+  if (keys.length !== expected.length || keys.some((key, index) => key !== expected[index]) ||
+      !Number.isSafeInteger(value.profileRevision) || value.profileRevision <= 0 ||
+      !Number.isSafeInteger(value.activeContextEpoch) || value.activeContextEpoch <= 0) {
+    throw new TypeError('active onboarding context is invalid');
+  }
+  return Object.freeze({
+    profileId: validateProfileId(value.profileId),
+    profileRevision: value.profileRevision,
+    accountHandle: validateAccountHandle(value.accountHandle),
+    activeContextEpoch: value.activeContextEpoch,
+  });
+}
+
+function sameContext(left, right) {
+  return left.profileId === right.profileId &&
+    left.profileRevision === right.profileRevision &&
+    left.accountHandle === right.accountHandle &&
+    left.activeContextEpoch === right.activeContextEpoch;
+}
+
+function onboardingErrorCode(error, fallback) {
+  return ONBOARDING_ERROR_CODES.has(error?.code) ? error.code : fallback;
+}
+
+function boundedViewText(value, maxLength) {
+  return typeof value === 'string' && value.length >= 1 && value.length <= maxLength &&
+    !/[\u0000-\u001f\u007f<>]/u.test(value);
+}
+
+function profileViews(value, activeProfileId) {
+  if (!Array.isArray(value) || value.length > 64) {
+    throw new TypeError('Profile candidate views are invalid');
+  }
+  return Object.freeze(value.map((view) => {
+    if (!view || typeof view !== 'object' || Array.isArray(view) ||
+        view.schemaVersion !== 1 || !Number.isSafeInteger(view.profileRevision) ||
+        view.profileRevision <= 0 || !['builtin-reviewed', 'custom-local'].includes(view.evidenceClass) ||
+        !boundedViewText(view.schoolName, 160) || !boundedViewText(view.shortName, 80) ||
+        (view.bundledAssetKey !== null && !boundedViewText(view.bundledAssetKey, 80)) ||
+        !['reviewed', 'candidate', 'unsupported', 'unknown'].includes(view.sanitizedCompatibility) ||
+        typeof view.unverified !== 'boolean') {
+      throw new TypeError('Profile candidate view is invalid');
+    }
+    const profileId = validateProfileId(view.profileId);
+    return Object.freeze({
+      schemaVersion: 1,
+      profileId,
+      profileRevision: view.profileRevision,
+      evidenceClass: view.evidenceClass,
+      schoolName: view.schoolName,
+      shortName: view.shortName,
+      bundledAssetKey: view.bundledAssetKey,
+      normalizedGatewayOrigin: normalizeGatewayOrigin(view.normalizedGatewayOrigin).origin,
+      sanitizedCompatibility: view.sanitizedCompatibility,
+      unverified: view.unverified,
+      active: profileId === activeProfileId,
+    });
+  }));
+}
+
+class SchoolProfileOnboardingCoordinator {
+  #running = false;
+
+  constructor({
+    probeRunner,
+    confirmationOwner,
+    provisioningRuntime,
+    getActiveContext,
+    listProfiles,
+    onDiagnostic = () => {},
+  } = {}) {
+    if (!probeRunner || typeof probeRunner.probe !== 'function' ||
+        typeof probeRunner.cancel !== 'function' ||
+        !confirmationOwner || typeof confirmationOwner.issue !== 'function' ||
+        typeof confirmationOwner.consume !== 'function' ||
+        typeof confirmationOwner.invalidate !== 'function' ||
+        !provisioningRuntime || typeof provisioningRuntime.begin !== 'function' ||
+        typeof getActiveContext !== 'function' || typeof listProfiles !== 'function' ||
+        typeof onDiagnostic !== 'function') {
+      throw new TypeError('school Profile onboarding dependencies are invalid');
+    }
+    this.probeRunner = probeRunner;
+    this.confirmationOwner = confirmationOwner;
+    this.provisioningRuntime = provisioningRuntime;
+    this.getActiveContext = getActiveContext;
+    this.listProfilesSource = listProfiles;
+    this.onDiagnostic = onDiagnostic;
+  }
+
+  list({ locale = 'en' } = {}) {
+    if (!['zh', 'en'].includes(locale)) throw new TypeError('Profile locale is invalid');
+    const current = activeContext(this.getActiveContext());
+    return profileViews(this.listProfilesSource({ locale }), current.profileId);
+  }
+
+  async probe({ origin, schoolLabel = '' } = {}) {
+    return this.#singleFlight(async () => {
+      this.confirmationOwner.invalidate();
+      const context = activeContext(this.getActiveContext());
+      let result;
+      try { result = await this.probeRunner.probe(origin); }
+      catch (error) {
+        const code = onboardingErrorCode(error, 'GATEWAY_PROBE_FAILED');
+        this.onDiagnostic(code);
+        return Object.freeze({ ok: false, code });
+      }
+      if (!sameContext(context, activeContext(this.getActiveContext()))) {
+        this.confirmationOwner.invalidate();
+        return Object.freeze({ ok: false, code: 'PROFILE_CONFIRMATION_STALE' });
+      }
+      try {
+        return Object.freeze({
+          ok: true,
+          confirmation: this.confirmationOwner.issue({
+            probeResult: result,
+            schoolLabel,
+            activeContext: context,
+          }),
+        });
+      } catch (error) {
+        this.onDiagnostic('GATEWAY_PROBE_UNSUPPORTED');
+        return Object.freeze({ ok: false, code: 'GATEWAY_PROBE_UNSUPPORTED' });
+      }
+    });
+  }
+
+  confirm({ confirmationHandle } = {}) {
+    if (this.#running) return Object.freeze({ ok: false, code: 'PROFILE_ONBOARDING_NOT_READY' });
+    const context = activeContext(this.getActiveContext());
+    let confirmation;
+    try {
+      confirmation = this.confirmationOwner.consume({
+        confirmationHandle,
+        activeContext: context,
+      });
+    } catch (error) {
+      return Object.freeze({ ok: false, code: 'PROFILE_CONFIRMATION_STALE' });
+    }
+    try {
+      const provisioned = this.provisioningRuntime.begin(confirmation);
+      let profiles;
+      let warningCode = null;
+      try { profiles = this.list(); }
+      catch {
+        profiles = Object.freeze([]);
+        warningCode = 'PROFILE_LIST_FAILED';
+        this.onDiagnostic(warningCode);
+      }
+      return Object.freeze({
+        ok: true,
+        profileId: provisioned.profileId,
+        profiles,
+        warningCode,
+      });
+    } catch (error) {
+      this.onDiagnostic('PROFILE_PROVISIONING_FAILED');
+      return Object.freeze({ ok: false, code: 'PROFILE_PROVISIONING_FAILED' });
+    }
+  }
+
+  cancel() {
+    const probe = this.probeRunner.cancel();
+    const confirmation = this.confirmationOwner.invalidate();
+    return probe || confirmation;
+  }
+
+  #singleFlight(operation) {
+    if (this.#running) {
+      return Promise.resolve(Object.freeze({
+        ok: false,
+        code: 'GATEWAY_PROBE_ALREADY_RUNNING',
+      }));
+    }
+    this.#running = true;
+    return Promise.resolve().then(operation).finally(() => { this.#running = false; });
+  }
+}
+
+module.exports = {
+  ONBOARDING_ERROR_CODES,
+  SchoolProfileOnboardingCoordinator,
+  onboardingErrorCode,
+};

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -30,8 +30,7 @@ const {
 const { AuthChallengeCoordinator, EngineControlRegistry } = require('./lib/engine-control-suite');
 const { EngineConnectionRuntime } = require('./lib/engine-connection-runtime');
 const { DesktopShell } = require('./lib/desktop-shell');
-const { SYNTHETIC_ENGINE_E2E_ENV, exactExecutablePattern, resolveEngineLaunch } =
-  require('./lib/engine-process');
+const { SYNTHETIC_ENGINE_E2E_ENV, exactExecutablePattern, resolveEngineLaunch, resolveNativeResourcePath } = require('./lib/engine-process');
 const {
   EngineSupervisor,
   loadEngineOwnerRecord,
@@ -48,6 +47,7 @@ const { CampusBrowserManager } = require('./lib/campus-browser-manager');
 const { createPreReadySchoolProfileController } = require('./lib/school-profile-controller');
 const {
   createControlStateSnapshot,
+  createSchoolProfileOnboardingRuntime,
   registerControlDataIpc,
   registerCoreControlIpc,
   registerSettingsCredentialIpc,
@@ -263,6 +263,11 @@ const persistenceRuntime = new DesktopPersistenceRuntime({
   },
 });
 const initializeMultiSchoolStartup = createMultiSchoolStartupInitializer({ userData: DATA, packageRoot: __dirname, isPackaged: app.isPackaged, resourcesPath: process.resourcesPath, desktopDir: __dirname });
+const schoolProfileOnboarding = createSchoolProfileOnboardingRuntime({
+  userData: DATA, executablePath: gatewayProbePath(), spawnProcess: spawn,
+  getActiveContext: () => activeSchoolProfile.activeContextBinding(), listProfiles: (options) => initializeMultiSchoolStartup.listViews(options),
+  onDiagnostic: (code) => logWriter?.append(`[profile-onboarding] ${code}\n`),
+});
 function loadSettings() { return persistenceRuntime.loadSettings(); }
 function reportSettingsReadFailure(cause, { emitState = true } = {}) {
   if (cause?.code === 'SETTINGS_READ_FAILED') return cause;
@@ -441,19 +446,12 @@ const domainRoutePolicy = new DomainRoutePolicyStore({
   serverResources: () => serverCampusResources,
 });
 // ---------- engine ----------
-function enginePath() {
-  const plat = process.platform === 'win32' ? 'windows' : process.platform === 'darwin' ? 'darwin' : 'linux';
-  const arch = process.arch === 'arm64' ? 'arm64' : 'amd64';
-  const ext = plat === 'windows' ? '.exe' : '';
-  const named = `ec-engine-${plat}-${arch}${ext}`;
-  const dir = app.isPackaged ? path.join(process.resourcesPath, 'engine') : path.join(__dirname, 'engine');
-  const candidates = [
-    path.join(dir, named),
-    path.join(dir, plat === 'windows' ? 'ec-engine.exe' : 'ec-engine'),
-    path.join(__dirname, '..', 'independent', 'target', 'release', plat === 'windows' ? 'ec-engine.exe' : 'ec-engine'),
-  ];
-  return candidates.find((p) => fs.existsSync(p)) || candidates[0];
+function nativeResourcePath(kind) {
+  return resolveNativeResourcePath({ kind, appIsPackaged: app.isPackaged,
+    baseDirectory: __dirname, resourcesPath: process.resourcesPath });
 }
+function enginePath() { return nativeResourcePath('ec-engine'); }
+function gatewayProbePath() { return nativeResourcePath('ec-gateway-probe'); }
 function emit() {
   state.pacUrl = pacUrl();
   connectionWaitRegistry.observe(connectionState.snapshot());
@@ -1380,6 +1378,7 @@ registerControlDataIpc({
     runTransaction: runDomainPolicyTransaction,
     safeResources: safeCampusResources,
   },
+  schools: { onboarding: schoolProfileOnboarding, getLocale: () => locale },
 });
 registerSettingsCredentialIpc({
   register: trustedHandle,
@@ -1502,6 +1501,7 @@ desktopShell = new DesktopShell({
   openCampusBrowser: () => connectAndOpenCampusBrowser(),
   rememberCloseAction,
   disposeLifecycle: () => {
+    schoolProfileOnboarding.cancel();
     networkStartupCoordinator.dispose(); connectionWaitRegistry.dispose();
     connectivityRecovery.dispose();
     networkStatusMonitor.dispose();
@@ -1512,7 +1512,7 @@ desktopShell = new DesktopShell({
     stableProxyCredential?.destroy();
     stableProxyCredential = null;
   },
-  onControlRendererUnavailable: () => authChallengeCoordinator.cancelForLifecycle(),
+  onControlRendererUnavailable: () => (schoolProfileOnboarding.cancel(), authChallengeCoordinator.cancelForLifecycle()),
   onWindowError: (error) => {
     state.settingsError = error.userMessage || error.message;
     emit();

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -27,6 +27,10 @@ contextBridge.exposeInMainWorld('api', {
   deleteRoutingRule: (identity) => ipcRenderer.invoke('delete-routing-rule', identity),
   listCertificatePins: () => ipcRenderer.invoke('list-certificate-pins'),
   deleteCertificatePin: (identity) => ipcRenderer.invoke('delete-certificate-pin', identity),
+  listSchoolProfiles: () => ipcRenderer.invoke('list-school-profiles'),
+  probeCustomGateway: (request) => ipcRenderer.invoke('probe-custom-gateway', request),
+  confirmCustomGateway: (request) => ipcRenderer.invoke('confirm-custom-gateway', request),
+  cancelCustomGateway: () => ipcRenderer.invoke('cancel-custom-gateway'),
   resize: (height) => ipcRenderer.invoke('resize', height),
   onOpenRoutingRules: (cb) => {
     if (typeof cb !== 'function') return () => {};

--- a/desktop/test/control-data-ipc.test.js
+++ b/desktop/test/control-data-ipc.test.js
@@ -36,11 +36,20 @@ function fixture() {
       runTransaction,
       safeResources: () => settings.customResources,
     },
+    schools: {
+      onboarding: {
+        list: () => [],
+        probe: () => ({ ok: true }),
+        confirm: () => ({ ok: true }),
+        cancel: () => false,
+      },
+      getLocale: () => 'en',
+    },
   });
   return { handlers, get pins() { return pins; }, get rules() { return rules; } };
 }
 
-test('facade registers exact routing, certificate and resource channels', () => {
+test('facade registers exact routing certificate resource and school channels', () => {
   const f = fixture();
   assert.deepEqual([...f.handlers.keys()], [
     'list-routing-rules',
@@ -51,6 +60,10 @@ test('facade registers exact routing, certificate and resource channels', () => 
     'save-resource',
     'delete-resource',
     'reorder-resources',
+    'list-school-profiles',
+    'probe-custom-gateway',
+    'confirm-custom-gateway',
+    'cancel-custom-gateway',
   ]);
 });
 

--- a/desktop/test/control-preload.test.js
+++ b/desktop/test/control-preload.test.js
@@ -78,6 +78,28 @@ test('control preload exposes narrow certificate-pin IPC methods', async () => {
   assert.equal(invocations[1].payload, identity);
 });
 
+test('control preload exposes only bounded school onboarding operations', async () => {
+  const { api, invocations } = loadPreload();
+  const probe = { origin: 'https://vpn.example.edu', schoolLabel: 'Example University' };
+  const confirmation = { confirmationHandle: 'confirmation-123' };
+  await api.listSchoolProfiles();
+  await api.probeCustomGateway(probe);
+  await api.confirmCustomGateway(confirmation);
+  await api.cancelCustomGateway();
+  assert.deepEqual(invocations.map(({ channel }) => channel), [
+    'list-school-profiles',
+    'probe-custom-gateway',
+    'confirm-custom-gateway',
+    'cancel-custom-gateway',
+  ]);
+  assert.equal(invocations[0].argumentCount, 1);
+  assert.equal(invocations[1].payload, probe);
+  assert.equal(invocations[2].payload, confirmation);
+  assert.equal(invocations[3].argumentCount, 1);
+  assert.equal(typeof api.getProfileKey, 'undefined');
+  assert.equal(typeof api.getGatewayCookie, 'undefined');
+});
+
 test('Clash copy is a value-free trusted IPC and never returns YAML through the renderer', async () => {
   const { api, invocations } = loadPreload();
   const result = await api.copyClashNode();

--- a/desktop/test/engine-process.test.js
+++ b/desktop/test/engine-process.test.js
@@ -9,6 +9,7 @@ const {
   SYNTHETIC_ENGINE_E2E_ENV,
   exactExecutablePattern,
   resolveEngineLaunch,
+  resolveNativeResourcePath,
 } = require('../lib/engine-process');
 
 test('orphan cleanup matches only the resolved engine executable', () => {
@@ -16,6 +17,24 @@ test('orphan cleanup matches only the resolved engine executable', () => {
   assert.equal(pattern.test('/tmp/build+test/ec-engine --config profile.json'), true);
   assert.equal(pattern.test('cargo build --bin ec-engine'), false);
   assert.equal(pattern.test('/other/ec-engine --config profile.json'), false);
+});
+
+test('native resource resolver selects exact platform architecture and kind', () => {
+  const baseDirectory = '/app/desktop';
+  const resourcesPath = '/app/resources';
+  const existing = new Set(['/app/resources/engine/ec-gateway-probe-darwin-arm64']);
+  assert.equal(resolveNativeResourcePath({
+    kind: 'ec-gateway-probe',
+    appIsPackaged: true,
+    baseDirectory,
+    resourcesPath,
+    platform: 'darwin',
+    architecture: 'arm64',
+    fileSystem: { existsSync: (file) => existing.has(file) },
+  }), '/app/resources/engine/ec-gateway-probe-darwin-arm64');
+  assert.throws(() => resolveNativeResourcePath({
+    kind: 'unknown', appIsPackaged: true, baseDirectory, resourcesPath,
+  }), /native resource/u);
 });
 
 test('synthetic Engine launch is a fixed dev-only fixture and packaged apps ignore it', (t) => {

--- a/desktop/test/gateway-probe-runner.test.js
+++ b/desktop/test/gateway-probe-runner.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const test = require('node:test');
+const {
+  GatewayProbeRunner,
+  MAX_GATEWAY_PROBE_OUTPUT_BYTES,
+  privateProbeEnvironment,
+} = require('../lib/gateway-probe-runner');
+
+function child() {
+  const value = new EventEmitter();
+  value.stdout = new EventEmitter();
+  value.stderr = new EventEmitter();
+  value.kill = () => { value.killed = true; };
+  return value;
+}
+
+test('probe launches one credential-free bounded native request', async () => {
+  const calls = [];
+  const process = child();
+  const runner = new GatewayProbeRunner({
+    executablePath: '/app/ec-gateway-probe-darwin-arm64',
+    environment: {
+      TMPDIR: '/private/tmp',
+      HTTP_PROXY: 'http://untrusted.invalid',
+      GH_TOKEN: 'must-not-cross',
+    },
+    spawnProcess: (...args) => { calls.push(args); return process; },
+  });
+  const pending = runner.probe('https://vpn.example.edu/');
+  process.stdout.emit('data', Buffer.from(`${JSON.stringify({
+    schema_version: 1,
+    normalized_origin: 'https://vpn.example.edu',
+    https_identity_valid: true,
+    compatibility: 'recognized_candidate',
+    candidate_family: 'easyconnect-modern-l3',
+    reported_version: 'M7.6.8R2',
+    http_status: 200,
+  })}\n`));
+  process.emit('close', 0, null);
+  const result = await pending;
+  assert.equal(result.normalized_origin, 'https://vpn.example.edu');
+  assert.deepEqual(calls[0][1], ['--origin', 'https://vpn.example.edu']);
+  assert.deepEqual(calls[0][2].env, { TMPDIR: '/private/tmp' });
+  assert.equal(calls[0][2].shell, false);
+  assert.deepEqual(calls[0][2].stdio, ['ignore', 'pipe', 'pipe']);
+});
+
+test('probe rejects concurrent oversized malformed and failed child outcomes', async () => {
+  const first = child();
+  const runner = new GatewayProbeRunner({
+    executablePath: '/app/ec-gateway-probe-darwin-arm64',
+    spawnProcess: () => first,
+  });
+  const pending = runner.probe('https://vpn.example.edu');
+  await assert.rejects(runner.probe('https://other.example.edu'), {
+    code: 'GATEWAY_PROBE_ALREADY_RUNNING',
+  });
+  first.stdout.emit('data', Buffer.alloc(MAX_GATEWAY_PROBE_OUTPUT_BYTES + 1, 1));
+  first.emit('close', 1, null);
+  await assert.rejects(pending, { code: 'GATEWAY_PROBE_OUTPUT_INVALID' });
+
+  const malformed = child();
+  const malformedRunner = new GatewayProbeRunner({
+    executablePath: '/app/ec-gateway-probe-darwin-arm64',
+    spawnProcess: () => malformed,
+  });
+  const malformedPending = malformedRunner.probe('https://vpn.example.edu');
+  malformed.stdout.emit('data', '{not-json}\n');
+  malformed.emit('close', 0, null);
+  await assert.rejects(malformedPending, { code: 'GATEWAY_PROBE_OUTPUT_INVALID' });
+});
+
+test('timeout and explicit cancellation terminate the child and settle once', async () => {
+  for (const action of ['timeout', 'cancel']) {
+    const process = child();
+    let timeoutCallback = null;
+    const runner = new GatewayProbeRunner({
+      executablePath: '/app/ec-gateway-probe-darwin-arm64',
+      spawnProcess: () => process,
+      setTimeoutFn: (callback) => { timeoutCallback = callback; return { unref() {} }; },
+      clearTimeoutFn: () => {},
+    });
+    const pending = runner.probe('https://vpn.example.edu');
+    if (action === 'timeout') timeoutCallback();
+    else assert.equal(runner.cancel(), true);
+    await assert.rejects(pending, {
+      code: action === 'timeout' ? 'GATEWAY_PROBE_TIMEOUT' : 'GATEWAY_PROBE_CANCELLED',
+    });
+    assert.equal(process.killed, true);
+    process.emit('close', 0, null);
+  }
+});
+
+test('private child environment never forwards proxy credential or certificate overrides', () => {
+  assert.deepEqual(privateProbeEnvironment({
+    SYSTEMROOT: 'C:\\Windows',
+    TEMP: 'C:\\Temp',
+    HTTP_PROXY: 'forbidden',
+    SSL_CERT_FILE: 'forbidden',
+    TOKEN: 'forbidden',
+  }, 'win32'), {
+    SYSTEMROOT: 'C:\\Windows',
+    TEMP: 'C:\\Temp',
+  });
+});

--- a/desktop/test/school-profile-onboarding-ipc.test.js
+++ b/desktop/test/school-profile-onboarding-ipc.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  confirmationRequest,
+  probeRequest,
+  registerSchoolProfileOnboardingIpc,
+} = require('../lib/school-profile-onboarding-ipc');
+
+function fixture() {
+  const handlers = new Map();
+  const calls = [];
+  const onboarding = {
+    list: (value) => { calls.push(['list', value]); return []; },
+    probe: (value) => { calls.push(['probe', value]); return { ok: true }; },
+    confirm: (value) => { calls.push(['confirm', value]); return { ok: true }; },
+    cancel: () => { calls.push(['cancel']); return true; },
+  };
+  registerSchoolProfileOnboardingIpc({
+    register: (channel, handler) => handlers.set(channel, handler),
+    onboarding,
+    getLocale: () => 'zh',
+  });
+  return { calls, handlers };
+}
+
+test('onboarding IPC exposes four exact channels with bounded schemas', async () => {
+  const f = fixture();
+  assert.deepEqual([...f.handlers.keys()], [
+    'list-school-profiles',
+    'probe-custom-gateway',
+    'confirm-custom-gateway',
+    'cancel-custom-gateway',
+  ]);
+  await f.handlers.get('list-school-profiles')({});
+  await f.handlers.get('probe-custom-gateway')({}, {
+    origin: ' https://vpn.example.edu ',
+    schoolLabel: ' Example University ',
+  });
+  await f.handlers.get('confirm-custom-gateway')({}, {
+    confirmationHandle: ' confirmation-123 ',
+  });
+  assert.deepEqual(await f.handlers.get('cancel-custom-gateway')({}), {
+    ok: true,
+    cancelled: true,
+  });
+  assert.deepEqual(f.calls, [
+    ['list', { locale: 'zh' }],
+    ['probe', { origin: 'https://vpn.example.edu', schoolLabel: 'Example University' }],
+    ['confirm', { confirmationHandle: 'confirmation-123' }],
+    ['cancel'],
+  ]);
+});
+
+test('onboarding IPC rejects unknown credential-like fields before Main', () => {
+  assert.throws(() => probeRequest({
+    origin: 'https://vpn.example.edu',
+    password: 'forbidden',
+  }), /未知字段/u);
+  assert.throws(() => probeRequest({ origin: 'x'.repeat(2049) }), /Gateway/u);
+  assert.throws(() => confirmationRequest({
+    confirmationHandle: 'confirmation-1',
+    token: 'forbidden',
+  }), /未知字段/u);
+});
+
+test('profile list failures collapse without exposing Main error text', () => {
+  const handlers = new Map();
+  registerSchoolProfileOnboardingIpc({
+    register: (channel, handler) => handlers.set(channel, handler),
+    onboarding: {
+      list: () => { throw new Error('/private/user/path'); },
+      probe: () => {},
+      confirm: () => {},
+      cancel: () => false,
+    },
+    getLocale: () => 'en',
+  });
+  assert.deepEqual(handlers.get('list-school-profiles')({}), {
+    ok: false,
+    code: 'PROFILE_LIST_FAILED',
+    profiles: [],
+  });
+});

--- a/desktop/test/school-profile-onboarding.test.js
+++ b/desktop/test/school-profile-onboarding.test.js
@@ -1,0 +1,235 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { CustomGatewayConfirmationOwner } = require('../lib/custom-gateway-onboarding');
+const { CustomProfileProvisioningRuntime } = require('../lib/custom-profile-provisioning-runtime');
+const { ProfileCandidateDirectory } = require('../lib/profile-candidate-directory');
+const {
+  SchoolProfileOnboardingCoordinator,
+} = require('../lib/school-profile-onboarding');
+const { PROTOCOL_FAMILY } = require('../lib/school-profile-schema');
+
+function context(epoch = 7) {
+  return {
+    profileId: 'hkustgz',
+    profileRevision: 1,
+    accountHandle: `account-${'a'.repeat(36)}`,
+    activeContextEpoch: epoch,
+  };
+}
+
+function probeResult() {
+  return {
+    schema_version: 1,
+    normalized_origin: 'https://vpn.example.edu',
+    https_identity_valid: true,
+    compatibility: 'recognized_candidate',
+    candidate_family: PROTOCOL_FAMILY,
+    reported_version: 'M7.6.8R2',
+    http_status: 200,
+  };
+}
+
+function profileView(profileId, { custom = false } = {}) {
+  return {
+    schemaVersion: 1,
+    profileId,
+    profileRevision: 1,
+    evidenceClass: custom ? 'custom-local' : 'builtin-reviewed',
+    schoolName: custom ? 'Example University' : 'HKUST(GZ)',
+    shortName: custom ? 'Example University' : 'HKUST(GZ)',
+    bundledAssetKey: custom ? null : 'hkustgz-logo',
+    normalizedGatewayOrigin: custom
+      ? 'https://vpn.example.edu'
+      : 'https://remote.hkust-gz.edu.cn',
+    sanitizedCompatibility: custom ? 'candidate' : 'reviewed',
+    unverified: custom,
+  };
+}
+
+function fixture(overrides = {}) {
+  let active = context();
+  let views = [profileView('hkustgz')];
+  let seed = 1;
+  const diagnostics = [];
+  const provisioned = [];
+  const probeRunner = overrides.probeRunner || {
+    probe: async () => probeResult(),
+    cancel: () => false,
+  };
+  const coordinator = new SchoolProfileOnboardingCoordinator({
+    probeRunner,
+    confirmationOwner: new CustomGatewayConfirmationOwner({
+      randomBytes: (length) => Buffer.alloc(length, seed++),
+      now: () => 1_800_000_000_000,
+      ttlMs: 10_000,
+    }),
+    provisioningRuntime: {
+      begin(confirmation) {
+        provisioned.push(confirmation);
+        views = [...views, profileView(confirmation.draftProfileId, { custom: true })];
+        return { profileId: confirmation.draftProfileId };
+      },
+    },
+    getActiveContext: () => ({ ...active }),
+    listProfiles: overrides.listProfiles || (() => views.map((view) => ({ ...view }))),
+    onDiagnostic: (code) => diagnostics.push(code),
+  });
+  return {
+    coordinator,
+    diagnostics,
+    provisioned,
+    setActive(value) { active = value; },
+  };
+}
+
+test('profile list is sanitized and marks only the current Profile active', () => {
+  const [view] = fixture({
+    listProfiles: () => [{ ...profileView('hkustgz'), profileKey: 'must-not-cross' }],
+  }).coordinator.list({ locale: 'en' });
+  assert.equal(view.profileId, 'hkustgz');
+  assert.equal(view.schoolName, 'HKUST(GZ)');
+  assert.equal(view.active, true);
+  assert.equal(Object.hasOwn(view, 'profileKey'), false);
+});
+
+test('probe confirmation provisions an unverified Profile without returning persistent keys', async () => {
+  const f = fixture();
+  const probed = await f.coordinator.probe({
+    origin: 'https://vpn.example.edu',
+    schoolLabel: 'Example University',
+  });
+  assert.equal(probed.ok, true);
+  assert.equal(probed.confirmation.normalizedOrigin, 'https://vpn.example.edu');
+  assert.equal(Object.hasOwn(probed.confirmation, 'profileKey'), false);
+  assert.equal(Object.hasOwn(probed.confirmation, 'accountKey'), false);
+  const confirmed = f.coordinator.confirm({
+    confirmationHandle: probed.confirmation.confirmationHandle,
+  });
+  assert.equal(confirmed.ok, true);
+  assert.equal(confirmed.profileId.startsWith('custom-'), true);
+  assert.equal(f.provisioned.length, 1);
+  assert.equal(confirmed.profiles.length, 2);
+  assert.equal(confirmed.profiles[1].active, false);
+  assert.equal(confirmed.warningCode, null);
+  assert.equal(Object.hasOwn(confirmed, 'context'), false);
+});
+
+test('active-context drift invalidates the probe before a confirmation can be issued', async () => {
+  let resolveProbe;
+  const f = fixture({
+    probeRunner: {
+      probe: () => new Promise((resolve) => { resolveProbe = resolve; }),
+      cancel: () => false,
+    },
+  });
+  const pending = f.coordinator.probe({ origin: 'https://vpn.example.edu' });
+  await Promise.resolve();
+  f.setActive(context(8));
+  resolveProbe(probeResult());
+  assert.deepEqual(await pending, { ok: false, code: 'PROFILE_CONFIRMATION_STALE' });
+  assert.deepEqual(f.coordinator.confirm({ confirmationHandle: 'confirmation-stale' }), {
+    ok: false,
+    code: 'PROFILE_CONFIRMATION_STALE',
+  });
+});
+
+test('renderer lifecycle cancellation invalidates an issued confirmation', async () => {
+  const f = fixture();
+  const probed = await f.coordinator.probe({ origin: 'https://vpn.example.edu' });
+  assert.equal(probed.ok, true);
+  assert.equal(f.coordinator.cancel(), true);
+  assert.deepEqual(f.coordinator.confirm({
+    confirmationHandle: probed.confirmation.confirmationHandle,
+  }), { ok: false, code: 'PROFILE_CONFIRMATION_STALE' });
+});
+
+test('a post-commit list failure cannot misreport durable provisioning as failed', async () => {
+  const f = fixture({ listProfiles: () => { throw new Error('private path'); } });
+  const probed = await f.coordinator.probe({ origin: 'https://vpn.example.edu' });
+  const confirmed = f.coordinator.confirm({
+    confirmationHandle: probed.confirmation.confirmationHandle,
+  });
+  assert.equal(confirmed.ok, true);
+  assert.equal(confirmed.profileId.startsWith('custom-'), true);
+  assert.deepEqual(confirmed.profiles, []);
+  assert.equal(confirmed.warningCode, 'PROFILE_LIST_FAILED');
+  assert.deepEqual(f.diagnostics, ['PROFILE_LIST_FAILED']);
+});
+
+test('runner and unsupported results collapse to stable value-free codes', async () => {
+  const failed = fixture({
+    probeRunner: {
+      probe: async () => { const error = new Error('private path'); error.code = 'GATEWAY_PROBE_TIMEOUT'; throw error; },
+      cancel: () => false,
+    },
+  });
+  assert.deepEqual(await failed.coordinator.probe({ origin: 'https://vpn.example.edu' }), {
+    ok: false,
+    code: 'GATEWAY_PROBE_TIMEOUT',
+  });
+  assert.deepEqual(failed.diagnostics, ['GATEWAY_PROBE_TIMEOUT']);
+
+  const unsupported = fixture({
+    probeRunner: {
+      probe: async () => ({ ...probeResult(), compatibility: 'unknown' }),
+      cancel: () => false,
+    },
+  });
+  assert.deepEqual(await unsupported.coordinator.probe({ origin: 'https://vpn.example.edu' }), {
+    ok: false,
+    code: 'GATEWAY_PROBE_UNSUPPORTED',
+  });
+});
+
+test('confirmed onboarding materializes a restart-readable custom candidate', async (t) => {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'school-onboarding-real-'));
+  fs.chmodSync(userData, 0o700);
+  t.after(() => fs.rmSync(userData, { recursive: true, force: true }));
+  const desktop = path.join(__dirname, '..');
+  const directory = new ProfileCandidateDirectory({
+    userData,
+    packageRoot: desktop,
+    desktopDir: desktop,
+    resourcesPath: '/unused',
+    isPackaged: false,
+  });
+  let confirmationSeed = 10;
+  let provisioningSeed = 30;
+  const coordinator = new SchoolProfileOnboardingCoordinator({
+    probeRunner: { probe: async () => probeResult(), cancel: () => false },
+    confirmationOwner: new CustomGatewayConfirmationOwner({
+      randomBytes: (length) => Buffer.alloc(length, ++confirmationSeed),
+      now: () => 1_800_000_000_000,
+      ttlMs: 10_000,
+    }),
+    provisioningRuntime: new CustomProfileProvisioningRuntime({
+      userData,
+      randomBytes: (length) => Buffer.alloc(length, ++provisioningSeed),
+      now: () => 1_800_000_000_100,
+    }),
+    getActiveContext: () => context(),
+    listProfiles: (options) => directory.listViews(options),
+  });
+  const probed = await coordinator.probe({ origin: 'https://vpn.example.edu' });
+  const confirmed = coordinator.confirm({
+    confirmationHandle: probed.confirmation.confirmationHandle,
+  });
+  assert.equal(confirmed.ok, true);
+  let record;
+  new ProfileCandidateDirectory({
+    userData,
+    packageRoot: desktop,
+    desktopDir: desktop,
+    resourcesPath: '/unused',
+    isPackaged: false,
+  }).withCandidate(confirmed.profileId, (value) => { record = value; });
+  assert.equal(record.profile.gateway.origin.origin, 'https://vpn.example.edu');
+  assert.equal(record.kind, 'custom-local');
+  assert.equal(record.context.activeContextEpoch, 1);
+  assert.equal(Object.hasOwn(confirmed, 'context'), false);
+});

--- a/docs/adr/0028-main-owned-custom-gateway-onboarding.md
+++ b/docs/adr/0028-main-owned-custom-gateway-onboarding.md
@@ -1,0 +1,48 @@
+# ADR-0028: Keep custom Gateway onboarding in Main
+
+- Status: Accepted for 2.0 P6i
+- Scope: credential-free probe, confirmation and durable Candidate provisioning
+- School selector and active Profile switch: deferred to P6j
+
+## Decision
+
+The control Renderer may request four narrow operations: list sanitized Profile
+views, probe a custom Gateway origin, confirm the short-lived result, and cancel
+the flow. Main owns every protocol and persistence component.
+
+The native `ec-gateway-probe` receives one normalized HTTPS root origin and no
+credential, cookie, token, account name or Profile key. Its child environment
+does not inherit proxy variables, certificate overrides or application secrets.
+Stdout and discarded stderr are bounded, the process has a fixed deadline, and
+malformed, concurrent, failed and cancelled outcomes use stable value-free error
+codes.
+
+Main binds a successful probe to the exact current process-lifetime active
+context before issuing a two-minute confirmation handle. Context drift,
+expiration, cancellation or duplicate consumption makes that handle unusable.
+The Renderer receives the normalized origin, candidate family, reported version,
+expiry and unverified flag, but never the generated Profile/Account/Workspace
+keys or the unredacted Profile document.
+
+Confirmation is consumed synchronously into the existing recoverable custom
+Profile provisioning journal. Only after all Profile, Engine config, Account and
+Workspace files are materialized and the custom index is committed does Main
+return the new public `profileId` and refreshed sanitized Profile views.
+
+## Boundaries
+
+P6i intentionally does not expose a visible selector or activate the Candidate.
+Doing so before P4 switch recovery and controlled relaunch are composed in Main
+would leave path-bound credentials, Browser Session, routes and Engine ownership
+on the previous school. P6j must switch those authorities transactionally before
+the onboarding UI becomes user-facing.
+
+## Evidence
+
+- exact child argv and scrubbed environment contract;
+- timeout, cancellation, concurrent, oversized and malformed output tests;
+- active-context drift invalidates a completed probe;
+- real provisioning produces a restart-readable custom Candidate;
+- trusted IPC and Preload expose no raw invoke, persistent key or Gateway state;
+- real Electron reviewed/custom Main startup can list only sanitized active views;
+- live credential-free HKUST probe returns the recognized compiled family.


### PR DESCRIPTION
## Scope

Complete the credential-free custom Gateway probe, confirmation, and recoverable Candidate provisioning runtime behind trusted Main-owned IPC. The school selector and active switch remain hidden until P6j composes P4 recovery/relaunch.

## Delivered

- Added a bounded native `ec-gateway-probe` runner:
  - one normalized HTTPS root origin;
  - no credential/cookie/token/account/Profile key;
  - no shell, proxy environment, certificate override, or application secrets;
  - bounded stdout and discarded stderr;
  - fixed timeout, single-flight, cancellation, and stable error codes.
- Bound each successful probe to the exact process-lifetime active context before issuing a short-lived confirmation.
- Context drift, Renderer loss, quit, cancellation, expiry, duplicate use, or malformed results fail closed.
- Confirmation feeds the existing prepared→materialized→indexed provisioning transaction.
- Main returns only the public `profileId`, unverified confirmation view, and allowlisted SchoolProfile views; persistent Profile/Account/Workspace keys never cross Preload.
- Added exact trusted IPC/Preload operations for list, probe, confirm, and cancel without exposing raw `ipcRenderer.invoke`.
- Centralized native executable resolution for Engine and Gateway probe without increasing Main dependencies or lines.
- Added ADR-0028 documenting why UI activation is deferred until P4 switching is composed.

## Evidence

- Desktop full suite: 859 passed, 0 failed, 1 explicit Windows-only skip before the final added onboarding cases; all later onboarding cases pass.
- Real Electron reviewed Main and clean custom Main Profile listing: PASS.
- Real provisioning produces a restart-readable custom Candidate and consumption-time Engine binding.
- Live credential-free HKUST probe through the new Main runner contract:
  - HTTPS identity valid;
  - recognized candidate;
  - `easyconnect-password-modern-l3-v1`;
  - `M7.6.8R2`;
  - HTTP 200.
- Architecture: 313 files, 614 edges, 0 cycles; Main 1644 lines / 35 direct dependencies; Renderer 524 lines.
- Secret gate on staged index and committed tree: PASS.

## Deferred boundary

No visible selector or `switch-school-profile` IPC is exposed in this PR. P6j must first compose ActiveContextSwitch recovery, cleanup, authority activation, and controlled relaunch so a provisioned school cannot inherit the old school's Engine, Browser Session, credentials, routes, or stale events.
