### PR TITLE
fix(schedule): split events by intersecting calendar dates

### DIFF
--- a/desktop/e2e/control-shell-layout.electron.js
+++ b/desktop/e2e/control-shell-layout.electron.js
@@ -791,12 +791,19 @@ async function main() {
         days: [...document.querySelectorAll('#scheduleBody .week-event')].map(el => el.dataset.day),
         times: [...document.querySelectorAll('#scheduleBody .week-event time')].map(el => el.textContent),
         count: document.querySelector('#scheduleBody .week-summary span').textContent,
+        firstTime: document.querySelector('#scheduleBody .week-time').textContent,
+        rows: getComputedStyle(document.querySelector('#scheduleBody .week-body')).gridTemplateRows.split(' ').length,
+        eventRows: [...document.querySelectorAll('#scheduleBody .week-event')]
+          .map(el => [getComputedStyle(el).gridRowStart, getComputedStyle(el).gridRowEnd]),
         overflow: document.documentElement.scrollWidth - window.innerWidth,
       };
     })()`);
     assert.deepEqual(calendar.days, ['1', '2']);
     assert.deepEqual(calendar.times, ['20:00–24:00', '00:00–10:00']);
     assert.equal(calendar.count, '1');
+    assert.equal(calendar.firstTime, '00:00');
+    assert.equal(calendar.rows, 12);
+    assert.deepEqual(calendar.eventRows, [['11', 'span 2'], ['1', 'span 5']]);
     assert.ok(calendar.overflow <= 0);
     await capture(window, output, 'narrow-calendar-segments');
     process.stdout.write('control shell layout: PASS\n');

--- a/desktop/e2e/control-shell-layout.electron.js
+++ b/desktop/e2e/control-shell-layout.electron.js
@@ -782,7 +782,10 @@ async function main() {
         document,
         api: { getCampusData: async () => ({ sessionState: 'fixture', modules: {
           schedule: { state: 'ready', source: 'myportal-calendar', items: [{ id: 'overnight', title: 'Fixture event',
-            startsAt: start.getTime(), endsAt: end.getTime() }] },
+            startsAt: start.getTime(), endsAt: end.getTime() }, {
+              id: 'overlap', title: 'Concurrent fixture', startsAt: start.getTime(),
+              endsAt: start.getTime() + 2 * 3600000,
+            }] },
         } }) },
         translate: (key, values) => key === 'workspace.scheduleWeekCount'
           ? String(values.count) : key,
@@ -799,15 +802,23 @@ async function main() {
         rows: getComputedStyle(document.querySelector('#scheduleBody .week-body')).gridTemplateRows.split(' ').length,
         eventRows: [...document.querySelectorAll('#scheduleBody .week-event')]
           .map(el => [getComputedStyle(el).gridRowStart, getComputedStyle(el).gridRowEnd]),
+        eventRects: [...document.querySelectorAll('#scheduleBody .week-event')].map(el => {
+          const r = el.getBoundingClientRect();
+          return { left: r.left, right: r.right, top: r.top, width: r.width };
+        }),
         overflow: document.documentElement.scrollWidth - window.innerWidth,
       };
     })()`);
-    assert.deepEqual(calendar.days, ['1', '2']);
-    assert.deepEqual(calendar.times, ['20:00–24:00', '00:00–10:00']);
-    assert.equal(calendar.count, '1');
+    assert.deepEqual(calendar.days, ['1', '1', '2']);
+    assert.deepEqual(calendar.times, ['20:00–24:00', '20:00–22:00', '00:00–10:00']);
+    assert.equal(calendar.count, '2');
     assert.equal(calendar.firstTime, '00:00');
     assert.equal(calendar.rows, 12);
-    assert.deepEqual(calendar.eventRows, [['11', 'span 2'], ['1', 'span 5']]);
+    assert.deepEqual(calendar.eventRows, [['11', 'span 2'], ['11', 'span 1'], ['1', 'span 5']]);
+    assert.equal(calendar.eventRects[0].top, calendar.eventRects[1].top);
+    assert.ok(calendar.eventRects[0].right <= calendar.eventRects[1].left,
+      'concurrent events must be side by side instead of covering one another');
+    assert.ok(calendar.eventRects.every(rect => rect.width > 0));
     assert.ok(calendar.overflow <= 0);
     await capture(window, output, 'narrow-calendar-segments');
     process.stdout.write('control shell layout: PASS\n');

