### PR TITLE
security: update time to 0.3.47

### DIFF
--- a/independent/Cargo.lock
+++ b/independent/Cargo.lock
@@ -1024,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1728,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -1743,15 +1743,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
## Outcome

Resolves the open Dependabot advisory for stack-exhaustion denial of service in `time < 0.3.47`.

## Scope

- Updates only `independent/Cargo.lock`.
- `time` 0.3.45 → 0.3.47.
- Lockfile companions: `time-core` 0.1.7 → 0.1.8, `time-macros` 0.2.25 → 0.2.27, `num-conv` 0.1.0 → 0.2.2.
- No source, API, protocol, credential, GUI or release changes.

## Local evidence

- `cargo fmt --all -- --check`: pass.
- `cargo clippy --locked --all-targets --no-default-features -- -D warnings`: pass.
- `cargo test --locked --no-default-features`: pass.

The branch is based on exact `main@9e88449a375a66c34321207e6deaf097daebc6f3`.