### PR TITLE
2.0: freeze the v1.2.3 upgrade gate after P8

### DIFF
--- a/desktop/e2e/fixtures/v1.2.3-settings.json
+++ b/desktop/e2e/fixtures/v1.2.3-settings.json
@@ -1,0 +1,27 @@
+{
+  "username": "synthetic-v1-2-3-user",
+  "port": 6280,
+  "autoReconnect": false,
+  "maxAttempts": 4,
+  "startAtLogin": false,
+  "autoConnect": false,
+  "strictProxyAuth": false,
+  "proxySecurityVersion": 3,
+  "proxyAuthMigrationPending": true,
+  "closeAction": "quit",
+  "language": "en",
+  "updateCheckedAt": 1780000000000,
+  "routeDomains": [
+    "hkust-gz.edu.cn",
+    "hkust.edu.hk"
+  ],
+  "customResources": [
+    {
+      "id": "synthetic-v123-direct",
+      "name": "Synthetic direct portal",
+      "description": "Sanitized v1.2.3 upgrade fixture",
+      "url": "https://portal.example.edu/",
+      "route": "direct"
+    }
+  ]
+}

--- a/desktop/e2e/persistence-migration.electron.js
+++ b/desktop/e2e/persistence-migration.electron.js
@@ -6,8 +6,11 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { app, safeStorage } = require('electron');
-const { createLegacyFlatSourcePaths } = require('../lib/persistence/paths/profile-workspace-layout');
-const { normalizeSettings } = require('../lib/persistence/settings/settings-store');
+const {
+  createLegacyFlatSourcePaths,
+  createProfileAccountWorkspaceLayout,
+} = require('../lib/persistence/paths/profile-workspace-layout');
+const v123Settings = require('./fixtures/v1.2.3-settings.json');
 
 const WAIT_MS = 30_000;
 
@@ -42,17 +45,13 @@ async function run() {
   assert.equal(safeStorage.isEncryptionAvailable(), true);
   const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'hkust-persistence-e2e-'));
   const legacy = createLegacyFlatSourcePaths(userData);
-  const settings = normalizeSettings({
-    username: 'synthetic-user',
-    port: 6180,
-    autoConnect: false,
-    startAtLogin: false,
-    routeDomains: ['hkust-gz.edu.cn'],
-  });
-  const bytes = Buffer.from(JSON.stringify(settings), 'utf8');
+  // This checked-in document is the exact flat settings shape emitted by the
+  // published v1.2.3 line. Do not generate it with current normalizers: doing
+  // so would let a schema regression change both the migration and its input.
+  const bytes = Buffer.from(JSON.stringify(v123Settings), 'utf8');
   fs.writeFileSync(legacy.settings, bytes, { mode: 0o600 });
   fs.writeFileSync(legacy.settingsBackup, bytes, { mode: 0o600 });
