### PR TITLE
refactor(renderer): inject campus data clock and timers

### DIFF
--- a/desktop/renderer/campus-data-modules.js
+++ b/desktop/renderer/campus-data-modules.js
@@ -62,9 +62,12 @@
     return Object.freeze({ ...range, events: Object.freeze(events) });
   }
 
-  function create({ document: doc, api, translate, escapeHtml, openDeepLink, onCatalog = null } = {}) {
+  function create({ document: doc, api, translate, escapeHtml, openDeepLink, onCatalog = null,
+    now: clockNow = Date.now, setTimeout: scheduleTimer = setTimeout,
+    clearTimeout: cancelTimer = clearTimeout } = {}) {
     if (!doc || !api || typeof translate !== 'function' || typeof escapeHtml !== 'function' ||
-        typeof openDeepLink !== 'function') {
+        typeof openDeepLink !== 'function' || typeof clockNow !== 'function' ||
+        typeof scheduleTimer !== 'function' || typeof cancelTimer !== 'function') {
       throw new TypeError('campus data module dependencies are incomplete');
     }
     const $ = (id) => doc.getElementById(id);
@@ -136,8 +139,8 @@
 
     function scheduleHtml(module) {
       if (!['ready', 'empty'].includes(module.state)) return stateHtml(module, 'schedule');
-      const model = scheduleWeekModel(module.state === 'ready' ? module.items : []);
-      const now = Date.now();
+      const now = clockNow();
+      const model = scheduleWeekModel(module.state === 'ready' ? module.items : [], now);
       const lastDay = model.days.at(-1);
       const weekLabel = translate('workspace.scheduleWeekRange', {
         start: formatDate(model.start), end: formatDate(lastDay),
@@ -177,7 +180,7 @@
 
     function loansHtml(module) {
       if (module.state !== 'ready') return stateHtml(module, 'loans');
-      const now = Date.now();
+      const now = clockNow();
       const dueSoon = module.items.filter(({ dueAt }) => dueAt >= now && dueAt - now <= 3 * 86_400_000).length;
       return `<div class="data-summary"><strong>${escapeHtml(translate('workspace.loansSummary', { count: module.items.length }))}</strong>`
         + (dueSoon ? `<span>${escapeHtml(translate('workspace.loansDueSoon', { count: dueSoon }))}</span>` : '') + '</div>'
@@ -225,12 +228,12 @@
     }
 
     function scheduleNextRefresh() {
-      if (scheduleRefreshTimer !== null) clearTimeout(scheduleRefreshTimer);
+      if (scheduleRefreshTimer !== null) cancelTimer(scheduleRefreshTimer);
       scheduleRefreshTimer = null;
       if (!loaded || snapshot?.sessionState !== 'authenticated') return;
-      const fetchedAt = snapshot?.modules?.schedule?.fetchedAt || lastLoadedAt || Date.now();
-      const delay = Math.max(1_000, SCHEDULE_AUTO_REFRESH_MS - (Date.now() - fetchedAt));
-      scheduleRefreshTimer = setTimeout(() => {
+      const fetchedAt = snapshot?.modules?.schedule?.fetchedAt || lastLoadedAt || clockNow();
+      const delay = Math.max(1_000, SCHEDULE_AUTO_REFRESH_MS - (clockNow() - fetchedAt));
+      scheduleRefreshTimer = scheduleTimer(() => {
         scheduleRefreshTimer = null;
         void refreshSchedule();
       }, delay);
@@ -252,7 +255,7 @@
       inflight = Promise.resolve(method.call(api)).then((value) => {
         snapshot = value;
         loaded = true;
-        lastLoadedAt = Date.now();
+        lastLoadedAt = clockNow();
         publishCatalog(value?.catalog || null);
         render();
         return value;
@@ -261,7 +264,7 @@
           state: 'failed', items: [],
         }])) };
         loaded = true;
-        lastLoadedAt = Date.now();
+        lastLoadedAt = clockNow();
         render();
         return null;
       }).finally(() => {
@@ -288,7 +291,7 @@
       const operation = Promise.resolve(api.refreshCampusSchedule()).then((value) => {
         snapshot = value;
         loaded = true;
-        lastLoadedAt = Date.now();
+        lastLoadedAt = clockNow();
         render();
         return value;
       }).catch(() => {
@@ -300,7 +303,7 @@
           },
         };
         loaded = true;
-        lastLoadedAt = Date.now();
+        lastLoadedAt = clockNow();
         render();
         return null;
       }).finally(() => {
@@ -347,7 +350,7 @@
         ['not-authenticated', 'session-expired'].includes(scheduleState);
       if (sessionRecovery) return load(true);
       const fetchedAt = snapshot?.modules?.schedule?.fetchedAt || lastLoadedAt;
-      if (Date.now() - fetchedAt >= SCHEDULE_AUTO_REFRESH_MS) return refreshSchedule();
+      if (clockNow() - fetchedAt >= SCHEDULE_AUTO_REFRESH_MS) return refreshSchedule();
       scheduleNextRefresh();
       return Promise.resolve(snapshot);
     }

--- a/desktop/test/unit/renderer/campus-data-clock.test.js
+++ b/desktop/test/unit/renderer/campus-data-clock.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { create } = require('../../../renderer/campus-data-modules.js');
+
+test('injected clock keeps daily cache and manual refresh independent from wall time', async () => {
+  let now = new Date(2027, 0, 15, 10).getTime();
+  let reads = 0;
+  let refreshes = 0;
+  let timerId = 0;
+  const timers = new Map();
+  const snapshot = () => ({ sessionState: 'authenticated', modules: {
+    schedule: { state: 'empty', items: [], fetchedAt: now },
+  } });
+  const feature = create({
+    document: { getElementById: () => null, documentElement: { lang: 'en' } },
+    api: {
+      getCampusData: async () => { reads += 1; return snapshot(); },
+      refreshCampusSchedule: async () => { refreshes += 1; return snapshot(); },
+    },
+    translate: (key) => key, escapeHtml: (text) => text, openDeepLink: () => {},
+    now: () => now,
+    setTimeout: (callback, delay) => { timers.set(++timerId, { callback, delay }); return timerId; },
+    clearTimeout: (id) => timers.delete(id),
+  });
+  const day = 86_400_000;
+  await feature.ensureLoaded();
+  assert.equal(reads, 1);
+  assert.equal([...timers.values()][0].delay, day);
+  now += day - 1;
+  await feature.ensureLoaded();
+  assert.equal(refreshes, 0);
+  assert.equal(timers.size, 1);
+  now += 1;
+  await feature.ensureLoaded();
+  assert.equal(refreshes, 1);
+  await feature.refreshSchedule();
+  assert.equal(refreshes, 2);
+  assert.equal(reads, 1);
+  assert.equal(timers.size, 1);
+  assert.equal([...timers.values()][0].delay, day);
+});


### PR DESCRIPTION
Adds injected clock and timer dependencies to the existing campus-data feature factory. Production callers retain their defaults. Schedule projection, cache age and refresh scheduling can now be tested deterministically without changing the global clock or accessing portal sessions.

The behavioral contract covers the 24-hour cache boundary, manual refresh, and replacing the pending timer. Full Desktop suite: 1239 tests, 1234 passed, 5 platform skips, zero failures. Architecture and dependency install-script gates passed. This is the first testing seam; full Renderer dependency extraction and calendar behavior changes remain separate work.

No persistence, Profile, session or credential changes. Rollback is a source-only revert. Browser layout validation is not claimed; this PR changes no markup or styles. No merge or release requested.
