### PR TITLE
feat: bind update discovery to repository identity

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -2,7 +2,7 @@
 
 - Status: Active
 - Authority: project maintainer
-- Baseline: `main@415a3b5dfb9d11bffa14cde27e924af486823249`
+- Baseline: `main@15738338ff2a280300b66e98a1823659f24630a4`
 - Started: 2026-09-04
 - Scope: repository governance, documentation truth, agent instructions, module boundaries,
   contributor workflow, GitHub protections and organization migration
@@ -32,16 +32,16 @@ high-risk rules. No instruction file is treated as a substitute for review or te
 
 ## Current findings
 
-1. Runtime architecture and CI are mature, but the repository has no contributor or agent
-   operating contract.
+1. PR #59 established the contributor, agent, documentation and machine-governance baseline on
+   `main`; runtime modularization must now consume those boundaries rather than create alternatives.
 2. `desktop/main.js`, `desktop/lib/browser/session/campus-browser.js`, the Renderer bootstrap/CSS,
    and `independent/src/bin/ec-engine.rs` are concurrency hot spots.
 3. Renderer feature files still depend on global `window.*` names and HTML script order that the
    CommonJS architecture graph cannot see.
-4. Current-state, product, roadmap, ADR-index and release documents contain pre-release or
-   worktree-era statements that conflict with the published 2.0.0 release.
-5. The GitHub repository has one administrator, no CODEOWNERS, no Rulesets, no Dependabot alerts,
-   no contribution templates and no protected release-tag policy.
+4. The immutable `v2.0.0` tag exists, but no stable GitHub Release is published for it and
+   `/releases/latest` still resolves to `v1.2.3`; Issue #76 owns the 2.0.1 repair release.
+5. Repository Rulesets, CODEOWNERS, templates, Dependabot, release Environment and immutable Action
+   policies are active, but one administrator and no independent reviewer prevent full enforcement.
 6. The `heeh02` account currently has no GitHub Organization membership. Repository transfer is
    blocked until the maintainer chooses or creates the destination organization.
 
@@ -129,13 +129,13 @@ The goal is complete only when:
 
 ## Progress receipt — 2026-09-04
 
-- G0 implemented on `codex/open-source-governance`, pending PR/CI: current release truth is aligned;
-  obsolete tool-specific documents and completed product proposals are removed; original 2.0 vision
-  documents are classified under `docs/archive/`.
-- G1 implemented on the governance branch, pending PR/CI: six-level agent instructions,
-  contribution/security/conduct policies, CODEOWNERS, templates and AI provenance are present.
-- G2 partially implemented: module inventory, repository-governance/link/Action-pin checks and CI
-  wiring are present; enforcing target module dependency/public-entrypoint rules belongs to M1–M4.
+- G0 merged through PR #59: current release truth is aligned; obsolete tool-specific documents and
+  completed product proposals are removed; original 2.0 vision documents are classified under
+  `docs/archive/`.
+- G1 merged through PR #59: six-level agent instructions, contribution/security/conduct policies,
+  CODEOWNERS, templates and AI provenance are present.
+- G2 baseline merged through PR #59: module inventory, repository-governance/link/Action-pin checks
+  and CI wiring are present; target module dependency/public-entrypoint enforcement belongs to M1–M4.
 - G3 planned but intentionally not mixed into this governance PR. Runtime modularization begins only
   after the governance baseline merges.
 - G4 partially activated on the current personal repository: squash-only, branch auto-delete,
@@ -144,6 +144,11 @@ The goal is complete only when:
 - Organization transfer, team CODEOWNERS, release-tag creation restriction, protected release
   reviewers and administrator enforcement remain blocked on the destination Organization login and
   a second trusted reviewer.
+- Windows/Profile upgrade repair merged through PR #75. Issue #76 records that the missing stable
+  2.0 channel must be repaired with a verified 2.0.1 rather than republishing the known-buggy 2.0.0
+  Windows artifact.
+- PR #78 provides the repository-ID-based 2.0.1 transition patch so update discovery remains bound
+  to the same public, enabled repository across owner transfer without trusting arbitrary redirects.
 
 ## Current external blocker
 