-  fs.writeFileSync(legacy.vpnCredential, safeStorage.encryptString('synthetic-password'), {
+  fs.writeFileSync(legacy.vpnCredential, safeStorage.encryptString('synthetic-v1-2-3-password'), {
     mode: 0o600,
   });
   fs.writeFileSync(legacy.routingRules, '{"schemaVersion":1,"rules":[]}', { mode: 0o600 });
@@ -81,9 +80,46 @@ async function run() {
     assert.equal(Number.isInteger(marker.pid) && marker.pid > 0, true);
     assert.equal(fs.existsSync(legacy.settings), false);
     assert.equal(fs.existsSync(legacy.vpnCredential), false);
-    assert.equal(fs.existsSync(path.join(userData, 'global', 'settings.json')), true);
+    const globalSettingsPath = path.join(userData, 'global', 'settings.json');
+    assert.equal(fs.existsSync(globalSettingsPath), true);
+    const globalSettings = JSON.parse(fs.readFileSync(globalSettingsPath, 'utf8'));
+    assert.equal(globalSettings.port, 6280);
+    assert.equal(globalSettings.strictProxyAuth, false);
+    assert.equal(globalSettings.proxyAuthMigrationPending, true);
+    assert.equal(globalSettings.closeAction, 'quit');
+    assert.equal(globalSettings.language, 'en');
+    assert.equal(globalSettings.startAtLogin, false);
+    assert.equal(Object.hasOwn(globalSettings, 'username'), false);
     const profilesRoot = path.join(userData, 'profiles');
-    assert.equal(fs.readdirSync(profilesRoot).length, 1);
+    const profileKeys = fs.readdirSync(profilesRoot);
+    assert.equal(profileKeys.length, 1);
+    assert.equal(profileKeys[0], globalSettings.activeProfileKey);
+    const accountRoot = path.join(
+      profilesRoot,
+      globalSettings.activeProfileKey,
+      'accounts',
+      globalSettings.activeAccountKey,
+    );
+    const account = JSON.parse(fs.readFileSync(path.join(accountRoot, 'account.json'), 'utf8'));
+    const layout = createProfileAccountWorkspaceLayout({
+      userData,
+      profileKey: globalSettings.activeProfileKey,
+      accountKey: globalSettings.activeAccountKey,
+      workspaceKey: account.workspaceKey,
+      adoptLegacyHkustBrowserPartition: true,
+    });
+    const workspaceSettings = JSON.parse(fs.readFileSync(layout.workspace.settings, 'utf8'));
+    assert.equal(workspaceSettings.autoReconnect, false);
+    assert.equal(workspaceSettings.maxAttempts, 4);
+    assert.equal(workspaceSettings.autoConnect, false);
+    assert.deepEqual(workspaceSettings.routeDomains, ['hkust-gz.edu.cn', 'hkust.edu.hk']);
+    const localResources = JSON.parse(fs.readFileSync(layout.workspace.localResources, 'utf8'));
+    assert.deepEqual(localResources.resources, [{
+      ...v123Settings.customResources[0],
+      category: 'custom',
+      keywords: [],
+    }]);
+    assert.equal(fs.statSync(layout.account.vpnCredential).size > 0, true);
   } finally {
     if (marker?.pid) await stopOwnedProcess(marker.pid);
     try { child.kill('SIGTERM'); } catch {}

--- a/docs/2.0-status.md
+++ b/docs/2.0-status.md
@@ -1,8 +1,8 @@
 # Campus Connect 2.0 implementation status
 
 - Status authority: current `main` source plus required GitHub checks
-- Merged implementation baseline: `8c1f83cf941e92582e2540d138ae3e264d4d58c5`
-- Baseline merge: PR #52, 2.0 stabilization
+- Merged implementation baseline: `17f9f5f2461e79081f156b55db829c9ab4d12eb2`
+- Baseline merge: PR #53, P8 WebResource library
 - Published stable line: `v1.2.3` at `5d8323d37de7c279ae70b3ec646f93791d6a3581`
 - Release state: 2.0 development is not a published release
 
@@ -21,8 +21,8 @@ the current `main` tree and this status file win.
 | P5 | Generation-bound Gateway connector consumed by Gateway HTTP and Modern transport before credentials |
 | P6 | School selector plus credential-free, confirmed, isolated `custom-local` Gateway onboarding |
 | P7 | Profile-bound Integration Center for Clash/Mihomo/PAC/manual export, Clash Verge Rev and OpenSSH/VS Code |
-| Stabilization branch | Exact-tree source gates, authoritative status/ADR index, domain directories, dependency/cycle/unresolved-import gates and an empty root-debt ledger |
-| P8 branch | Versioned WebResource library, owner-only favorites/recents, ID-only stored opens, Direct-without-Engine, on-demand Campus redirect gate, search and categories |
+| Stabilization | Exact-tree source gates, authoritative status/ADR index, domain directories, dependency/cycle/unresolved-import gates and an empty root-debt ledger |
+| P8 | Versioned WebResource library, 15 reviewed HKUST(GZ) entries, owner-only favorites/recents, ID-only stored opens, Direct-without-Engine, on-demand Campus redirect gate, search and categories |
 
 P7 uses redacted preview and explicit confirmation. Managed actions own only their marked blocks, use bounded
 backup/atomic replacement/readback/rollback, retain only non-secret ownership records and never scan disks or
@@ -48,9 +48,10 @@ processes, overwrite subscriptions, launch third-party tools or weaken local pro
 
 ## Active order
 
-1. merge P8 only after full Desktop/Rust/Electron/package validation and independent review;
-2. add a second reviewed Profile before claiming formal multi-school production support;
-3. implement P9 only from authorized, sanitized current-school evidence.
+1. keep an exact, sanitized v1.2.3 user-data fixture as the 2.0 release-candidate upgrade gate;
+2. decide the first 2.0 pre-release version only when migration and package evidence are ready;
+3. add a second reviewed Profile before claiming formal multi-school production support;
+4. implement P9 only from authorized, sanitized current-school evidence.
 
 The application remains Web-resource-first for ordinary users and exposes external-tool configuration for
 advanced users. It does not add an SSH client, HPC manager, Jupyter/database launcher or `ForwardLease`.

--- a/docs/audits/2026-08-25-p8-webresource-review.md
+++ b/docs/audits/2026-08-25-p8-webresource-review.md
@@ -2,8 +2,9 @@
 
 ## Scope
 
-This review covers the ordinary-user WebResource upgrade on `codex/2.0-p8-web-resources`. It changes no Gateway
-authentication, Modern L3, DNS, SOCKS/HTTP frontend or External Tool Integration provider.
+This review covers the ordinary-user WebResource upgrade merged by PR #53 as
+`17f9f5f2461e79081f156b55db829c9ab4d12eb2`. It changes no Gateway authentication, Modern L3, DNS, SOCKS/HTTP
+frontend or External Tool Integration provider.
 
 ## Delivered boundaries
 
@@ -40,3 +41,4 @@ or authenticated server catalogue was added.
   residue.
 - Rust fmt and Clippy `-D warnings` passed. Rust tests: 297 passed, two explicit performance matrices ignored,
   zero failures.
+- GitHub required checks passed on macOS, Windows and Linux before PR #53 merged.

--- a/docs/plans/2.0-preparation-execution-plan.md
+++ b/docs/plans/2.0-preparation-execution-plan.md
@@ -1,12 +1,12 @@
 # Campus Connect 2.0 — Campus Workspace + Secure Access Runtime Execution Plan
 
-- Status: Historical execution plan reconciled with implemented P1-P7; current status is `../2.0-status.md`
-- Revision: 8 — records implemented P1-P8 branches and keeps P9 independently evidence-gated
+- Status: Historical execution plan reconciled with implemented P1-P8; current status is `../2.0-status.md`
+- Revision: 9 — records merged P1-P8 and keeps P9 independently evidence-gated
 - Scope: implementation history plus remaining gated direction
 - Production behavior change: none
 - Version/release change: none
 - Baseline: HKUST(GZ) Connect `main` at
-  `35996adb4d52d8dba5e6a4e2f92582260ac4228e`
+  `17f9f5f2461e79081f156b55db829c9ab4d12eb2`
 - zju-connect protocol reference: `2c71a34c17ea7ecf04c5fe862c4c315344128653`; reviewed current-main
   configuration delta: `4b2bcaa0acc34a33de672c26e3b2cb83bd583b15`
 
@@ -78,7 +78,7 @@ reviewed school仍是正式多学校支持的证据门，而不是该实验路�
 
 | Source | Fixed identity | Evidence class | Permitted conclusion |
 | --- | --- | --- | --- |
-| HKUST(GZ) Connect | `35996ad` | Current merged source and green CI | implemented P1-P7; current provider remains password + Modern L3 |
+| HKUST(GZ) Connect | `17f9f5f` | Current merged source and green CI | implemented P1-P8; current provider remains password + Modern L3 |
 | Released client | `v1.2.3` → `5d8323d` | Published package evidence | Released behavior only; excludes post-release convergence fixes |
 | Installed EasyConnect macOS | [7.6.7 x86_64 sample](../research/easyconnect/sample-manifest.md) | Installed-mutated authorized static extraction | [Electron/Web/native feature topology](../research/easyconnect/macos-7.6.7-static-observation.md); school activation still unknown |
 | EasyConnect Linux | public 7.6.7.3 package baseline | Sanitized static evidence | Named binary/capability marker and legacy transport clues |
@@ -731,7 +731,7 @@ Deliver it as three review units:
   strict local proxy authentication;
 - do not add Router, ForwardLease, SSH/HPC/Jupyter/database modules or an integrated SSH client.
 
-### 2.0-P8 — Lightweight WebResource and ordinary-user Campus Workspace upgrade
+### 2.0-P8 — Lightweight WebResource and ordinary-user Campus Workspace upgrade (implemented)
 
 - introduce only `WebResource { id, localizedName, localizedDescription, url, route, category, keywords,
   iconKey?, reviewed }` for packaged and local Web pages;
@@ -879,8 +879,8 @@ Before any broader EasyConnect dynamic analysis, the school must also:
 No 2.0 production feature or release is authorized by this plan alone.
 
 P2-P5 are implemented foundation. P6 implements the school selector and isolated experimental custom-domain
-path; a second reviewed Profile remains required before a formal multi-school support statement. P7 is merged.
-P8 remains the ordinary-user Web Campus Workspace upgrade, and P9 requires real school evidence. P10-P12+
+path; a second reviewed Profile remains required before a formal multi-school support statement. P7 and P8 are
+merged. P9 requires real school evidence. P10-P12+
 capabilities retain independent evidence, canary and rollback gates.
 
 `main` continues to require pull requests plus CI, package-verifier and exact-tree secret-scan checks according to


### PR DESCRIPTION
## What changed

- replace the migration E2E's self-generated legacy input with a checked-in, sanitized v1.2.3 settings fixture
- verify preserved port, proxy-auth choice, window/language settings, reconnect policy, route domains, custom WebResource conversion, and migrated VPN credential presence
- update the 2.0 status, execution baseline, and P8 audit to the merged PR #53 commit

## Why

The previous Electron migration test generated its old input with the current normalizer, so a schema regression could change both the migration and its fixture. This PR makes the published v1.2.3 layout an independent release-candidate upgrade gate.

## Verification

- npm run test:persistence-migration
- npm run check:syntax (380 files)
- npm test (992 total, 991 pass, 1 Windows-only skip)
- npm run check:architecture
- npm run check:install-scripts
- npm run check:secrets
- npm audit --audit-level=high (0 vulnerabilities)

No production runtime behavior changes.