--- a/desktop/e2e/control-shell-layout.electron.js
+++ b/desktop/e2e/control-shell-layout.electron.js
@@ -766,6 +766,39 @@ async function main() {
       return { page: document.querySelector('.page.active').dataset.page, focused: document.activeElement.id };
     })()`);
     assert.deepEqual(shortcut, { page: 'browser', focused: 'resourceSearch' });
+    // Exercise the real timetable DOM with synthetic dates, independent of a
+    // portal session. The ordinary layout fixture only renders signed-out data.
+    await settle(window, 440, 540);
+    await shellSnapshot(window, 'browser');
+    const calendar = await window.webContents.executeJavaScript(`(async () => {
+      const range = window.campusDataModules.weekRange();
+      const start = new Date(range.days[1]); start.setHours(20);
+      const end = new Date(range.days[2]); end.setHours(10);
+      const feature = window.campusDataModules.create({
+        document,
+        api: { getCampusData: async () => ({ sessionState: 'fixture', modules: {
+          schedule: { state: 'ready', items: [{ id: 'overnight', title: 'Fixture event',
+            startsAt: start.getTime(), endsAt: end.getTime() }] },
+        } }) },
+        translate: (key, values) => key === 'workspace.scheduleWeekCount'
+          ? String(values.count) : key,
+        escapeHtml: (text) => String(text).replaceAll('&', '&amp;').replaceAll('<', '&lt;'),
+        openDeepLink: () => {},
+      });
+      await feature.load();
+      document.getElementById('moduleSchedule').scrollIntoView();
+      return {
+        days: [...document.querySelectorAll('#scheduleBody .week-event')].map(el => el.dataset.day),
+        times: [...document.querySelectorAll('#scheduleBody .week-event time')].map(el => el.textContent),
+        count: document.querySelector('#scheduleBody .week-summary span').textContent,
+        overflow: document.documentElement.scrollWidth - window.innerWidth,
+      };
+    })()`);
+    assert.deepEqual(calendar.days, ['1', '2']);
+    assert.deepEqual(calendar.times, ['20:00–24:00', '00:00–10:00']);
+    assert.equal(calendar.count, '1');
+    assert.ok(calendar.overflow <= 0);
+    await capture(window, output, 'narrow-calendar-segments');
     process.stdout.write('control shell layout: PASS\n');
   } finally {
     if (window.webContents.debugger.isAttached()) window.webContents.debugger.detach();

--- a/desktop/e2e/control-shell-layout.electron.js
+++ b/desktop/e2e/control-shell-layout.electron.js
@@ -770,14 +770,18 @@ async function main() {
     // portal session. The ordinary layout fixture only renders signed-out data.
     await settle(window, 440, 540);
     await shellSnapshot(window, 'browser');
+    if (!window.webContents.debugger.isAttached()) window.webContents.debugger.attach('1.3');
+    await window.webContents.debugger.sendCommand('Emulation.setTimezoneOverride', {
+      timezoneId: 'America/Los_Angeles',
+    });
     const calendar = await window.webContents.executeJavaScript(`(async () => {
-      const range = window.campusDataModules.weekRange();
-      const start = new Date(range.days[1]); start.setHours(20);
-      const end = new Date(range.days[2]); end.setHours(10);
+      const range = window.campusDataModules.weekRange(Date.now(), true);
+      const start = new Date(range.days[1] + 20 * 3600000);
+      const end = new Date(range.days[2] + 10 * 3600000);
       const feature = window.campusDataModules.create({
         document,
         api: { getCampusData: async () => ({ sessionState: 'fixture', modules: {
-          schedule: { state: 'ready', items: [{ id: 'overnight', title: 'Fixture event',
+          schedule: { state: 'ready', source: 'myportal-calendar', items: [{ id: 'overnight', title: 'Fixture event',
             startsAt: start.getTime(), endsAt: end.getTime() }] },
         } }) },
         translate: (key, values) => key === 'workspace.scheduleWeekCount'

--- a/desktop/renderer/campus-data-modules.js
+++ b/desktop/renderer/campus-data-modules.js
@@ -19,7 +19,17 @@
   const WEEK_SLOT_COUNT = 7;
   const SCHEDULE_AUTO_REFRESH_MS = 24 * 60 * 60 * 1_000;
 
-  function weekRange(now = Date.now()) {
+  function weekRange(now = Date.now(), campusTime = false) {
+    if (campusTime) {
+      const offset = 8 * 60 * 60 * 1000;
+      const day = new Date(now + offset);
+      if (!Number.isFinite(day.getTime())) throw new TypeError('week timestamp is invalid');
+      day.setUTCHours(0, 0, 0, 0);
+      day.setUTCDate(day.getUTCDate() - ((day.getUTCDay() + 6) % 7));
+      const start = day.getTime() - offset;
+      return Object.freeze({ start, end: start + 7 * 86_400_000,
+        days: Object.freeze(Array.from({ length: 7 }, (_, i) => start + i * 86_400_000)) });
+    }
     const start = new Date(now);
     if (!Number.isFinite(start.getTime())) throw new TypeError('week timestamp is invalid');
     start.setHours(0, 0, 0, 0);
@@ -34,15 +44,17 @@
     return Object.freeze({ start: start.getTime(), end: end.getTime(), days: Object.freeze(days) });
   }
 
-  function sameLocalDay(left, right) {
+  function sameLocalDay(left, right, campusTime = false) {
+    if (campusTime) return Math.floor((left + 28_800_000) / 86_400_000) ===
+      Math.floor((right + 28_800_000) / 86_400_000);
     const a = new Date(left);
     const b = new Date(right);
     return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() &&
       a.getDate() === b.getDate();
   }
 
-  function scheduleWeekModel(entries, now = Date.now()) {
-    const range = weekRange(now);
+  function scheduleWeekModel(entries, now = Date.now(), campusTime = false) {
+    const range = weekRange(now, campusTime);
     const items = Array.isArray(entries) ? entries : [];
     const intersecting = items.filter((entry) => Number.isFinite(entry?.startsAt) &&
       Number.isFinite(entry?.endsAt) && entry.endsAt > entry.startsAt &&
@@ -54,11 +66,13 @@
       const segmentStart = Math.max(entry.startsAt, dayStart);
       const segmentEnd = Math.min(entry.endsAt, dayEnd);
       if (segmentEnd <= segmentStart) return [];
-      const start = new Date(segmentStart);
-      const end = new Date(segmentEnd);
-      const startMinutes = start.getHours() * 60 + start.getMinutes();
+      const start = new Date(segmentStart + (campusTime ? 28_800_000 : 0));
+      const end = new Date(segmentEnd + (campusTime ? 28_800_000 : 0));
+      const minutes = (date) => campusTime ? date.getUTCHours() * 60 + date.getUTCMinutes()
+        : date.getHours() * 60 + date.getMinutes();
+      const startMinutes = minutes(start);
       const endMinutes = segmentEnd === dayEnd ? 24 * 60
-        : end.getHours() * 60 + end.getMinutes();
+        : minutes(end);
       return [{ entry, day, startMinutes, endMinutes, segmentStart, segmentEnd }];
     }));
     const slotStart = Math.floor(Math.min(WEEK_SLOT_START,
@@ -90,14 +104,8 @@
 
     const locale = () => String(doc.documentElement.lang || '').toLowerCase().startsWith('en')
       ? 'en' : 'zh-CN';
-    const formatTime = (value) => new Intl.DateTimeFormat(locale(), {
-      hour: '2-digit', minute: '2-digit', hour12: false,
-    }).format(new Date(value));
     const formatDate = (value) => new Intl.DateTimeFormat(locale(), {
       month: 'short', day: 'numeric',
-    }).format(new Date(value));
-    const formatWeekday = (value) => new Intl.DateTimeFormat(locale(), {
-      weekday: 'short',
     }).format(new Date(value));
 
     function validModule(module) {
@@ -149,19 +157,26 @@
 
     function scheduleHtml(module) {
       if (!['ready', 'empty'].includes(module.state)) return stateHtml(module, 'schedule');
-      const model = scheduleWeekModel(module.state === 'ready' ? module.items : []);
       const now = Date.now();
+      const campusTime = module.source === 'myportal-calendar';
+      const model = scheduleWeekModel(module.state === 'ready' ? module.items : [], now, campusTime);
+      const format = (value, options) => new Intl.DateTimeFormat(locale(), {
+        ...options, ...(campusTime ? { timeZone: 'Asia/Shanghai' } : {}),
+      }).format(new Date(value));
+      const formatDate = value => format(value, { month: 'short', day: 'numeric' });
+      const formatWeekday = value => format(value, { weekday: 'short' });
+      const formatTime = value => format(value, { hour: '2-digit', minute: '2-digit', hour12: false });
       const lastDay = model.days.at(-1);
       const weekLabel = translate('workspace.scheduleWeekRange', {
         start: formatDate(model.start), end: formatDate(lastDay),
       });
       const headers = model.days.map((day) => {
-        const today = sameLocalDay(day, now);
+        const today = sameLocalDay(day, now, campusTime);
         return `<div class="week-day-head${today ? ' is-today' : ''}" role="columnheader"${today ? ' aria-current="date"' : ''}>`
           + `<span>${escapeHtml(formatWeekday(day))}</span><strong>${escapeHtml(formatDate(day))}</strong></div>`;
       }).join('');
       const lanes = model.days.map((day, index) => (
-        `<div class="week-day-lane${sameLocalDay(day, now) ? ' is-today' : ''}" data-day="${index}" aria-hidden="true"></div>`
+        `<div class="week-day-lane${sameLocalDay(day, now, campusTime) ? ' is-today' : ''}" data-day="${index}" aria-hidden="true"></div>`
       )).join('');
       const times = Array.from({ length: model.slotCount }, (_, index) => {
         const hour = String(model.slotStart / 60 + index * 2).padStart(2, '0');

--- a/desktop/renderer/campus-data-modules.js
+++ b/desktop/renderer/campus-data-modules.js
@@ -182,15 +182,21 @@
         const hour = String(model.slotStart / 60 + index * 2).padStart(2, '0');
         return `<time class="week-time" data-slot="${index}" aria-hidden="true">${hour}:00</time>`;
       }).join('');
-      const events = model.events.map(({ entry, day, slot, span, segmentStart, segmentEnd }) => {
+      const events = model.days.map((_, index) => {
+        const dayEvents = model.events.filter(({ day }) => day === index)
+          .map(({ entry, day, slot, span, segmentStart, segmentEnd }) => {
         const endLabel = segmentEnd === (model.days[day + 1] ?? model.end) ? '24:00' : formatTime(segmentEnd);
         const content = `<time>${escapeHtml(`${formatTime(segmentStart)}–${endLabel}`)}</time>`
           + `<strong>${escapeHtml(entry.title)}</strong>`
           + (entry.location ? `<small>${escapeHtml(entry.location)}</small>` : '');
-        const attrs = `class="week-event" data-day="${day}" data-slot="${slot}" data-span="${span}"`;
+        const label = `${formatTime(segmentStart)}–${endLabel} ${entry.title}${entry.location ? ` · ${entry.location}` : ''}`;
+        const attrs = `class="week-event" data-day="${day}" data-slot="${slot}" data-span="${span}"`
+          + ` title="${escapeHtml(label)}" aria-label="${escapeHtml(label)}"`;
         return entry.url
           ? `<button type="button" ${attrs} data-entry-url="${escapeHtml(entry.url)}">${content}</button>`
           : `<div ${attrs} role="gridcell">${content}</div>`;
+          }).join('');
+        return `<div class="week-event-day" data-day="${index}">${dayEvents}</div>`;
       }).join('');
       const empty = model.events.length ? ''
         : `<div class="week-empty" role="status"><strong>${escapeHtml(translate('workspace.scheduleWeekEmpty'))}</strong>`

--- a/desktop/renderer/campus-data-modules.js
+++ b/desktop/renderer/campus-data-modules.js
@@ -44,22 +44,28 @@
   function scheduleWeekModel(entries, now = Date.now()) {
     const range = weekRange(now);
     const items = Array.isArray(entries) ? entries : [];
-    const events = items.filter((entry) => Number.isFinite(entry?.startsAt) &&
+    const intersecting = items.filter((entry) => Number.isFinite(entry?.startsAt) &&
       Number.isFinite(entry?.endsAt) && entry.endsAt > entry.startsAt &&
-      entry.startsAt < range.end && entry.endsAt > range.start).map((entry) => {
-      const start = new Date(entry.startsAt);
-      const end = new Date(entry.endsAt);
-      const day = range.days.findIndex((timestamp) => sameLocalDay(timestamp, entry.startsAt));
+      Number.isFinite(new Date(entry.startsAt).getTime()) &&
+      Number.isFinite(new Date(entry.endsAt).getTime()) &&
+      entry.startsAt < range.end && entry.endsAt > range.start);
+    const events = intersecting.flatMap((entry) => range.days.flatMap((dayStart, day) => {
+      const dayEnd = range.days[day + 1] ?? range.end;
+      const segmentStart = Math.max(entry.startsAt, dayStart);
+      const segmentEnd = Math.min(entry.endsAt, dayEnd);
+      if (segmentEnd <= segmentStart) return [];
+      const start = new Date(segmentStart);
+      const end = new Date(segmentEnd);
       const startMinutes = start.getHours() * 60 + start.getMinutes();
-      const endMinutes = sameLocalDay(entry.startsAt, entry.endsAt)
-        ? end.getHours() * 60 + end.getMinutes() : 24 * 60;
+      const endMinutes = segmentEnd === dayEnd ? 24 * 60
+        : end.getHours() * 60 + end.getMinutes();
       const slot = Math.max(0, Math.min(WEEK_SLOT_COUNT - 1,
         Math.floor((startMinutes - WEEK_SLOT_START) / WEEK_SLOT_MINUTES)));
       const endSlot = Math.max(slot + 1, Math.min(WEEK_SLOT_COUNT,
         Math.ceil((endMinutes - WEEK_SLOT_START) / WEEK_SLOT_MINUTES)));
-      return Object.freeze({ entry, day: Math.max(0, day), slot, span: endSlot - slot });
-    }).sort((left, right) => left.entry.startsAt - right.entry.startsAt);
-    return Object.freeze({ ...range, events: Object.freeze(events) });
+      return [Object.freeze({ entry, day, slot, span: endSlot - slot, segmentStart, segmentEnd })];
+    })).sort((left, right) => left.segmentStart - right.segmentStart);
+    return Object.freeze({ ...range, events: Object.freeze(events), eventCount: intersecting.length });
   }
 
   function create({ document: doc, api, translate, escapeHtml, openDeepLink, onCatalog = null } = {}) {
@@ -154,8 +160,9 @@
         const hour = String(8 + index * 2).padStart(2, '0');
         return `<time class="week-time" data-slot="${index}" aria-hidden="true">${hour}:00</time>`;
       }).join('');
-      const events = model.events.map(({ entry, day, slot, span }) => {
-        const content = `<time>${escapeHtml(`${formatTime(entry.startsAt)}–${formatTime(entry.endsAt)}`)}</time>`
+      const events = model.events.map(({ entry, day, slot, span, segmentStart, segmentEnd }) => {
+        const endLabel = segmentEnd === (model.days[day + 1] ?? model.end) ? '24:00' : formatTime(segmentEnd);
+        const content = `<time>${escapeHtml(`${formatTime(segmentStart)}–${endLabel}`)}</time>`
           + `<strong>${escapeHtml(entry.title)}</strong>`
           + (entry.location ? `<small>${escapeHtml(entry.location)}</small>` : '');
         const attrs = `class="week-event" data-day="${day}" data-slot="${slot}" data-span="${span}"`;
@@ -167,7 +174,7 @@
         : `<div class="week-empty" role="status"><strong>${escapeHtml(translate('workspace.scheduleWeekEmpty'))}</strong>`
           + `<span>${escapeHtml(translate('workspace.scheduleWeekEmptyHint'))}</span></div>`;
       return `<div class="week-summary"><strong>${escapeHtml(weekLabel)}</strong>`
-        + `<span>${escapeHtml(translate('workspace.scheduleWeekCount', { count: model.events.length }))}</span></div>`
+        + `<span>${escapeHtml(translate('workspace.scheduleWeekCount', { count: model.eventCount }))}</span></div>`
         + `<div class="week-scroll" tabindex="0" aria-label="${escapeHtml(translate('workspace.scheduleWeekTable'))}">`
         + `<div class="week-table" role="grid"><div class="week-head" role="row">`
         + `<div class="week-time-head" role="columnheader">${escapeHtml(translate('workspace.scheduleTime'))}</div>${headers}</div>`

--- a/desktop/renderer/campus-data-modules.js
+++ b/desktop/renderer/campus-data-modules.js
@@ -49,7 +49,7 @@
       Number.isFinite(new Date(entry.startsAt).getTime()) &&
       Number.isFinite(new Date(entry.endsAt).getTime()) &&
       entry.startsAt < range.end && entry.endsAt > range.start);
-    const events = intersecting.flatMap((entry) => range.days.flatMap((dayStart, day) => {
+    const segments = intersecting.flatMap((entry) => range.days.flatMap((dayStart, day) => {
       const dayEnd = range.days[day + 1] ?? range.end;
       const segmentStart = Math.max(entry.startsAt, dayStart);
       const segmentEnd = Math.min(entry.endsAt, dayEnd);
@@ -59,13 +59,20 @@
       const startMinutes = start.getHours() * 60 + start.getMinutes();
       const endMinutes = segmentEnd === dayEnd ? 24 * 60
         : end.getHours() * 60 + end.getMinutes();
-      const slot = Math.max(0, Math.min(WEEK_SLOT_COUNT - 1,
-        Math.floor((startMinutes - WEEK_SLOT_START) / WEEK_SLOT_MINUTES)));
-      const endSlot = Math.max(slot + 1, Math.min(WEEK_SLOT_COUNT,
-        Math.ceil((endMinutes - WEEK_SLOT_START) / WEEK_SLOT_MINUTES)));
-      return [Object.freeze({ entry, day, slot, span: endSlot - slot, segmentStart, segmentEnd })];
-    })).sort((left, right) => left.segmentStart - right.segmentStart);
-    return Object.freeze({ ...range, events: Object.freeze(events), eventCount: intersecting.length });
+      return [{ entry, day, startMinutes, endMinutes, segmentStart, segmentEnd }];
+    }));
+    const slotStart = Math.floor(Math.min(WEEK_SLOT_START,
+      ...segments.map(({ startMinutes }) => startMinutes)) / WEEK_SLOT_MINUTES) * WEEK_SLOT_MINUTES;
+    const slotEnd = Math.ceil(Math.max(WEEK_SLOT_START + WEEK_SLOT_COUNT * WEEK_SLOT_MINUTES,
+      ...segments.map(({ endMinutes }) => endMinutes)) / WEEK_SLOT_MINUTES) * WEEK_SLOT_MINUTES;
+    const slotCount = (slotEnd - slotStart) / WEEK_SLOT_MINUTES;
+    const events = segments.map(({ startMinutes, endMinutes, ...segment }) => {
+      const slot = Math.floor((startMinutes - slotStart) / WEEK_SLOT_MINUTES);
+      const endSlot = Math.max(slot + 1, Math.ceil((endMinutes - slotStart) / WEEK_SLOT_MINUTES));
+      return Object.freeze({ ...segment, slot, span: endSlot - slot });
+    }).sort((left, right) => left.segmentStart - right.segmentStart);
+    return Object.freeze({ ...range, slotStart, slotCount,
+      events: Object.freeze(events), eventCount: intersecting.length });
   }
 
   function create({ document: doc, api, translate, escapeHtml, openDeepLink, onCatalog = null } = {}) {
@@ -156,8 +163,8 @@
       const lanes = model.days.map((day, index) => (
         `<div class="week-day-lane${sameLocalDay(day, now) ? ' is-today' : ''}" data-day="${index}" aria-hidden="true"></div>`
       )).join('');
-      const times = Array.from({ length: WEEK_SLOT_COUNT }, (_, index) => {
-        const hour = String(8 + index * 2).padStart(2, '0');
+      const times = Array.from({ length: model.slotCount }, (_, index) => {
+        const hour = String(model.slotStart / 60 + index * 2).padStart(2, '0');
         return `<time class="week-time" data-slot="${index}" aria-hidden="true">${hour}:00</time>`;
       }).join('');
       const events = model.events.map(({ entry, day, slot, span, segmentStart, segmentEnd }) => {
@@ -178,7 +185,7 @@
         + `<div class="week-scroll" tabindex="0" aria-label="${escapeHtml(translate('workspace.scheduleWeekTable'))}">`
         + `<div class="week-table" role="grid"><div class="week-head" role="row">`
         + `<div class="week-time-head" role="columnheader">${escapeHtml(translate('workspace.scheduleTime'))}</div>${headers}</div>`
-        + `<div class="week-body">${lanes}${times}${events}${empty}</div></div></div>`
+        + `<div class="week-body" data-slot-count="${model.slotCount}">${lanes}${times}${events}${empty}</div></div></div>`
         + actionHtml('source', 'schedule');
     }
 

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -1750,25 +1750,26 @@ button.week-event:hover { border-color: #86a9d3; background: #dceafa; }
 }
 .week-empty strong { color: var(--ink); font-size: 12px; }
 .week-empty span { color: var(--muted); font-size: 10.5px; }
-.week-day-lane[data-day="0"], .week-event[data-day="0"] { grid-column: 2; }
-.week-day-lane[data-day="1"], .week-event[data-day="1"] { grid-column: 3; }
-.week-day-lane[data-day="2"], .week-event[data-day="2"] { grid-column: 4; }
-.week-day-lane[data-day="3"], .week-event[data-day="3"] { grid-column: 5; }
-.week-day-lane[data-day="4"], .week-event[data-day="4"] { grid-column: 6; }
-.week-day-lane[data-day="5"], .week-event[data-day="5"] { grid-column: 7; }
-.week-day-lane[data-day="6"], .week-event[data-day="6"] { grid-column: 8; }
-.week-body > [data-slot="0"] { grid-row-start: 1; }
-.week-body > [data-slot="1"] { grid-row-start: 2; }
-.week-body > [data-slot="2"] { grid-row-start: 3; }
-.week-body > [data-slot="3"] { grid-row-start: 4; }
-.week-body > [data-slot="4"] { grid-row-start: 5; }
-.week-body > [data-slot="5"] { grid-row-start: 6; }
-.week-body > [data-slot="6"] { grid-row-start: 7; }
-.week-body > [data-slot="7"] { grid-row-start: 8; }
-.week-body > [data-slot="8"] { grid-row-start: 9; }
-.week-body > [data-slot="9"] { grid-row-start: 10; }
-.week-body > [data-slot="10"] { grid-row-start: 11; }
-.week-body > [data-slot="11"] { grid-row-start: 12; }
+.week-event-day { display: grid; grid-row: 1 / -1; grid-template-rows: subgrid; grid-auto-flow: row dense; grid-auto-columns: minmax(0, 1fr); min-width: 0; }
+.week-day-lane[data-day="0"], .week-event-day[data-day="0"] { grid-column: 2; }
+.week-day-lane[data-day="1"], .week-event-day[data-day="1"] { grid-column: 3; }
+.week-day-lane[data-day="2"], .week-event-day[data-day="2"] { grid-column: 4; }
+.week-day-lane[data-day="3"], .week-event-day[data-day="3"] { grid-column: 5; }
+.week-day-lane[data-day="4"], .week-event-day[data-day="4"] { grid-column: 6; }
+.week-day-lane[data-day="5"], .week-event-day[data-day="5"] { grid-column: 7; }
+.week-day-lane[data-day="6"], .week-event-day[data-day="6"] { grid-column: 8; }
+.week-body [data-slot="0"] { grid-row-start: 1; }
+.week-body [data-slot="1"] { grid-row-start: 2; }
+.week-body [data-slot="2"] { grid-row-start: 3; }
+.week-body [data-slot="3"] { grid-row-start: 4; }
+.week-body [data-slot="4"] { grid-row-start: 5; }
+.week-body [data-slot="5"] { grid-row-start: 6; }
+.week-body [data-slot="6"] { grid-row-start: 7; }
+.week-body [data-slot="7"] { grid-row-start: 8; }
+.week-body [data-slot="8"] { grid-row-start: 9; }
+.week-body [data-slot="9"] { grid-row-start: 10; }
+.week-body [data-slot="10"] { grid-row-start: 11; }
+.week-body [data-slot="11"] { grid-row-start: 12; }
 .week-event[data-span="1"] { grid-row-end: span 1; }
 .week-event[data-span="2"] { grid-row-end: span 2; }
 .week-event[data-span="3"] { grid-row-end: span 3; }

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -1695,6 +1695,11 @@ button.data-row:hover strong { color: var(--navy-2); }
   background: repeating-linear-gradient(to bottom, transparent 0 37px, #edf1f6 37px 38px);
 }
 .week-day-lane { grid-row: 1 / -1; border-left: 1px solid #e4eaf2; }
+.week-body[data-slot-count="8"] { grid-template-rows: repeat(8, 38px); }
+.week-body[data-slot-count="9"] { grid-template-rows: repeat(9, 38px); }
+.week-body[data-slot-count="10"] { grid-template-rows: repeat(10, 38px); }
+.week-body[data-slot-count="11"] { grid-template-rows: repeat(11, 38px); }
+.week-body[data-slot-count="12"] { grid-template-rows: repeat(12, 38px); }
 .week-day-lane.is-today { background: rgba(232, 240, 251, .5); }
 .week-time {
   z-index: 1;
@@ -1759,6 +1764,11 @@ button.week-event:hover { border-color: #86a9d3; background: #dceafa; }
 .week-body > [data-slot="4"] { grid-row-start: 5; }
 .week-body > [data-slot="5"] { grid-row-start: 6; }
 .week-body > [data-slot="6"] { grid-row-start: 7; }
+.week-body > [data-slot="7"] { grid-row-start: 8; }
+.week-body > [data-slot="8"] { grid-row-start: 9; }
+.week-body > [data-slot="9"] { grid-row-start: 10; }
+.week-body > [data-slot="10"] { grid-row-start: 11; }
+.week-body > [data-slot="11"] { grid-row-start: 12; }
 .week-event[data-span="1"] { grid-row-end: span 1; }
 .week-event[data-span="2"] { grid-row-end: span 2; }
 .week-event[data-span="3"] { grid-row-end: span 3; }
@@ -1766,6 +1776,11 @@ button.week-event:hover { border-color: #86a9d3; background: #dceafa; }
 .week-event[data-span="5"] { grid-row-end: span 5; }
 .week-event[data-span="6"] { grid-row-end: span 6; }
 .week-event[data-span="7"] { grid-row-end: span 7; }
+.week-event[data-span="8"] { grid-row-end: span 8; }
+.week-event[data-span="9"] { grid-row-end: span 9; }
+.week-event[data-span="10"] { grid-row-end: span 10; }
+.week-event[data-span="11"] { grid-row-end: span 11; }
+.week-event[data-span="12"] { grid-row-end: span 12; }
 .news-unread { width: 6px; height: 6px; border-radius: 50%; background: transparent; }
 .news-unread.is-unread { background: var(--gold); }
 

--- a/desktop/test/unit/renderer/schedule-calendar.test.js
+++ b/desktop/test/unit/renderer/schedule-calendar.test.js
@@ -4,6 +4,25 @@ const assert = require('node:assert/strict');
 const { scheduleWeekModel } = require('../../../renderer/campus-data-modules');
 const date = (day, hour = 0) => new Date(2027, 0, day, hour).getTime();
 
+test('campus week and event slots stay stable when the host has not reached Monday', () => {
+  const original = process.env.TZ;
+  try {
+    for (const zone of ['UTC', 'America/Los_Angeles', 'Asia/Shanghai']) {
+      process.env.TZ = zone;
+      const model = scheduleWeekModel([{
+        startsAt: Date.parse('2027-01-18T10:00:00+08:00'),
+        endsAt: Date.parse('2027-01-18T12:00:00+08:00'),
+      }], Date.parse('2027-01-17T20:00:00Z'), true);
+      assert.equal(model.start, Date.parse('2027-01-17T16:00:00Z'), zone);
+      assert.equal(model.events[0].day, 0);
+      assert.equal(model.events[0].slot, 1);
+    }
+  } finally {
+    if (original === undefined) delete process.env.TZ;
+    else process.env.TZ = original;
+  }
+});
+
 test('cross-day events project only onto intersecting calendar dates', () => {
   const entry = { id: 'overnight', startsAt: date(12, 20), endsAt: date(13, 10) };
   const model = scheduleWeekModel([entry], date(13));

--- a/desktop/test/unit/renderer/schedule-calendar.test.js
+++ b/desktop/test/unit/renderer/schedule-calendar.test.js
@@ -1,0 +1,37 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { scheduleWeekModel } = require('../../../renderer/campus-data-modules');
+const date = (day, hour = 0) => new Date(2027, 0, day, hour).getTime();
+
+test('cross-day events project only onto intersecting calendar dates', () => {
+  const entry = { id: 'overnight', startsAt: date(12, 20), endsAt: date(13, 10) };
+  const model = scheduleWeekModel([entry], date(13));
+  assert.deepEqual(model.events.map(({ day }) => day), [1, 2]);
+  assert.deepEqual(model.events.map(({ segmentStart, segmentEnd }) => [segmentStart, segmentEnd]),
+    [[date(12, 20), date(13)], [date(13), date(13, 10)]]);
+  assert.equal(model.eventCount, 1);
+  assert.equal(model.events[0].entry, entry);
+});
+
+test('week clipping uses interval intersection, not the original weekday', () => {
+  const model = scheduleWeekModel([
+    { id: 'previous-week', startsAt: date(10, 20), endsAt: date(11, 10) },
+    { id: 'next-week', startsAt: date(17, 20), endsAt: date(18, 10) },
+  ], date(13));
+  assert.deepEqual(model.events.map(({ day }) => day), [0, 6]);
+  assert.equal(model.events[0].segmentStart, date(11));
+  assert.equal(model.events[1].segmentEnd, date(18));
+});
+
+test('exclusive end midnight creates no extra day and invalid intervals are absent', () => {
+  const model = scheduleWeekModel([
+    { startsAt: date(12, 20), endsAt: date(13) },
+    { startsAt: date(13), endsAt: date(13) },
+    { startsAt: date(14), endsAt: date(13) },
+    { startsAt: Number.MAX_VALUE, endsAt: Infinity },
+  ], date(13));
+  assert.equal(model.events.length, 1);
+  assert.equal(model.events[0].day, 1);
+  assert.equal(model.eventCount, 1);
+});

--- a/desktop/test/unit/renderer/schedule-calendar.test.js
+++ b/desktop/test/unit/renderer/schedule-calendar.test.js
@@ -12,6 +12,19 @@ test('cross-day events project only onto intersecting calendar dates', () => {
     [[date(12, 20), date(13)], [date(13), date(13, 10)]]);
   assert.equal(model.eventCount, 1);
   assert.equal(model.events[0].entry, entry);
+  assert.equal(model.slotStart, 0);
+  assert.equal(model.slotCount, 12);
+  assert.equal(model.events[0].slot, 10);
+  assert.equal(model.events[0].span, 2);
+  assert.equal(model.events[1].slot, 0);
+  assert.equal(model.events[1].span, 5);
+});
+
+test('ordinary daytime events retain the compact default time axis', () => {
+  const model = scheduleWeekModel([{ startsAt: date(12, 10), endsAt: date(12, 12) }], date(13));
+  assert.equal(model.slotStart, 480);
+  assert.equal(model.slotCount, 7);
+  assert.equal(model.events[0].slot, 1);
 });
 
 test('week clipping uses interval intersection, not the original weekday', () => {


### PR DESCRIPTION
Projects each schedule interval onto the calendar dates it actually overlaps. Cross-midnight events now appear on both days; intervals spanning the week boundary are clipped to this week. An exclusive midnight end does not create an extra next-day entry. The summary counts source events rather than visual segments.

Preserves the source event, identity and URL; adds display-only segment boundaries. No storage, portal authentication, or Profile changes. Revert the PR to roll back.

Validation: three focused regressions failed before the change and pass after it. Latest full Desktop suite: 1238 passed, 5 platform skips, zero failures. Architecture, syntax of changed files and sensitive-pattern checks passed; install-script checks passed earlier with unchanged dependencies. Electron validation includes five viewport widths and offline cross-midnight/concurrent events rendered through the real feature into DOM. This PR retains the two-hour grid; a separate all-day presentation is not implemented.

The time axis expands from the default 08:00–22:00 up to 00:00–24:00 when this week's events require it. Electron checks assert the actual CSS row positions and spans for overnight segments; control-shell layout passed at 440–1440 pixels.

MyPortal calendar presentation now uses campus UTC+08:00 for week boundaries, date columns, today highlighting and time labels. Other sources retain local-time defaults. Model tests cover UTC, Los Angeles and Shanghai hosts; Electron emulates Los Angeles and verifies real campus-time date columns and overnight grid positions. This complements the source/query timezone contract in PR #92.

Each day now has a row subgrid that places events occupying the same time rows into separate columns. Electron checks verify that concurrent event rectangles share the start row but do not intersect horizontally. Complete event time, title and location remain available through escaped title and accessible labels when narrow columns truncate visible text. Dense calendars still require visual usability review.

Based on main ff9e808d3eb5020169f5196b207fa85739b429e1, independent of PR #90. No merge or release requested.