--- a/RELEASE_NOTES_2.0.1.md
+++ b/RELEASE_NOTES_2.0.1.md
@@ -1,0 +1,43 @@
+# HKUST(GZ) Connect 2.0.1
+
+HKUST(GZ) Connect 2.0.1 is a repository-ownership migration bridge. It preserves the 2.0.0
+connection, Campus Browser, myPortal, MFA and workspace behavior while making future update checks
+survive a GitHub Organization transfer.
+
+## 主要更新
+
+- 更新检查不再把可变的 GitHub `owner/repository` 当作仓库身份。
+- 客户端先查询 HKUST-GZ-Connect 不变的 GitHub repository ID，再严格验证仓库 ID、名称、
+  当前 owner、API URL、Web URL 和 Release 模板。
+- 仓库转入 Organization 后，客户端可自动发现新 owner 的正式 Release 页面，无需放宽到
+  任意 GitHub 仓库或任意外部链接。
+- ID、仓库名、owner、主机、路径或 Release URL 不匹配时继续 fail-closed。
+- 本补丁不修改校园网关协议、凭据/MFA 处理、路由、DNS、SOCKS、用户数据结构或 GUI。
+
+## 安全与兼容性
+
+- 固定 repository ID 为 GitHub 当前公开记录的 `1279507615`；仓库转移不改变该身份。
+- 只接受 GitHub API 返回且与该 ID 完整一致的当前 owner 和 Release 前缀。
+- 更新功能仍然只提示并打开 Release 页面，不静默下载、安装或执行文件。
+- 升级保留设置、收藏、校园浏览器数据和已安全保存的凭据。
+
+## 安装与签名说明
+
+- macOS DMG 使用包体校验和 ad-hoc 签名，尚未 Developer ID 公证；首次启动可能需要在
+  Finder 中右键应用并选择“打开”。
+- Windows 安装器尚未配置 Authenticode 发布者证书，SmartScreen 可能提示未知发布者。
+- GitHub Release 为每个附件公布 SHA-256 摘要，可在安装前核对完整性。
+
+## Downloads
+
+- macOS Apple Silicon: `hkustgzconnect-2.0.1-mac-arm64.dmg`
+- macOS Intel: `hkustgzconnect-2.0.1-mac-x64.dmg`
+- Windows x64: `hkustgzconnect-2.0.1-win-x64.exe`
+- Linux x86_64: `hkustgzconnect-2.0.1-linux-x86_64.AppImage`
+
+## English summary
+
+Version 2.0.1 resolves the repository's current owner through its immutable GitHub repository ID,
+validates the complete canonical API and web identity, and accepts only that repository's Release
+pages. This lets update checks survive an ownership transfer without trusting arbitrary redirects or
+repositories. Runtime networking, MFA, routing, persistence and GUI behavior are unchanged.

--- a/desktop/lib/platform/update/update-check.js
+++ b/desktop/lib/platform/update/update-check.js
@@ -8,9 +8,9 @@
 // never surface as an error in the main loop.
 const https = require('https');
 
-const RELEASES_API_URL = 'https://api.github.com/repos/heeh02/HKUST-GZ-Connect/releases/latest';
-const PRERELEASES_API_URL = 'https://api.github.com/repos/heeh02/HKUST-GZ-Connect/releases?per_page=30';
-const RELEASES_URL_PREFIX = 'https://github.com/heeh02/HKUST-GZ-Connect/releases';
+const REPOSITORY_ID = 1279507615;
+const REPOSITORY_NAME = 'HKUST-GZ-Connect';
+const REPOSITORY_API_URL = `https://api.github.com/repositories/${REPOSITORY_ID}`;
 const AUTO_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const REQUEST_TIMEOUT_MS = 8000;
 const MAX_BODY_BYTES = 1024 * 1024;
@@ -18,9 +18,31 @@ const USER_AGENT = 'hkustgzconnect-update-check';
 
 // shell.openExternal targets from the renderer are confined to this prefix so
 // a compromised or buggy page cannot hand the OS an arbitrary URL.
