### PR TITLE
fix: recover Windows 2.0 startup and in-place upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,11 +242,15 @@ jobs:
         env:
           ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
         run: npm ci
-      - name: Verify current-user-only helper credential DACL
+      - name: Verify Windows private files, legacy upgrade, and packaged school discovery
         run: >-
           node --test
           test/unit/platform/storage/windows-private-file.test.js
-          test/unit/integrations/external-proxy-config.test.js
+          test/unit/persistence/migration/legacy-hkust/legacy-flat-source-receipts.test.js
+          test/unit/app/startup/multi-school-startup-runtime.test.js
+          test/windows-platform-smoke.test.js
+      - name: Verify current-user-only helper credential DACL
+        run: node --test test/unit/integrations/external-proxy-config.test.js
 
   engine:
     timeout-minutes: 20

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ HKUST(GZ) Connect 用于在校外访问香港科技大学（广州）的校内�
 
 ### macOS 安装
 
-打开 dmg，把应用拖入“应用程序”。如果 macOS 提示“无法验证开发者”或应用
+打开 dmg，把应用拖入“应用程序”；升级时对同名应用选择“替换”，应用数据会保留。
+如果 macOS 提示“无法验证开发者”或应用
 “已损坏”，可以：
 
 1. 在 Finder 中右键点击应用，选择“打开”，然后再次确认；或
@@ -61,7 +62,8 @@ HKUST(GZ) Connect 用于在校外访问香港科技大学（广州）的校内�
 
 ### Windows 安装
 
-运行下载的 exe。如果 SmartScreen 出现提示，点击“更多信息”→“仍要运行”。
+运行下载的 exe。升级时直接运行新版安装器；它会复用已登记的当前用户安装目录并覆盖旧版程序，
+不会删除设置、收藏或凭据。如果 SmartScreen 出现提示，点击“更多信息”→“仍要运行”。
 
 ### Linux 使用
 
@@ -78,6 +80,7 @@ chmod +x hkustgzconnect-<版本>-linux-x86_64.AppImage
 
 Linux 只有在系统提供 Secret Service/密钥环时才会保存密码；没有安全密钥环时，
 应用会要求每次启动重新输入，不会把密码明文写入磁盘。
+AppImage 是独立文件，下载新版后请用它替换旧 AppImage；应用数据目录不会随文件替换而删除。
 
 ## 最简单的使用方法
 
@@ -269,16 +272,19 @@ Download the latest build from
 
 ### macOS
 
-Open the dmg and drag the app into Applications. If macOS says the developer
-cannot be verified or the app is damaged:
+Open the dmg and drag the app into Applications. When upgrading, choose
+**Replace** for the existing app; application data is preserved. If macOS says
+the developer cannot be verified or the app is damaged:
 
 1. Right-click the app in Finder, choose **Open**, and confirm; or
 2. Open **System Settings → Privacy & Security** and choose **Open Anyway**.
 
 ### Windows
 
-Run the downloaded exe. If SmartScreen appears, choose **More info → Run
-anyway**.
+Run the downloaded exe. For an upgrade, run the new installer directly: it
+reuses the registered per-user install directory and replaces the old program
+files without deleting settings, favorites, or credentials. If SmartScreen
+appears, choose **More info → Run anyway**.
 
 ### Linux
 
@@ -290,6 +296,8 @@ chmod +x hkustgzconnect-<version>-linux-x86_64.AppImage
 Without FUSE, use `--appimage-extract-and-run`. Linux saves passwords only when
 a Secret Service/keyring backend is available; otherwise the password must be
 entered on each start and is never persisted as plaintext.
+An AppImage is a standalone file, so replace the old AppImage with the newly
+downloaded one; replacing it does not remove the application data directory.
 
 ## Easiest setup
 

--- a/desktop/e2e/school-profile-asar.electron.js
+++ b/desktop/e2e/school-profile-asar.electron.js
@@ -6,6 +6,9 @@ const os = require('node:os');
 const path = require('node:path');
 const asar = require('@electron/asar');
 const { app } = require('electron');
+const {
+  MultiSchoolStartupRuntime,
+} = require('../lib/app/startup/multi-school-startup-runtime');
 const { SchoolProfileRegistry } = require('../lib/profiles/registry/school-profile-registry');
 
 const desktopRoot = path.join(__dirname, '..');
@@ -46,6 +49,23 @@ async function run() {
     'hkustgz-engine-config',
     'engine-config',
   ).length > 0, true);
+  const firstRun = new MultiSchoolStartupRuntime({
+    userData: path.join(temporaryRoot, 'user-data'),
+    packageRoot: archive,
+    desktopDir: desktopRoot,
+    resourcesPath: temporaryRoot,
+    isPackaged: true,
+  });
+  assert.equal(firstRun.initialize({ mode: 'legacy-flat' }).profileCount, 1);
+  assert.deepEqual(firstRun.listViews({ locale: 'zh' }).map((view) => ({
+    profileId: view.profileId,
+    schoolName: view.schoolName,
+    unverified: view.unverified,
+  })), [{
+    profileId: 'hkustgz',
+    schoolName: '香港科技大学(广州)',
+    unverified: false,
+  }]);
   process.stdout.write('school profile ASAR runtime: PASS\n');
 }
 

--- a/desktop/lib/app/startup/multi-school-startup-runtime.js
+++ b/desktop/lib/app/startup/multi-school-startup-runtime.js
@@ -2,6 +2,7 @@
 
 const { CustomProfileProvisioningRuntime } = require('../../profiles/provisioning/custom-profile-provisioning-runtime');
 const { ProfileCandidateDirectory } = require('../../profiles/registry/profile-candidate-directory');
+const { SchoolProfileRegistry } = require('../../profiles/registry/school-profile-registry');
 const { validateSchoolProfileDocument } = require('../../profiles/schema/school-profile-schema');
 
 function customGatewayProductAvailability({ environment = process.env } = {}) {
@@ -17,26 +18,37 @@ class MultiSchoolStartupRuntime {
     desktopDir,
     ProvisioningRuntimeClass = CustomProfileProvisioningRuntime,
     CandidateDirectoryClass = ProfileCandidateDirectory,
+    PackagedRegistryClass = SchoolProfileRegistry,
   } = {}) {
     if (typeof ProvisioningRuntimeClass !== 'function' ||
-        typeof CandidateDirectoryClass !== 'function') {
+        typeof CandidateDirectoryClass !== 'function' ||
+        typeof PackagedRegistryClass !== 'function') {
       throw new TypeError('multi-school startup runtime dependencies are invalid');
     }
     this.options = { userData, packageRoot, isPackaged, resourcesPath, desktopDir };
     this.ProvisioningRuntimeClass = ProvisioningRuntimeClass;
     this.CandidateDirectoryClass = CandidateDirectoryClass;
+    this.PackagedRegistryClass = PackagedRegistryClass;
     this.state = null;
     this.directory = null;
+    this.packagedRegistry = null;
   }
 
   initialize({ mode, authority, withProfileDocument } = {}) {
     if (this.state) return this.state;
     if (mode === 'legacy-flat') {
+      // A fresh install has no Profile Workspace anchor yet, but the reviewed
+      // packaged school is still a valid read-only candidate for onboarding.
+      // Listing it independently prevents the selector from degrading to only
+      // "Other school" before the first successful persistence migration.
+      const profileCount = this.#packagedRegistry().listViews({
+        locale: 'en', compatibility: 'reviewed',
+      }).length;
       this.state = Object.freeze({
         ready: true,
         mode,
         provisioningStatus: 'not_applicable',
-        profileCount: 0,
+        profileCount,
       });
       return this.state;
     }
@@ -85,8 +97,9 @@ class MultiSchoolStartupRuntime {
   }
 
   listViews(options) {
-    if (!this.directory) return Object.freeze([]);
-    return this.directory.listViews(options);
+    if (this.directory) return this.directory.listViews(options);
+    if (!this.packagedRegistry) return Object.freeze([]);
+    return this.packagedRegistry.listViews({ ...options, compatibility: 'reviewed' });
   }
 
   withDirectory(callback) {
@@ -94,6 +107,15 @@ class MultiSchoolStartupRuntime {
       throw new Error('multi-school candidate directory is unavailable');
     }
     return callback(this.directory);
+  }
+
+  #packagedRegistry() {
+    if (!this.packagedRegistry) {
+      this.packagedRegistry = new this.PackagedRegistryClass({
+        packageRoot: this.options.packageRoot,
+      }).load();
+    }
+    return this.packagedRegistry;
   }
 }
 

--- a/desktop/lib/persistence/migration/legacy-hkust/legacy-flat-source-receipts.js
+++ b/desktop/lib/persistence/migration/legacy-hkust/legacy-flat-source-receipts.js
@@ -7,7 +7,10 @@ const {
   validateUserDataRoot,
 } = require('../../paths/profile-workspace-layout');
 const { LEGACY_SOURCE_IDS } = require('./profile-workspace-migration-journal');