-function isAllowedReleaseUrl(url) {
+function isAllowedReleaseUrl(url, releasesUrlPrefix) {
   return typeof url === 'string'
-    && (url === RELEASES_URL_PREFIX || url.startsWith(`${RELEASES_URL_PREFIX}/`));
+    && typeof releasesUrlPrefix === 'string'
+    && (url === releasesUrlPrefix || url.startsWith(`${releasesUrlPrefix}/`));
+}
+
+function repositoryReleaseEndpoints(repository) {
+  if (!repository || repository.id !== REPOSITORY_ID || repository.name !== REPOSITORY_NAME ||
+      typeof repository.owner?.login !== 'string' ||
+      !/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$/u.test(repository.owner.login)) return null;
+
+  const owner = repository.owner.login;
+  const canonicalApi = `https://api.github.com/repos/${owner}/${REPOSITORY_NAME}`;
+  const canonicalWeb = `https://github.com/${owner}/${REPOSITORY_NAME}`;
+  if (repository.full_name !== `${owner}/${REPOSITORY_NAME}` ||
+      repository.private !== false || repository.visibility !== 'public' ||
+      repository.archived !== false || repository.disabled !== false ||
+      repository.url !== canonicalApi || repository.html_url !== canonicalWeb ||
+      repository.releases_url !== `${canonicalApi}/releases{/id}`) return null;
+
+  return Object.freeze({
+    latestApiUrl: `${canonicalApi}/releases/latest`,
+    prereleasesApiUrl: `${canonicalApi}/releases?per_page=30`,
+    releasesUrlPrefix: `${canonicalWeb}/releases`,
+  });
 }
 
 function parseVersion(version) {
@@ -104,13 +126,13 @@ function releaseVersion(release) {
   return parseVersion(version) ? version : null;
 }
 
-function selectPrereleaseUpdate(releases, currentVersion) {
+function selectPrereleaseUpdate(releases, currentVersion, releasesUrlPrefix) {
   if (!Array.isArray(releases)) return null;
   const eligible = releases
     .map((release) => ({ release, version: releaseVersion(release) }))
     .filter(({ version }) => version && isUpdateCandidate(version, currentVersion));
   if (eligible.length === 0) {
-    return { updateAvailable: false, latestVersion: currentVersion, url: RELEASES_URL_PREFIX };
+    return { updateAvailable: false, latestVersion: currentVersion, url: releasesUrlPrefix };
   }
 
   // A stable release wins over a Beta once it is eligible. Otherwise choose
@@ -125,8 +147,8 @@ function selectPrereleaseUpdate(releases, currentVersion) {
   return {
     updateAvailable: true,
     latestVersion: selected.version,
-    url: isAllowedReleaseUrl(selected.release.html_url)
-      ? selected.release.html_url : RELEASES_URL_PREFIX,
+    url: isAllowedReleaseUrl(selected.release.html_url, releasesUrlPrefix)
+      ? selected.release.html_url : releasesUrlPrefix,
   };
 }
 
@@ -164,11 +186,17 @@ async function checkForUpdate(currentVersion, fetchJson = defaultFetchJson) {
   try {
     const current = parseVersion(currentVersion);
     if (!current) return null;
+    const endpoints = repositoryReleaseEndpoints(await fetchJson(REPOSITORY_API_URL));
+    if (!endpoints) return null;
     if (current.prerelease.length > 0) {
-      return selectPrereleaseUpdate(await fetchJson(PRERELEASES_API_URL), current.normalized);
+      return selectPrereleaseUpdate(
+        await fetchJson(endpoints.prereleasesApiUrl),
+        current.normalized,
+        endpoints.releasesUrlPrefix,
+      );
     }
 
-    const release = await fetchJson(RELEASES_API_URL);
+    const release = await fetchJson(endpoints.latestApiUrl);
     if (!release || typeof release.tag_name !== 'string') return null;
     const latestVersion = release.tag_name.trim().replace(/^v/i, '');
     const comparison = compareVersions(latestVersion, currentVersion);
@@ -176,7 +204,8 @@ async function checkForUpdate(currentVersion, fetchJson = defaultFetchJson) {
     return {
       updateAvailable: comparison > 0,
       latestVersion,
-      url: isAllowedReleaseUrl(release.html_url) ? release.html_url : RELEASES_URL_PREFIX,
+      url: isAllowedReleaseUrl(release.html_url, endpoints.releasesUrlPrefix)
+        ? release.html_url : endpoints.releasesUrlPrefix,
     };
   } catch {
     return null;
@@ -194,13 +223,14 @@ function shouldAutoCheck(lastCheckedAt, now = Date.now(), intervalMs = AUTO_CHEC
 
 module.exports = {
   AUTO_CHECK_INTERVAL_MS,
-  PRERELEASES_API_URL,
-  RELEASES_API_URL,
-  RELEASES_URL_PREFIX,
+  REPOSITORY_API_URL,
+  REPOSITORY_ID,
+  REPOSITORY_NAME,
   REQUEST_TIMEOUT_MS,
   checkForUpdate,
   compareVersions,
   isBetaFinalPromotion,
   isAllowedReleaseUrl,
+  repositoryReleaseEndpoints,
   shouldAutoCheck,
 };

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hkustgzconnect",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hkustgzconnect",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "@electron/asar": "^3.4.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hkustgzconnect",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "HKUST(GZ) EasyConnect-compatible client with an independent Rust engine",
   "main": "main.js",
   "author": "heeh02",

--- a/desktop/test/unit/platform/update/update-check.test.js
+++ b/desktop/test/unit/platform/update/update-check.test.js
@@ -4,15 +4,46 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 const {
   AUTO_CHECK_INTERVAL_MS,
-  PRERELEASES_API_URL,
-  RELEASES_API_URL,
-  RELEASES_URL_PREFIX,
+  REPOSITORY_API_URL,
+  REPOSITORY_ID,
+  REPOSITORY_NAME,
   checkForUpdate,
   compareVersions,
   isBetaFinalPromotion,
   isAllowedReleaseUrl,
+  repositoryReleaseEndpoints,
   shouldAutoCheck,
 } = require('../../../../lib/platform/update/update-check');
+
+const INITIAL_OWNER = 'heeh02';
+const INITIAL_API = `https://api.github.com/repos/${INITIAL_OWNER}/${REPOSITORY_NAME}`;
+const RELEASES_API_URL = `${INITIAL_API}/releases/latest`;
+const PRERELEASES_API_URL = `${INITIAL_API}/releases?per_page=30`;
+const RELEASES_URL_PREFIX = `https://github.com/${INITIAL_OWNER}/${REPOSITORY_NAME}/releases`;
+
+function repositoryMetadata(owner = INITIAL_OWNER) {
+  const api = `https://api.github.com/repos/${owner}/${REPOSITORY_NAME}`;
+  const web = `https://github.com/${owner}/${REPOSITORY_NAME}`;
+  return {
+    id: REPOSITORY_ID,
+    name: REPOSITORY_NAME,
+    full_name: `${owner}/${REPOSITORY_NAME}`,
+    owner: { login: owner },
+    url: api,
+    html_url: web,
+    releases_url: `${api}/releases{/id}`,
+    private: false,
+    visibility: 'public',
+    archived: false,
+    disabled: false,
+  };
+}
+
+function repositoryFetcher(releaseValue, owner = INITIAL_OWNER) {
+  return async (url) => url === REPOSITORY_API_URL
+    ? repositoryMetadata(owner)
+    : releaseValue;
+}
 
 test('compareVersions orders plain numeric versions', () => {
   assert.equal(compareVersions('1.0.7', '1.0.7'), 0);
@@ -58,7 +89,7 @@ test('checkForUpdate reports a newer release with its allowlisted page', async (
     tag_name: 'v1.1.0',
     html_url: `${RELEASES_URL_PREFIX}/tag/v1.1.0`,
   };
-  const result = await checkForUpdate('1.0.7', async () => release);
+  const result = await checkForUpdate('1.0.7', repositoryFetcher(release));
   assert.deepEqual(result, {
     updateAvailable: true,
     latestVersion: '1.1.0',
@@ -66,27 +97,29 @@ test('checkForUpdate reports a newer release with its allowlisted page', async (
   });
 });
 
-test('checkForUpdate passes the releases API URL to the fetcher', async () => {
-  let requested = null;
+test('checkForUpdate resolves the canonical release API through the immutable repository ID', async () => {
+  const requested = [];
   await checkForUpdate('1.0.7', async (url) => {
-    requested = url;
+    requested.push(url);
+    if (url === REPOSITORY_API_URL) return repositoryMetadata();
     return { tag_name: 'v1.0.7' };
   });
-  assert.equal(requested, RELEASES_API_URL);
+  assert.deepEqual(requested, [REPOSITORY_API_URL, RELEASES_API_URL]);
 });
 
 test('prerelease builds query the release list and discover a newer Beta', async () => {
-  let requested = null;
+  const requested = [];
   const release = {
     tag_name: 'v2.0.1-beta.2',
     prerelease: true,
     html_url: `${RELEASES_URL_PREFIX}/tag/v2.0.1-beta.2`,
   };
   const result = await checkForUpdate('2.0.0-beta.1', async (url) => {
-    requested = url;
+    requested.push(url);
+    if (url === REPOSITORY_API_URL) return repositoryMetadata();
     return [{ tag_name: 'v1.2.3', prerelease: false }, release];
   });
-  assert.equal(requested, PRERELEASES_API_URL);
+  assert.deepEqual(requested, [REPOSITORY_API_URL, PRERELEASES_API_URL]);
   assert.deepEqual(result, {
     updateAvailable: true,
     latestVersion: '2.0.1-beta.2',
@@ -100,10 +133,10 @@ test('the evidence-gated final supersedes a numerically higher maintenance Beta'
     prerelease: false,
     html_url: `${RELEASES_URL_PREFIX}/tag/v2.0.0`,
   };
-  const result = await checkForUpdate('2.0.1-beta.7', async () => [
+  const result = await checkForUpdate('2.0.1-beta.7', repositoryFetcher([
     { tag_name: 'v2.0.1-beta.8', prerelease: true },
     release,
-  ]);
+  ]));
   assert.deepEqual(result, {
     updateAvailable: true,
     latestVersion: '2.0.0',
@@ -112,11 +145,11 @@ test('the evidence-gated final supersedes a numerically higher maintenance Beta'
 });
 
 test('prerelease selection ignores drafts and older stable releases', async () => {
-  const result = await checkForUpdate('2.0.0-beta.3', async () => [
+  const result = await checkForUpdate('2.0.0-beta.3', repositoryFetcher([
     { tag_name: 'v2.0.0-beta.4', prerelease: true, draft: true },
     { tag_name: 'v1.2.3', prerelease: false },
     { tag_name: 'not-a-version', prerelease: true },
-  ]);
+  ]));
   assert.deepEqual(result, {
     updateAvailable: false,
     latestVersion: '2.0.0-beta.3',
@@ -126,7 +159,7 @@ test('prerelease selection ignores drafts and older stable releases', async () =
 
 test('checkForUpdate treats same or older tags as no update', async () => {
   for (const tag of ['v1.0.7', '1.0.7', 'v1.0.6', 'v0.9.9']) {
-    const result = await checkForUpdate('1.0.7', async () => ({ tag_name: tag }));
+    const result = await checkForUpdate('1.0.7', repositoryFetcher({ tag_name: tag }));
     assert.equal(result.updateAvailable, false, tag);
     assert.equal(result.latestVersion, tag.replace(/^v/, ''));
     assert.equal(result.url, RELEASES_URL_PREFIX);
@@ -134,7 +167,7 @@ test('checkForUpdate treats same or older tags as no update', async () => {
 });
 
 test('checkForUpdate replaces off-allowlist release URLs with the releases index', async () => {
-  const result = await checkForUpdate('1.0.7', async () => ({
+  const result = await checkForUpdate('1.0.7', repositoryFetcher({
     tag_name: 'v2.0.0',
     html_url: 'https://evil.example.com/releases/tag/v2.0.0',
   }));
@@ -144,24 +177,74 @@ test('checkForUpdate replaces off-allowlist release URLs with the releases index
 
 test('checkForUpdate collapses every failure mode to null', async () => {
   assert.equal(await checkForUpdate('1.0.7', async () => { throw new Error('offline'); }), null);
-  assert.equal(await checkForUpdate('1.0.7', async () => null), null);
-  assert.equal(await checkForUpdate('1.0.7', async () => ({})), null);
-  assert.equal(await checkForUpdate('1.0.7', async () => ({ tag_name: 42 })), null);
-  assert.equal(await checkForUpdate('1.0.7', async () => ({ tag_name: 'not-a-version' })), null);
+  assert.equal(await checkForUpdate('1.0.7', repositoryFetcher(null)), null);
+  assert.equal(await checkForUpdate('1.0.7', repositoryFetcher({})), null);
+  assert.equal(await checkForUpdate('1.0.7', repositoryFetcher({ tag_name: 42 })), null);
+  assert.equal(await checkForUpdate('1.0.7', repositoryFetcher({ tag_name: 'not-a-version' })), null);
   assert.equal(await checkForUpdate('not-a-version', async () => ({ tag_name: 'v1.0.8' })), null);
 });
 
+test('repository identity accepts an Organization transfer without trusting a different repository', () => {
+  const transferred = repositoryReleaseEndpoints(repositoryMetadata('hkust-connect'));
+  assert.deepEqual(transferred, {
+    latestApiUrl: `https://api.github.com/repos/hkust-connect/${REPOSITORY_NAME}/releases/latest`,
+    prereleasesApiUrl: `https://api.github.com/repos/hkust-connect/${REPOSITORY_NAME}/releases?per_page=30`,
+    releasesUrlPrefix: `https://github.com/hkust-connect/${REPOSITORY_NAME}/releases`,
+  });
+
+  for (const tampered of [
+    { ...repositoryMetadata(), id: REPOSITORY_ID + 1 },
+    { ...repositoryMetadata(), name: 'lookalike' },
+    { ...repositoryMetadata(), full_name: 'evil/lookalike' },
+    { ...repositoryMetadata(), html_url: 'https://evil.example.com/repository' },
+    { ...repositoryMetadata(), url: 'https://api.github.com/repos/evil/lookalike' },
+    { ...repositoryMetadata(), releases_url: 'https://api.github.com/repos/evil/lookalike/releases{/id}' },
+    { ...repositoryMetadata(), owner: { login: 'bad/name' } },
+    { ...repositoryMetadata(), private: true },
+    { ...repositoryMetadata(), visibility: 'private' },
+    { ...repositoryMetadata(), archived: true },
+    { ...repositoryMetadata(), disabled: true },
+  ]) assert.equal(repositoryReleaseEndpoints(tampered), null);
+});
+
+test('checkForUpdate accepts only the release page for the repository ID current owner', async () => {
+  const owner = 'hkust-connect';
+  const prefix = `https://github.com/${owner}/${REPOSITORY_NAME}/releases`;
+  const result = await checkForUpdate('2.0.0', repositoryFetcher({
+    tag_name: 'v2.0.1',
+    html_url: `${prefix}/tag/v2.0.1`,
+  }, owner));
+  assert.deepEqual(result, {
+    updateAvailable: true,
+    latestVersion: '2.0.1',
+    url: `${prefix}/tag/v2.0.1`,
+  });
+});
+
 test('isAllowedReleaseUrl only trusts the GitHub releases prefix', () => {
-  assert.equal(isAllowedReleaseUrl(RELEASES_URL_PREFIX), true);
-  assert.equal(isAllowedReleaseUrl(`${RELEASES_URL_PREFIX}/tag/v1.0.8`), true);
-  assert.equal(isAllowedReleaseUrl(`http://github.com/heeh02/HKUST-GZ-Connect/releases/tag/v1`), false);
-  assert.equal(isAllowedReleaseUrl('https://github.com/heeh02/HKUST-GZ-Connect/releases.evil.com/x'), false);
-  assert.equal(isAllowedReleaseUrl('https://github.com/heeh02/HKUST-GZ-Connect/issues/1'), false);
-  assert.equal(isAllowedReleaseUrl('https://example.com'), false);
-  assert.equal(isAllowedReleaseUrl('file:///etc/passwd'), false);
-  assert.equal(isAllowedReleaseUrl(''), false);
-  assert.equal(isAllowedReleaseUrl(null), false);
-  assert.equal(isAllowedReleaseUrl(undefined), false);
+  assert.equal(isAllowedReleaseUrl(RELEASES_URL_PREFIX, RELEASES_URL_PREFIX), true);
+  assert.equal(isAllowedReleaseUrl(
+    `${RELEASES_URL_PREFIX}/tag/v1.0.8`, RELEASES_URL_PREFIX,
+  ), true);
+  assert.equal(isAllowedReleaseUrl(
+    `http://github.com/heeh02/HKUST-GZ-Connect/releases/tag/v1`, RELEASES_URL_PREFIX,
+  ), false);
+  assert.equal(isAllowedReleaseUrl(
+    'https://github.com/heeh02/HKUST-GZ-Connect/releases.evil.com/x', RELEASES_URL_PREFIX,
+  ), false);
+  assert.equal(isAllowedReleaseUrl(
+    'https://github.com/heeh02/HKUST-GZ-Connect/issues/1', RELEASES_URL_PREFIX,
+  ), false);
+  assert.equal(isAllowedReleaseUrl('https://example.com', RELEASES_URL_PREFIX), false);
+  assert.equal(isAllowedReleaseUrl('file:///etc/passwd', RELEASES_URL_PREFIX), false);
+  assert.equal(isAllowedReleaseUrl('', RELEASES_URL_PREFIX), false);
+  assert.equal(isAllowedReleaseUrl(null, RELEASES_URL_PREFIX), false);
+  assert.equal(isAllowedReleaseUrl(undefined, RELEASES_URL_PREFIX), false);
+  assert.equal(isAllowedReleaseUrl(RELEASES_URL_PREFIX), false,
+    'there is no mutable-owner production default');
+  const transferredPrefix = `https://github.com/hkust-connect/${REPOSITORY_NAME}/releases`;
+  assert.equal(isAllowedReleaseUrl(`${transferredPrefix}/tag/v2.0.1`, transferredPrefix), true);
+  assert.equal(isAllowedReleaseUrl(`${RELEASES_URL_PREFIX}/tag/v2.0.1`, transferredPrefix), false);
 });
 
 test('automatic checks are throttled to one per interval', () => {

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,5 +72,6 @@ durable contract. Release receipts may use exact tags, commits, workflow runs an
 - Main protection: `governance/main-branch-protection.md`
 - Current governance activation: `governance/2026-09-04-governance-activation.md`
 - Machine-readable GitHub settings: `governance/repository-governance-contract.json`
+- Organization transfer procedure: `governance/repository-transfer-playbook.md`
 - Data classification: `security/data-classification.md`
 - ADR index: `adr/README.md`

--- a/docs/adr/0032-repository-id-update-discovery.md
+++ b/docs/adr/0032-repository-id-update-discovery.md
@@ -1,0 +1,59 @@
+# ADR-0032: Repository-ID-bound update discovery
+
+- Status: Accepted for the 2.0.1 ownership-transfer bridge
+- Owner: Security and Release maintainers
+- Last verified: 2026-09-04
+- Applies to: `desktop/lib/platform/update/update-check.js`
+- Parent procedure: [`../governance/repository-transfer-playbook.md`](../governance/repository-transfer-playbook.md)
+
+## Context
+
+The 2.0.0 client discovers updates through a GitHub API URL containing the personal repository
+owner. GitHub preserves a repository's numeric ID across an ownership transfer, but the canonical
+owner/name URL changes. Node's basic HTTPS request does not make an old-owner redirect a durable
+trust or availability contract. Transferring before a bridge release could therefore strand the
+installed 2.0.0 update channel.
+
+Following arbitrary redirects or accepting any repository returned by GitHub would solve
+availability by weakening the release trust boundary. The client must discover the new owner while
+remaining bound to the same public repository.
+
+## Decision
+
+Update discovery has exactly two network stages:
+
+```text
+GET https://api.github.com/repositories/1279507615
+  -> validate immutable ID, fixed name, owner login, full name,
+     public/enabled/unarchived state, canonical API/Web URLs and Release template
+  -> construct the current repository's latest/list Release endpoints
+  -> fetch the applicable Release document
+  -> accept only a page beneath that exact canonical Release prefix
+```
+
+The production trust root contains the immutable numeric repository ID and the non-renamed
+repository name. It contains no default personal-owner Release endpoint. The owner returned by the
+ID lookup is data only after the complete metadata tuple matches; it is not accepted from a
+redirect, Release document or renderer input.
+
+Every timeout, non-200 response, malformed body, identity mismatch, private/archived/disabled
+repository, invalid version or off-prefix Release URL returns the existing unavailable result. The
+application continues to notify and open a page only; it does not download, install or execute an
+update.
+
+## Consequences
+
+- A transfer with unchanged repository ID and name keeps update discovery working.
+- Renaming, replacing, privatizing, archiving or disabling the repository intentionally disables
+  update notices until maintainers make another reviewed trust decision.
+- The bridge release must be published before transfer; a client with the old owner-bound code
+  cannot benefit from this decision after it loses its endpoint.
+- Repository links in documentation may be updated after transfer, but production update trust must
+  remain ID-bound.
+
+## Verification
+
+Unit tests cover the current owner, a synthetic Organization owner, every identity field mismatch,
+off-prefix pages, stable/prerelease ordering, network failure and the absence of an owner-based
+default. Release verification must additionally query the live numeric-ID endpoint from the exact
+tagged build before transfer and again after transfer.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,7 @@ records for review and recovery evidence; future procedural notes belong under `
 | 0023-0029 | Custom Profile provisioning, startup and switch | Accepted | Implementation records | P6 |
 | 0030 | P3 runtime storage path seam | Accepted | Implementation record; renumbered from duplicate 0016 | P3 |
 | 0031 | P8 WebResource library and on-demand Campus boundary | Accepted | Product/security decision | Released in 2.0.0 |
+| 0032 | Repository-ID-bound update discovery | Accepted | Security/ownership decision | 2.0.1 transfer bridge |
 
 No ADR type, fixture or design text promotes an unsupported provider. Current capability truth remains the
 intersection of compiled providers, active Profile policy and runtime evidence.

--- a/docs/governance/repository-transfer-playbook.md
+++ b/docs/governance/repository-transfer-playbook.md
@@ -1,0 +1,78 @@
+# GitHub Organization transfer playbook
+
+- Status: Current migration procedure
+- Owner: Security and Release maintainers
+- Last verified: 2026-09-04
+- Applies to: transfer from `heeh02/HKUST-GZ-Connect` to a maintainer-selected Organization
+
+## Why a bridge release is required
+
+The 2.0.0 update checker addresses the personal `owner/repository` API path directly. Node's
+`https.get` does not automatically follow the HTTP redirect GitHub may return after a repository
+transfer. Transferring first could therefore make existing 2.0.0 installations silently stop seeing
+future update notices.
+
+Version 2.0.1 resolves repository metadata through immutable GitHub repository ID `1279507615`,
+then validates the exact current owner/name/API/Web/Release identity. It must be published from the
+personal repository before transfer.
+
+## Phase A — Destination readiness
+
+1. The maintainer supplies the exact Organization login; agents never invent the public identity.
+2. Confirm `heeh02` is an Organization owner.
+3. Create teams for maintainers, architecture, Desktop, UI, Engine, Security, Release and triage.
+4. Confirm the destination has no conflicting `HKUST-GZ-Connect` repository.
+5. Record Organization plan and policy constraints without purchasing or upgrading a plan unless
+   separately authorized.
+
+## Phase B — Bridge release under the current owner
+
+1. Merge the independently reviewed Windows/Profile upgrade repair tracked by Issue #74 and PR #75;
+   do not republish its known-buggy 2.0.0 predecessor.
+2. Merge the repository-ID update through ordinary required CI.
+3. Publish `v2.0.1` from the exact reviewed `main` commit.
+4. Verify all four package assets, digests, signing state and release notes.
+5. Install the published macOS artifact and verify the application still reports 2.0.1.
+6. From the published code, query the repository-ID endpoint and confirm that 2.0.1 is the selected
+   stable Release.
+7. From a 2.0.0 installation before transfer, confirm that the new release is visible.
+
+## Phase C — Transfer
+
+1. Snapshot repository owner, numeric ID, default branch, releases/tags, branch protection,
+   Rulesets, Actions settings, environments, secrets names, webhooks, collaborators and open work.
+2. Transfer only the exact repository ID `1279507615` to the confirmed Organization.
+3. Do not rename the repository during the transfer.
+4. Poll the new canonical API path and the old redirect until both are stable.
+5. Change Git remotes only after the new owner and unchanged repository ID are read back.
+
+## Phase D — Organization governance
+
+1. Replace personal CODEOWNERS entries with Organization teams.
+2. Require code-owner and last-push approval after at least two trusted reviewers exist.
+3. Convert/verify main protection as a Ruleset and enable administrator enforcement.
+4. Extend the `v*` tag Ruleset with creation restriction and Release-team bypass.
+5. Add required reviewers to the `release` Environment.
+6. Recheck Discussions, private vulnerability reporting, Dependabot, secret scanning, push
+   protection, Action SHA policy and squash-only merge settings.
+7. Update canonical repository links in README, Issue templates and governance receipts. The
+   updater itself must remain repository-ID based rather than being rebound to the new owner.
+
+## Phase E — Post-transfer proof
+
+- Old clone/fetch URL redirects without credential leakage.
+- New clone/fetch/push URL works for the intended roles.
+- `main`, all tags, all Releases, assets/digests and Actions history are present.
+- 2.0.1 update discovery resolves the Organization Release URL.
+- A clean PR on the Organization repository passes every required check.
+- A dry-run patch tag is not created; tag protection is verified through Ruleset readback rather
+  than by publishing a fake version.
+- `docs/governance/<date>-organization-transfer-receipt.md` records exact before/after evidence and
+  remaining risks.
+
+## Rollback boundary
+
+Do not delete the old redirect, recreate a repository at the old path, rename the destination, or
+change updater trust rules during the transfer window. If repository ID, releases, protection or
+update discovery does not reconcile, stop before creating another release and restore governance
+through GitHub Support/owner controls rather than force-pushing tags or history.


### PR DESCRIPTION
## Outcome

Closes #77. Advances #60 and #76.

This is the pre-transfer 2.0.1 bridge. Update discovery now begins at immutable GitHub repository ID `1279507615`, validates the complete current public repository identity, then constructs and allowlists only that owner’s Release endpoints. Production no longer has a personal-owner Release URL as a default trust path.

## Security boundary

- Exact ID, fixed repository name, owner syntax, full name, public/enabled/unarchived state, API URL, Web URL, and Release template must all agree.
- Redirects, Release payloads, and Renderer values cannot choose the repository owner.
- Off-prefix Release pages and every malformed/network outcome remain fail-closed.
- The app remains check-and-notify only; it does not download, install, or execute updates.

## Repository/release work

- Bumps package metadata to 2.0.1.
- Adds ADR-0032 and the Organization transfer playbook.
- Updates GOAL.md with the merged governance baseline, green Windows repair PR #75, and the missing stable Release tracked by #76.

## Dependency order

PR #75 must merge first. This PR should merge second, and only then may the exact resulting `main` commit be reviewed and tagged as `v2.0.1`. Neither PR authorizes a Release or Organization transfer by itself.

## Evidence

- Update tests: 17 passed, 0 failed.
- Full Desktop suite: 1227 total, 1223 passed, 4 platform-only skipped on macOS, 0 failed.
- Architecture, governance, staged secret, install-script, and syntax gates: passed.
- Live pre-transfer readback: repository ID resolves to public enabled `heeh02/HKUST-GZ-Connect`; current stable Release still resolves to v1.2.3, confirming #76.