-const { verifyWindowsFileOwnerOnly } = require('../../../platform/storage/windows-private-file');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('../../../platform/storage/windows-private-file');
 
 const READ_CHUNK_BYTES = 64 * 1024;
 const LEGACY_SOURCE_MAX_BYTES = Object.freeze({
@@ -47,13 +50,20 @@ function collectPrivateFileReceipt({
   maxBytes,
   fileSystem = fs,
   platform = process.platform,
-  windowsAcl = { verify: verifyWindowsFileOwnerOnly },
+  windowsAcl = {
+    protect: protectWindowsFileOwnerOnly,
+    verify: verifyWindowsFileOwnerOnly,
+  },
+  repairWindowsAcl = false,
   label = 'private file',
 } = {}) {
   if (typeof file !== 'string' || !Number.isSafeInteger(maxBytes) || maxBytes < 1 ||
       !fileSystem || typeof fileSystem.lstatSync !== 'function' ||
       !['darwin', 'linux', 'win32'].includes(platform) ||
       (platform === 'win32' && typeof windowsAcl?.verify !== 'function') ||
+      (repairWindowsAcl === true && (platform !== 'win32' ||
+        typeof windowsAcl?.protect !== 'function')) ||
+      typeof repairWindowsAcl !== 'boolean' ||
       typeof label !== 'string' || !label) {
     throw new TypeError('private receipt dependencies are invalid');
   }
@@ -65,11 +75,26 @@ function collectPrivateFileReceipt({
     throw invalidSource(`${label} could not be inspected`, error);
   }
   if (!before.isFile() || before.isSymbolicLink() || before.size < 0 || before.size > maxBytes ||
-      (platform !== 'win32' && (before.nlink !== 1 || (before.mode & 0o077) !== 0))) {
+      (Number.isSafeInteger(before.nlink) && before.nlink !== 1) ||
+      (platform !== 'win32' && (before.mode & 0o077) !== 0)) {
     throw invalidSource(`${label} is not a bounded owner-only regular file`);
   }
   if (platform === 'win32' && !windowsAcl.verify(file)) {
-    throw invalidSource(`${label} Windows ACL is not current-user-only`);
+    if (!repairWindowsAcl || !windowsAcl.protect(file) || !windowsAcl.verify(file)) {
+      throw invalidSource(`${label} Windows ACL is not current-user-only`);
+    }
+    let tightened;
+    try { tightened = fileSystem.lstatSync(file); }
+    catch (error) { throw invalidSource(`${label} changed while tightening its Windows ACL`, error); }
+    if (!tightened.isFile() || tightened.isSymbolicLink() ||
+        tightened.dev !== before.dev || tightened.ino !== before.ino ||
+        tightened.size !== before.size || tightened.mtimeMs !== before.mtimeMs ||
+        (Number.isSafeInteger(tightened.nlink) && tightened.nlink !== 1)) {
+      throw invalidSource(`${label} changed while tightening its Windows ACL`);
+    }
+    // ACL updates can legitimately change ctime, so use the post-hardening
+    // snapshot as the exact version that the descriptor must open.
+    before = tightened;
   }
 
   const constants = fileSystem.constants || fs.constants;
@@ -83,7 +108,7 @@ function collectPrivateFileReceipt({
     }
     const opened = fileSystem.fstatSync(descriptor);
     if (!opened.isFile() || !sameFileVersion(opened, before) || opened.size > maxBytes ||
-        (platform !== 'win32' && opened.nlink !== 1)) {
+        (Number.isSafeInteger(opened.nlink) && opened.nlink !== 1)) {
       throw invalidSource(`${label} changed while opening`);
     }
 
@@ -100,7 +125,7 @@ function collectPrivateFileReceipt({
     }
     const after = fileSystem.fstatSync(descriptor);
     if (!after.isFile() || !sameFileVersion(after, opened) ||
-        (platform !== 'win32' && after.nlink !== 1)) {
+        (Number.isSafeInteger(after.nlink) && after.nlink !== 1)) {
       throw invalidSource(`${label} changed while reading`);
     }
     return Object.freeze({
@@ -120,11 +145,18 @@ function collectLegacyFlatSourceReceipts({
   userData,
   fileSystem = fs,
   platform = process.platform,
-  windowsAcl = { verify: verifyWindowsFileOwnerOnly },
+  windowsAcl = {
+    protect: protectWindowsFileOwnerOnly,
+    verify: verifyWindowsFileOwnerOnly,
+  },
+  repairWindowsAcl = false,
 } = {}) {
   if (!fileSystem || typeof fileSystem.lstatSync !== 'function' ||
       !['darwin', 'linux', 'win32'].includes(platform) ||
-      (platform === 'win32' && typeof windowsAcl?.verify !== 'function')) {
+      (platform === 'win32' && typeof windowsAcl?.verify !== 'function') ||
+      (repairWindowsAcl === true && (platform !== 'win32' ||
+        typeof windowsAcl?.protect !== 'function')) ||
+      typeof repairWindowsAcl !== 'boolean') {
     throw new TypeError('legacy receipt dependencies are invalid');
   }
   const root = validateUserDataRoot(userData);
@@ -151,6 +183,7 @@ function collectLegacyFlatSourceReceipts({
       fileSystem,
       platform,
       windowsAcl,
+      repairWindowsAcl,
       label: 'legacy source',
     }),
   ])));

--- a/desktop/lib/persistence/migration/legacy-hkust/legacy-flat-source-receipts.js
+++ b/desktop/lib/persistence/migration/legacy-hkust/legacy-flat-source-receipts.js
@@ -8,7 +8,7 @@ const {
 } = require('../../paths/profile-workspace-layout');
 const { LEGACY_SOURCE_IDS } = require('./profile-workspace-migration-journal');
 const {
-  protectWindowsFileOwnerOnly,
+  tightenWindowsFileOwnerOnly,
   verifyWindowsFileOwnerOnly,
 } = require('../../../platform/storage/windows-private-file');
 
@@ -51,7 +51,7 @@ function collectPrivateFileReceipt({
   fileSystem = fs,
   platform = process.platform,
   windowsAcl = {
-    protect: protectWindowsFileOwnerOnly,
+    tighten: tightenWindowsFileOwnerOnly,
     verify: verifyWindowsFileOwnerOnly,
   },
   repairWindowsAcl = false,
@@ -62,7 +62,7 @@ function collectPrivateFileReceipt({
       !['darwin', 'linux', 'win32'].includes(platform) ||
       (platform === 'win32' && typeof windowsAcl?.verify !== 'function') ||
       (repairWindowsAcl === true && (platform !== 'win32' ||
-        typeof windowsAcl?.protect !== 'function')) ||
+        typeof windowsAcl?.tighten !== 'function')) ||
       typeof repairWindowsAcl !== 'boolean' ||
       typeof label !== 'string' || !label) {
     throw new TypeError('private receipt dependencies are invalid');
@@ -80,7 +80,7 @@ function collectPrivateFileReceipt({
     throw invalidSource(`${label} is not a bounded owner-only regular file`);
   }
   if (platform === 'win32' && !windowsAcl.verify(file)) {
-    if (!repairWindowsAcl || !windowsAcl.protect(file) || !windowsAcl.verify(file)) {
+    if (!repairWindowsAcl || !windowsAcl.tighten(file) || !windowsAcl.verify(file)) {
       throw invalidSource(`${label} Windows ACL is not current-user-only`);
     }
     let tightened;
@@ -146,7 +146,7 @@ function collectLegacyFlatSourceReceipts({
   fileSystem = fs,
   platform = process.platform,
   windowsAcl = {
-    protect: protectWindowsFileOwnerOnly,
+    tighten: tightenWindowsFileOwnerOnly,
     verify: verifyWindowsFileOwnerOnly,
   },
   repairWindowsAcl = false,
@@ -155,7 +155,7 @@ function collectLegacyFlatSourceReceipts({
       !['darwin', 'linux', 'win32'].includes(platform) ||
       (platform === 'win32' && typeof windowsAcl?.verify !== 'function') ||
       (repairWindowsAcl === true && (platform !== 'win32' ||
-        typeof windowsAcl?.protect !== 'function')) ||
+        typeof windowsAcl?.tighten !== 'function')) ||
       typeof repairWindowsAcl !== 'boolean') {
     throw new TypeError('legacy receipt dependencies are invalid');
   }

--- a/desktop/lib/persistence/migration/legacy-hkust/profile-workspace-migration-runtime.js
+++ b/desktop/lib/persistence/migration/legacy-hkust/profile-workspace-migration-runtime.js
@@ -37,6 +37,7 @@ const {
 const { validateSchoolProfileDocument } = require('../../../profiles/schema/school-profile-schema');
 const {
   protectWindowsFileOwnerOnly,
+  tightenWindowsFileOwnerOnly,
   verifyWindowsFileOwnerOnly,
 } = require('../../../platform/storage/windows-private-file');
 
@@ -78,6 +79,7 @@ class ProfileWorkspaceMigrationRuntime {
     platform = process.platform,
     windowsAcl = {
       protect: protectWindowsFileOwnerOnly,
+      tighten: tightenWindowsFileOwnerOnly,
       verify: verifyWindowsFileOwnerOnly,
     },
     randomBytes = crypto.randomBytes,
@@ -86,7 +88,9 @@ class ProfileWorkspaceMigrationRuntime {
     if (!safeStorage || !fileSystem || typeof fileSystem.openSync !== 'function' ||
         !['darwin', 'linux', 'win32'].includes(platform) ||
         (platform === 'win32' &&
-          (typeof windowsAcl?.protect !== 'function' || typeof windowsAcl?.verify !== 'function')) ||
+          (typeof windowsAcl?.protect !== 'function' ||
+            typeof windowsAcl?.tighten !== 'function' ||
+            typeof windowsAcl?.verify !== 'function')) ||
         typeof randomBytes !== 'function' || typeof now !== 'function') {
       throw new TypeError('Profile Workspace migration runtime dependencies are invalid');
     }

--- a/desktop/lib/persistence/migration/legacy-hkust/profile-workspace-migration-runtime.js
+++ b/desktop/lib/persistence/migration/legacy-hkust/profile-workspace-migration-runtime.js
@@ -185,6 +185,11 @@ class ProfileWorkspaceMigrationRuntime {
       fileSystem: this.fileSystem,
       platform: this.platform,
       windowsAcl: this.windowsAcl,
+      // 1.x Windows files were created by the signed-in user but could retain
+      // inherited ACL entries. The ACL helper refuses foreign ownership, and
+      // receipts are collected only after the exact source has been tightened
+      // and re-identified.
+      repairWindowsAcl: this.platform === 'win32',
     });
   }
 

--- a/desktop/lib/persistence/runtime/profile-workspace-startup-runtime.js
+++ b/desktop/lib/persistence/runtime/profile-workspace-startup-runtime.js
@@ -23,6 +23,7 @@ const { createProfileWorkspaceRuntimeStoragePaths } = require('../paths/runtime-
 const { validateSchoolProfileDocument } = require('../../profiles/schema/school-profile-schema');
 const {
   protectWindowsFileOwnerOnly,
+  tightenWindowsFileOwnerOnly,
   verifyWindowsFileOwnerOnly,
 } = require('../../platform/storage/windows-private-file');
 
@@ -60,6 +61,7 @@ class ProfileWorkspaceStartupRuntime {
     platform = process.platform,
     windowsAcl = {
       protect: protectWindowsFileOwnerOnly,
+      tighten: tightenWindowsFileOwnerOnly,
       verify: verifyWindowsFileOwnerOnly,
     },
     randomBytes,
@@ -68,7 +70,9 @@ class ProfileWorkspaceStartupRuntime {
     if (!safeStorage || !fileSystem || typeof fileSystem.openSync !== 'function' ||
         !['darwin', 'linux', 'win32'].includes(platform) ||
         (platform === 'win32' &&
-          (typeof windowsAcl?.protect !== 'function' || typeof windowsAcl?.verify !== 'function'))) {
+          (typeof windowsAcl?.protect !== 'function' ||
+            typeof windowsAcl?.tighten !== 'function' ||
+            typeof windowsAcl?.verify !== 'function'))) {
       throw new TypeError('Profile Workspace startup dependencies are invalid');
     }
     this.userData = validateUserDataRoot(userData);

--- a/desktop/lib/platform/storage/private-file.js
+++ b/desktop/lib/platform/storage/private-file.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const fs = require('fs');
+const {
+  protectWindowsFileOwnerOnly,
+  verifyWindowsFileOwnerOnly,
+} = require('./windows-private-file');
 
 const MAX_PRIVATE_READ_BYTES = 64 * 1024 * 1024;
 
@@ -64,27 +68,54 @@ function readPrivateFileBounded(file, {
   }
 }
 
-function ensureOwnerOnly(file) {
+function sameFileIdentity(left, right) {
+  return left.dev === right.dev && left.ino === right.ino && left.size === right.size &&
+    left.mtimeMs === right.mtimeMs;
+}
+
+function ensureOwnerOnly(file, {
+  fileSystem = fs,
+  platform = process.platform,
+  windowsAcl = {
+    protect: protectWindowsFileOwnerOnly,
+    verify: verifyWindowsFileOwnerOnly,
+  },
+} = {}) {
   let descriptor = null;
   try {
-    const before = fs.lstatSync(file);
+    if (!['darwin', 'linux', 'win32'].includes(platform) ||
+        (platform === 'win32' && (typeof windowsAcl?.protect !== 'function' ||
+          typeof windowsAcl?.verify !== 'function'))) return false;
+    const before = fileSystem.lstatSync(file);
     if (!before.isFile() || before.isSymbolicLink() ||
-        (process.platform !== 'win32' && before.nlink !== 1)) return false;
-    const noFollow = fs.constants.O_NOFOLLOW || 0;
-    descriptor = fs.openSync(file, fs.constants.O_RDONLY | noFollow);
-    const opened = fs.fstatSync(descriptor);
+        (Number.isSafeInteger(before.nlink) && before.nlink !== 1)) return false;
+    const constants = fileSystem.constants || fs.constants;
+    const noFollow = constants.O_NOFOLLOW || 0;
+    descriptor = fileSystem.openSync(file, constants.O_RDONLY | noFollow);
+    const opened = fileSystem.fstatSync(descriptor);
     // The descriptor, rather than the path, owns the permission change. The
     // inode comparison also catches a path replacement between lstat/open on
     // platforms where O_NOFOLLOW is unavailable.
-    if (!opened.isFile() || opened.dev !== before.dev || opened.ino !== before.ino ||
-        (process.platform !== 'win32' && opened.nlink !== 1)) return false;
-    fs.fchmodSync(descriptor, 0o600);
+    if (!opened.isFile() || !sameFileIdentity(opened, before) ||
+        (Number.isSafeInteger(opened.nlink) && opened.nlink !== 1)) return false;
+    if (platform === 'win32') {
+      // Older releases created these files as the current user but could leave
+      // inherited Windows access rules in place. Tightening is allowed only
+      // after the PowerShell boundary proves the current SID already owns the
+      // exact regular path; it never takes ownership of a foreign file.
+      if (!windowsAcl.protect(file) || !windowsAcl.verify(file)) return false;
+      const after = fileSystem.lstatSync(file);
+      return after.isFile() && !after.isSymbolicLink() &&
+        sameFileIdentity(after, opened) &&
+        (!Number.isSafeInteger(after.nlink) || after.nlink === 1);
+    }
+    fileSystem.fchmodSync(descriptor, 0o600);
     return true;
   } catch {
     return false;
   } finally {
     if (descriptor !== null) {
-      try { fs.closeSync(descriptor); } catch {}
+      try { fileSystem.closeSync(descriptor); } catch {}
     }
   }
 }

--- a/desktop/lib/platform/storage/private-file.js
+++ b/desktop/lib/platform/storage/private-file.js
@@ -93,9 +93,10 @@ function ensureOwnerOnly(file, {
     const noFollow = constants.O_NOFOLLOW || 0;
     descriptor = fileSystem.openSync(file, constants.O_RDONLY | noFollow);
     const opened = fileSystem.fstatSync(descriptor);
-    // The descriptor, rather than the path, owns the permission change. The
-    // inode comparison also catches a path replacement between lstat/open on
-    // platforms where O_NOFOLLOW is unavailable.
+    // The no-follow descriptor owns the POSIX permission change. On Windows it
+    // pins the observed identity while the bounded PowerShell ACL operation
+    // acts on the path. The identity comparison catches replacement between
+    // lstat/open where O_NOFOLLOW is unavailable.
     if (!opened.isFile() || !sameFileIdentity(opened, before) ||
         (Number.isSafeInteger(opened.nlink) && opened.nlink !== 1)) return false;
     if (platform === 'win32') {

--- a/desktop/lib/platform/storage/private-file.js
+++ b/desktop/lib/platform/storage/private-file.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const {
-  protectWindowsFileOwnerOnly,
+  tightenWindowsFileOwnerOnly,
   verifyWindowsFileOwnerOnly,
 } = require('./windows-private-file');
 
@@ -77,14 +77,14 @@ function ensureOwnerOnly(file, {
   fileSystem = fs,
   platform = process.platform,
   windowsAcl = {
-    protect: protectWindowsFileOwnerOnly,
+    tighten: tightenWindowsFileOwnerOnly,
     verify: verifyWindowsFileOwnerOnly,
   },
 } = {}) {
   let descriptor = null;
   try {
     if (!['darwin', 'linux', 'win32'].includes(platform) ||
-        (platform === 'win32' && (typeof windowsAcl?.protect !== 'function' ||
+        (platform === 'win32' && (typeof windowsAcl?.tighten !== 'function' ||
           typeof windowsAcl?.verify !== 'function'))) return false;
     const before = fileSystem.lstatSync(file);
     if (!before.isFile() || before.isSymbolicLink() ||
@@ -103,7 +103,7 @@ function ensureOwnerOnly(file, {
       // inherited Windows access rules in place. Tightening is allowed only
       // after the PowerShell boundary proves the current SID already owns the
       // exact regular path; it never takes ownership of a foreign file.
-      if (!windowsAcl.protect(file) || !windowsAcl.verify(file)) return false;
+      if (!windowsAcl.tighten(file) || !windowsAcl.verify(file)) return false;
       const after = fileSystem.lstatSync(file);
       return after.isFile() && !after.isSymbolicLink() &&
         sameFileIdentity(after, opened) &&

--- a/desktop/lib/platform/storage/windows-private-file.js
+++ b/desktop/lib/platform/storage/windows-private-file.js
@@ -34,12 +34,7 @@ if (-not $verified.AreAccessRulesProtected -or $ownerSid -ne $currentSid -or -no
 }
 [Console]::Out.Write('owner_only')
 `;
-const PROTECT_SCRIPT = `${COMMON_PREFIX}
-$existing = [System.IO.File]::GetAccessControl($privatePath)
-$existingOwnerSid = $existing.GetOwner([Security.Principal.SecurityIdentifier])
-if ($existingOwnerSid -ne $currentSid) {
-  throw 'private path is not owned by the current user'
-}
+const APPLY_OWNER_ONLY_SUFFIX = String.raw`
 $acl = New-Object Security.AccessControl.FileSecurity
 $acl.SetOwner($currentSid)
 $acl.SetAccessRuleProtection($true, $false)
@@ -50,6 +45,17 @@ $rule = New-Object Security.AccessControl.FileSystemAccessRule(
 )
 $acl.AddAccessRule($rule)
 [System.IO.File]::SetAccessControl($privatePath, $acl)
+`;
+const PROTECT_SCRIPT = `${COMMON_PREFIX}
+${APPLY_OWNER_ONLY_SUFFIX}
+${VERIFY_SUFFIX}`;
+const TIGHTEN_SCRIPT = `${COMMON_PREFIX}
+$existing = [System.IO.File]::GetAccessControl($privatePath)
+$existingOwnerSid = $existing.GetOwner([Security.Principal.SecurityIdentifier])
+if ($existingOwnerSid -ne $currentSid) {
+  throw 'private path is not owned by the current user'
+}
+${APPLY_OWNER_ONLY_SUFFIX}
 ${VERIFY_SUFFIX}`;
 const VERIFY_SCRIPT = `${COMMON_PREFIX}
 ${VERIFY_SUFFIX}`;
@@ -87,6 +93,10 @@ function protectWindowsFileOwnerOnly(filePath, options) {
   return runAclScript(filePath, PROTECT_SCRIPT, options);
 }
 
+function tightenWindowsFileOwnerOnly(filePath, options) {
+  return runAclScript(filePath, TIGHTEN_SCRIPT, options);
+}
+
 function verifyWindowsFileOwnerOnly(filePath, options) {
   return runAclScript(filePath, VERIFY_SCRIPT, options);
 }
@@ -95,5 +105,6 @@ module.exports = {
   PRIVATE_FILE_ENV,
   POWERSHELL_ACL_TIMEOUT_MS,
   protectWindowsFileOwnerOnly,
+  tightenWindowsFileOwnerOnly,
   verifyWindowsFileOwnerOnly,
 };

--- a/desktop/lib/platform/storage/windows-private-file.js
+++ b/desktop/lib/platform/storage/windows-private-file.js
@@ -35,6 +35,11 @@ if (-not $verified.AreAccessRulesProtected -or $ownerSid -ne $currentSid -or -no
 [Console]::Out.Write('owner_only')
 `;
 const PROTECT_SCRIPT = `${COMMON_PREFIX}
+$existing = [System.IO.File]::GetAccessControl($privatePath)
+$existingOwnerSid = $existing.GetOwner([Security.Principal.SecurityIdentifier])
+if ($existingOwnerSid -ne $currentSid) {
+  throw 'private path is not owned by the current user'
+}
 $acl = New-Object Security.AccessControl.FileSecurity
 $acl.SetOwner($currentSid)
 $acl.SetAccessRuleProtection($true, $false)

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -13,7 +13,7 @@
     "check:syntax": "node scripts/check-javascript-syntax.js",
     "check:secrets": "node scripts/check-sensitive-patterns.js",
     "test": "node --test",
-    "test:windows": "node --test test/unit/platform/storage/windows-private-file.test.js test/windows-platform-smoke.test.js",
+    "test:windows": "node --test test/unit/platform/storage/windows-private-file.test.js test/unit/persistence/migration/legacy-hkust/legacy-flat-source-receipts.test.js test/unit/app/startup/multi-school-startup-runtime.test.js test/windows-platform-smoke.test.js",
     "test:browser-performance": "electron e2e/browser-performance.electron.js",
     "test:auth-control-e2e": "node e2e/auth-control-fixture.js",
     "test:campus-mfa-safety": "electron e2e/campus-mfa-safety.electron.js",
@@ -113,7 +113,7 @@
     },
     "nsis": {
       "oneClick": false,
-      "allowToChangeInstallationDirectory": true,
+      "allowToChangeInstallationDirectory": false,
       "perMachine": false
     },
     "linux": {

--- a/desktop/test/unit/app/startup/multi-school-startup-runtime.test.js
+++ b/desktop/test/unit/app/startup/multi-school-startup-runtime.test.js
@@ -52,16 +52,40 @@ test('Profile Workspace startup recovers provisioning before anchoring and enume
   assert.equal(runtime.initialize({}).profileCount, 2, 'startup ownership is idempotent');
 });
 
-test('legacy first-run remains behavior-compatible and does not construct multi-school stores', () => {
+test('legacy first-run lists the packaged HKUST profile without constructing persistent stores', () => {
   class Forbidden { constructor() { throw new Error('must not construct'); } }
+  class Registry {
+    load() { return this; }
+    listViews(options) {
+      assert.equal(options.compatibility, 'reviewed');
+      return [{ profileId: 'hkustgz' }];
+    }
+  }
   const runtime = new MultiSchoolStartupRuntime({
     ProvisioningRuntimeClass: Forbidden,
     CandidateDirectoryClass: Forbidden,
+    PackagedRegistryClass: Registry,
   });
   assert.deepEqual(runtime.initialize({ mode: 'legacy-flat' }), {
-    ready: true, mode: 'legacy-flat', provisioningStatus: 'not_applicable', profileCount: 0,
+    ready: true, mode: 'legacy-flat', provisioningStatus: 'not_applicable', profileCount: 1,
   });
-  assert.deepEqual(runtime.listViews(), []);
+  assert.deepEqual(runtime.listViews({ locale: 'zh' }), [{ profileId: 'hkustgz' }]);
+});
+
+test('real first-run registry exposes the reviewed HKUST option on every desktop platform', () => {
+  const runtime = new MultiSchoolStartupRuntime({
+    userData: path.resolve('/tmp/hkustgz-first-run'),
+    packageRoot: desktopRoot,
+    desktopDir: desktopRoot,
+    resourcesPath: '/unused',
+    isPackaged: false,
+  });
+  assert.equal(runtime.initialize({ mode: 'legacy-flat' }).profileCount, 1);
+  const views = runtime.listViews({ locale: 'zh' });
+  assert.equal(views.length, 1);
+  assert.equal(views[0].profileId, 'hkustgz');
+  assert.equal(views[0].schoolName, '香港科技大学(广州)');
+  assert.equal(views[0].unverified, false);
 });
 
 test('startup rejects asynchronous wrong or custom authority before ordinary services', () => {

--- a/desktop/test/unit/persistence/migration/legacy-hkust/legacy-flat-source-receipts.test.js
+++ b/desktop/test/unit/persistence/migration/legacy-hkust/legacy-flat-source-receipts.test.js
@@ -186,3 +186,33 @@ test('simulated Windows collection requires current-user-only ACL verification',
   assert.equal(receipts.settings.present, true);
   assert.deepEqual(verified, [paths.settings]);
 });
+
+test('Windows migration can tighten a current-user legacy ACL before hashing', (t) => {
+  const { userData, paths } = fixture(t);
+  writePrivate(paths.settings, 'settings');
+  let protectedFile = null;
+  let protectedState = false;
+  const receipts = collectLegacyFlatSourceReceipts({
+    userData,
+    platform: 'win32',
+    repairWindowsAcl: true,
+    windowsAcl: {
+      protect(file) { protectedFile = file; protectedState = true; return true; },
+      verify: () => protectedState,
+    },
+  });
+  assert.equal(protectedFile, paths.settings);
+  assert.equal(receipts.settings.present, true);
+  assert.equal(receipts.settings.sha256, sha256(Buffer.from('settings')));
+});
+
+test('Windows migration never proceeds when safe ACL tightening fails', (t) => {
+  const { userData, paths } = fixture(t);
+  writePrivate(paths.settings, 'settings');
+  assert.throws(() => collectLegacyFlatSourceReceipts({
+    userData,
+    platform: 'win32',
+    repairWindowsAcl: true,
+    windowsAcl: { protect: () => false, verify: () => false },
+  }), /Windows ACL/u);
+});

--- a/desktop/test/unit/persistence/migration/legacy-hkust/legacy-flat-source-receipts.test.js
+++ b/desktop/test/unit/persistence/migration/legacy-hkust/legacy-flat-source-receipts.test.js
@@ -10,6 +10,9 @@ const { createLegacyFlatSourcePaths } = require('../../../../../lib/persistence/
 const {
   collectLegacyFlatSourceReceipts,
 } = require('../../../../../lib/persistence/migration/legacy-hkust/legacy-flat-source-receipts');
+const {
+  protectWindowsFileOwnerOnly,
+} = require('../../../../../lib/platform/storage/windows-private-file');
 
 function fixture(t) {
   const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-legacy-receipts-'));
@@ -19,6 +22,9 @@ function fixture(t) {
 
 function writePrivate(file, value) {
   fs.writeFileSync(file, value, { mode: 0o600 });
+  if (process.platform === 'win32') {
+    assert.equal(protectWindowsFileOwnerOnly(file), true);
+  }
 }
 
 function sha256(value) {
@@ -197,7 +203,7 @@ test('Windows migration can tighten a current-user legacy ACL before hashing', (
     platform: 'win32',
     repairWindowsAcl: true,
     windowsAcl: {
-      protect(file) { protectedFile = file; protectedState = true; return true; },
+      tighten(file) { protectedFile = file; protectedState = true; return true; },
       verify: () => protectedState,
     },
   });
@@ -213,6 +219,6 @@ test('Windows migration never proceeds when safe ACL tightening fails', (t) => {
     userData,
     platform: 'win32',
     repairWindowsAcl: true,
-    windowsAcl: { protect: () => false, verify: () => false },
+    windowsAcl: { tighten: () => false, verify: () => false },
   }), /Windows ACL/u);
 });

--- a/desktop/test/unit/persistence/migration/legacy-hkust/profile-workspace-migration-runtime.test.js
+++ b/desktop/test/unit/persistence/migration/legacy-hkust/profile-workspace-migration-runtime.test.js
@@ -153,6 +153,7 @@ test('simulated Windows runtime protects destinations and verifies every private
   const verifiedFiles = [];
   const windowsAcl = {
     protect(file) { protectedFiles.push(file); return true; },
+    tighten(file) { protectedFiles.push(file); return true; },
     verify(file) { verifiedFiles.push(file); return fs.existsSync(file); },
   };
   const result = new ProfileWorkspaceMigrationRuntime({

--- a/desktop/test/unit/persistence/upgrades/profile-workspace-upgrade.test.js
+++ b/desktop/test/unit/persistence/upgrades/profile-workspace-upgrade.test.js
@@ -109,3 +109,21 @@ test('2.0 workspace upgrade keeps URLs favorites recents hidden sites and routin
     1700000002000);
   assert.deepEqual(loadRoutingRules(routingFile), fixture.routingRules.rules);
 });
+
+test('desktop package identities preserve in-place upgrades on every supported platform', () => {
+  assert.equal(packageDocument.build.appId, 'cn.edu.hkust-gz.connect');
+  assert.equal(packageDocument.build.productName, 'hkustgzconnect');
+  assert.deepEqual(packageDocument.build.nsis, {
+    oneClick: false,
+    allowToChangeInstallationDirectory: false,
+    perMachine: false,
+  });
+  assert.deepEqual(packageDocument.build.mac.target[0], {
+    target: 'dmg',
+    arch: ['arm64', 'x64'],
+  });
+  assert.deepEqual(packageDocument.build.linux.target[0], {
+    target: 'AppImage',
+    arch: ['x64'],
+  });
+});

--- a/desktop/test/unit/platform/storage/private-file.test.js
+++ b/desktop/test/unit/platform/storage/private-file.test.js
@@ -32,6 +32,26 @@ test('owner-only hardening never follows a symbolic link', (t) => {
   assert.equal(fs.statSync(target).mode & 0o777, before);
 });
 
+test('simulated Windows hardening upgrades a current-user file and fails closed otherwise', (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'hkustgz-private-windows-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const file = path.join(directory, 'settings.json');
+  fs.writeFileSync(file, '{}', { mode: 0o600 });
+  const calls = [];
+  assert.equal(ensureOwnerOnly(file, {
+    platform: 'win32',
+    windowsAcl: {
+      protect(value) { calls.push(['protect', value]); return true; },
+      verify(value) { calls.push(['verify', value]); return true; },
+    },
+  }), true);
+  assert.deepEqual(calls, [['protect', file], ['verify', file]]);
+  assert.equal(ensureOwnerOnly(file, {
+    platform: 'win32',
+    windowsAcl: { protect: () => false, verify: () => true },
+  }), false);
+});
+
 test('bounded private reads use one no-follow regular-file descriptor', (t) => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'hkustgz-private-read-'));
   t.after(() => fs.rmSync(directory, { recursive: true, force: true }));

--- a/desktop/test/unit/platform/storage/private-file.test.js
+++ b/desktop/test/unit/platform/storage/private-file.test.js
@@ -41,14 +41,14 @@ test('simulated Windows hardening upgrades a current-user file and fails closed 
   assert.equal(ensureOwnerOnly(file, {
     platform: 'win32',
     windowsAcl: {
-      protect(value) { calls.push(['protect', value]); return true; },
+      tighten(value) { calls.push(['tighten', value]); return true; },
       verify(value) { calls.push(['verify', value]); return true; },
     },
   }), true);
-  assert.deepEqual(calls, [['protect', file], ['verify', file]]);
+  assert.deepEqual(calls, [['tighten', file], ['verify', file]]);
   assert.equal(ensureOwnerOnly(file, {
     platform: 'win32',
-    windowsAcl: { protect: () => false, verify: () => true },
+    windowsAcl: { tighten: () => false, verify: () => true },
   }), false);
 });
 

--- a/desktop/test/unit/platform/storage/windows-private-file.test.js
+++ b/desktop/test/unit/platform/storage/windows-private-file.test.js
@@ -11,6 +11,7 @@ const {
   protectWindowsFileOwnerOnly,
   verifyWindowsFileOwnerOnly,
 } = require('../../../../lib/platform/storage/windows-private-file');
+const { ensureOwnerOnly } = require('../../../../lib/platform/storage/private-file');
 const { atomicWritePrivateFile } = require('../../../../lib/platform/storage/atomic-private-file');
 
 test('Windows ACL commands keep paths out of scripts and require fixed verification output', () => {
@@ -40,6 +41,13 @@ test('Windows ACL commands keep paths out of scripts and require fixed verificat
     assert.match(script, /\[System\.IO\.File\]::GetAccessControl\(\$privatePath\)/u);
     if (index === 0) {
       assert.match(script, /\[System\.IO\.File\]::SetAccessControl\(\$privatePath, \$acl\)/u);
+      assert.match(script, /existingOwnerSid -ne \$currentSid/u,
+        'ACL hardening must refuse a file owned by another SID');
+      assert.ok(
+        script.indexOf('existingOwnerSid -ne $currentSid') <
+          script.indexOf('[System.IO.File]::SetAccessControl'),
+        'ownership is checked before any ACL mutation',
+      );
     }
     assert.equal(call.options.env[PRIVATE_FILE_ENV], file);
     assert.equal(call.options.windowsHide, true);
@@ -69,6 +77,17 @@ test('real Windows ACL is current-user-only and inheritance-protected', {
   const file = path.join(directory, 'proxy-helper-credential.txt');
   fs.writeFileSync(file, 'synthetic-sidecar');
   assert.equal(protectWindowsFileOwnerOnly(file), true);
+  assert.equal(verifyWindowsFileOwnerOnly(file), true);
+});
+
+test('real Windows upgrade tightens an inherited current-user legacy file', {
+  skip: process.platform !== 'win32',
+}, (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'hkustgz-windows-legacy-acl-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const file = path.join(directory, 'settings.json');
+  fs.writeFileSync(file, '{"version":1}');
+  assert.equal(ensureOwnerOnly(file), true);
   assert.equal(verifyWindowsFileOwnerOnly(file), true);
 });
 

--- a/desktop/test/unit/platform/storage/windows-private-file.test.js
+++ b/desktop/test/unit/platform/storage/windows-private-file.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 const test = require('node:test');
 const {
   PRIVATE_FILE_ENV,
@@ -99,6 +100,25 @@ test('real Windows upgrade tightens an inherited current-user legacy file', {
   const file = path.join(directory, 'settings.json');
   fs.writeFileSync(file, '{"version":1}');
   assert.equal(protectWindowsFileOwnerOnly(file), true);
+  execFileSync('powershell.exe', ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', String.raw`
+$ErrorActionPreference = 'Stop'
+$privatePath = [Environment]::GetEnvironmentVariable('${PRIVATE_FILE_ENV}')
+$acl = [System.IO.File]::GetAccessControl($privatePath)
+$usersSid = New-Object Security.Principal.SecurityIdentifier('S-1-5-32-545')
+$rule = New-Object Security.AccessControl.FileSystemAccessRule(
+  $usersSid,
+  [Security.AccessControl.FileSystemRights]::Read,
+  [Security.AccessControl.AccessControlType]::Allow
+)
+$acl.AddAccessRule($rule)
+[System.IO.File]::SetAccessControl($privatePath, $acl)
+`], {
+    env: { ...process.env, [PRIVATE_FILE_ENV]: file },
+    timeout: POWERSHELL_ACL_TIMEOUT_MS,
+    windowsHide: true,
+  });
+  assert.equal(verifyWindowsFileOwnerOnly(file), false,
+    'the fixture must reproduce a broad legacy DACL');
   assert.equal(ensureOwnerOnly(file), true);
   assert.equal(verifyWindowsFileOwnerOnly(file), true);
 });

--- a/desktop/test/unit/platform/storage/windows-private-file.test.js
+++ b/desktop/test/unit/platform/storage/windows-private-file.test.js
@@ -9,6 +9,7 @@ const {
   PRIVATE_FILE_ENV,
   POWERSHELL_ACL_TIMEOUT_MS,
   protectWindowsFileOwnerOnly,
+  tightenWindowsFileOwnerOnly,
   verifyWindowsFileOwnerOnly,
 } = require('../../../../lib/platform/storage/windows-private-file');
 const { ensureOwnerOnly } = require('../../../../lib/platform/storage/private-file');
@@ -26,12 +27,17 @@ test('Windows ACL commands keep paths out of scripts and require fixed verificat
     environment: { SystemRoot: String.raw`C:\Windows` },
     platform: 'win32',
   }), true);
+  assert.equal(tightenWindowsFileOwnerOnly(file, {
+    execute,
+    environment: {},
+    platform: 'win32',
+  }), true);
   assert.equal(verifyWindowsFileOwnerOnly(file, {
     execute,
     environment: {},
     platform: 'win32',
   }), true);
-  assert.equal(calls.length, 2);
+  assert.equal(calls.length, 3);
   for (const [index, call] of calls.entries()) {
     assert.equal(call.command, 'powershell.exe');
     assert.equal(call.args.includes(file), false, 'the path is not interpolated into PowerShell');
@@ -39,8 +45,10 @@ test('Windows ACL commands keep paths out of scripts and require fixed verificat
     assert.doesNotMatch(script, /\b(?:Get|Set)-Acl\b/u,
       'the ACL boundary must not depend on an autoloadable PowerShell module');
     assert.match(script, /\[System\.IO\.File\]::GetAccessControl\(\$privatePath\)/u);
-    if (index === 0) {
+    if (index <= 1) {
       assert.match(script, /\[System\.IO\.File\]::SetAccessControl\(\$privatePath, \$acl\)/u);
+    }
+    if (index === 1) {
       assert.match(script, /existingOwnerSid -ne \$currentSid/u,
         'ACL hardening must refuse a file owned by another SID');
       assert.ok(
@@ -59,6 +67,9 @@ test('Windows ACL commands keep paths out of scripts and require fixed verificat
     execute: () => 'unexpected', platform: 'win32',
   }), false);
   assert.equal(protectWindowsFileOwnerOnly(file, {
+    execute: () => { throw new Error('synthetic failure'); }, platform: 'win32',
+  }), false);
+  assert.equal(tightenWindowsFileOwnerOnly(file, {
     execute: () => { throw new Error('synthetic failure'); }, platform: 'win32',
   }), false);
   assert.equal(protectWindowsFileOwnerOnly('relative.txt', { execute, platform: 'win32' }), false);
@@ -87,6 +98,7 @@ test('real Windows upgrade tightens an inherited current-user legacy file', {
   t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
   const file = path.join(directory, 'settings.json');
   fs.writeFileSync(file, '{"version":1}');
+  assert.equal(protectWindowsFileOwnerOnly(file), true);
   assert.equal(ensureOwnerOnly(file), true);
   assert.equal(verifyWindowsFileOwnerOnly(file), true);
 });

--- a/desktop/test/unit/profiles/profile-candidate-directory.test.js
+++ b/desktop/test/unit/profiles/profile-candidate-directory.test.js
@@ -242,6 +242,8 @@ test('reviewed anchor and custom index form one restart-safe candidate directory
   candidates.withCandidate(custom.profileId, (record) => {
     assert.equal(record.kind, 'custom-local');
     assert.deepEqual(record.context, custom.context);
+    assert.deepEqual(record.builtInResources, []);
+    assert.equal(record.serviceDesk, null);
     assert.equal(JSON.parse(record.engineLaunchBinding.stdinFrame).profileId, custom.profileId);
   });
 
@@ -252,6 +254,9 @@ test('reviewed anchor and custom index form one restart-safe candidate directory
   });
   assert.equal(customController.browserHomeUrl, null);
   assert.deepEqual(customController.defaultRouteDomains, []);
+  assert.deepEqual(customController.mergeResourceLibrary(), []);
+  assert.equal(customController.serviceDesk, null);
+  assert.equal(customController.builtInResourceCount, 0);
   assert.equal(customController.browserPartition.startsWith('persist:campus-workspace-'), true);
   assert.equal(customController.activeContextBinding().activeContextEpoch, 1);
   assert.equal(JSON.parse(customController.verifyEngineLaunchBinding().stdinFrame).profileId,

--- a/docs/adr/0017-p3-production-migration-runtime.md
+++ b/docs/adr/0017-p3-production-migration-runtime.md
@@ -1,7 +1,10 @@
 # ADR-0017: P3 production migration runtime composition
 
-- Status: Accepted as a non-activating P3k composition
-- Production Main activation: deferred to the next gate
+- Status: Accepted
+- Owner: Desktop maintainers
+- Last verified: 2026-09-04
+- Applies to: `desktop/lib/persistence/migration/legacy-hkust/` and the 2.0 upgrade path
+- Production Main activation: released in 2.0.0
 - Parent contracts: [`ADR-0010`](0010-p3-destination-and-retirement.md),
   [`ADR-0030`](0030-p3-runtime-storage-path-seam.md)
 
@@ -42,6 +45,13 @@ A committed journal makes partial source retirement restart-safe. A second run r
 already migrated. Orphaned legacy files without `settings.json`, dual authority, changed receipts, invalid
 credentials or incomplete destination state block rather than choosing an authority.
 
+Windows uses two deliberately different ACL operations. Newly created private files may assign ownership to the
+current SID before applying one protected FullControl rule. A legacy migration source may only be tightened when
+the current SID already owns the exact regular single-link file; migration never takes ownership of a foreign
+source. After tightening, the runtime re-identifies the file and only then hashes it into the migration receipt.
+This admits 1.x files that merely inherited broader Windows rules without weakening the link, size, identity or
+receipt checks.
+
 An empty first launch remains in legacy-compatible mode for this gate because direct initialization of a new P3
 Account has not yet been connected to the login flow. The next activation gate must either initialize an empty P3
 Account or migrate immediately after first credential commit; it may not leave two writable authorities.
@@ -54,11 +64,12 @@ Gateway object back into a raw-document validator.
 
 Tests cover real flat-file migration with and without credentials, envelope decrypt round-trip, payload and
 credential zeroization/redaction, changed/unexpected/symlink source rejection, empty first launch, orphaned legacy
-authority, interrupted source retirement recovery and simulated Windows source/destination ACL enforcement.
+authority, interrupted source retirement recovery, simulated Windows source/destination ACL enforcement, and a
+real Windows current-owner file whose deliberately broadened DACL is tightened before use.
 
-## Next gate
+## Release maintenance
 
-P3l must run this composition only after Electron safeStorage is ready and before constructing any path-bound
-service. It must reconcile settings and credential redo intents, choose one immutable runtime mode, create every
-service from that mode and prevent Engine/Browser/UI startup on ambiguous recovery. Packaged migration/restart
-tests are required before replacing the installed App.
+Main runs this composition only after Electron safeStorage is ready and before constructing any path-bound
+service. It reconciles settings and credential redo intents, chooses one immutable runtime mode, creates every
+service from that mode and prevents Engine/Browser/UI startup on ambiguous recovery. Packaged migration/restart
+tests remain required before replacing an installed App.


### PR DESCRIPTION
## Outcome

Fixes #74.

- Always lists the reviewed packaged HKUST(GZ) profile on a fresh/legacy first run, before Profile Workspace anchoring exists.
- Safely tightens current-user-owned legacy Windows files to the required current-user-only DACL before migration receipts are collected. Foreign ownership, links, multiple links, content drift, and oversize inputs remain fail-closed.
- Keeps other-school/custom profiles free of HKUST built-in sites, service desk, routes, and browser home; regression tests freeze this boundary.
- Restores Windows in-place upgrade behavior by disabling install-directory changes while keeping the stable `appId`, per-user install, and user data.
- Expands the real Windows CI gate and documents macOS/Windows/Linux replacement behavior.

## Local evidence

- `npm test`: 1231 total, 1226 passed, 5 Windows-only skipped on macOS, 0 failed.
- `npm run test:windows`: 22 total, 17 passed, 5 Windows-only skipped on macOS, 0 failed.
- `npm run test:persistence-migration`: passed.
- `npm run test:main-school-onboarding`: passed.
- architecture, governance, secret, install-script, syntax, and release-asset gates: passed.

## Required remote evidence

The Windows runner must execute the real inherited-file DACL upgrade test. The three-platform package verifier must prove the packaged HKUST manifest and native files on macOS, Windows, and Linux before merge.