### PR TITLE
fix(portal): reject invalid schedule intervals and dates

### DIFF
--- a/desktop/lib/browser/session/browser-session-manager.js
+++ b/desktop/lib/browser/session/browser-session-manager.js
@@ -363,7 +363,7 @@ function campusDataUrl(value, name, { optional = false } = {}) {
 
 function campusDataTimestamp(value, name, { optional = false } = {}) {
   if (optional && value == null) return null;
-  if (!Number.isSafeInteger(value) || value <= 0) {
+  if (!Number.isSafeInteger(value) || value <= 0 || !Number.isFinite(new Date(value).getTime())) {
     throw new TypeError(`${name} must be a positive millisecond timestamp`);
   }
   return value;
@@ -379,10 +379,13 @@ function campusDataItem(value, moduleId, index) {
     url: campusDataUrl(value.url, `${moduleId} item URL`, { optional: true }),
   };
   if (moduleId === 'schedule') {
+    const startsAt = campusDataTimestamp(value.startsAt, 'schedule startsAt');
+    const endsAt = campusDataTimestamp(value.endsAt, 'schedule endsAt');
+    if (endsAt <= startsAt) throw new TypeError('schedule interval must have positive duration');
     return Object.freeze({
       ...base,
-      startsAt: campusDataTimestamp(value.startsAt, 'schedule startsAt'),
-      endsAt: campusDataTimestamp(value.endsAt, 'schedule endsAt'),
+      startsAt,
+      endsAt,
       location: campusDataText(value.location, 'schedule location', { optional: true, maxLength: 120 }),
       kind: campusDataText(value.kind || 'event', 'schedule kind', { maxLength: 40 }),
     });
@@ -551,6 +554,14 @@ function portalTimestamp(value) {
   }
   const source = String(value || '').trim();
   if (!source) return null;
+  const calendar = /^(\d{4})-(\d{2})-(\d{2})(?:T|\s|$)/u.exec(source);
+  if (calendar) {
+    const [, year, month, day] = calendar.map(Number);
+    const date = new Date(0);
+    date.setUTCFullYear(year, month - 1, day);
+    if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 ||
+        date.getUTCDate() !== day) return null;
+  }
   const parsed = Date.parse(source.replace(/^(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2})/u, '$1T$2'));
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 }
@@ -623,7 +634,7 @@ function scheduleProjection(payload, context) {
       ['startsAt', 'startTime', 'startDate', 'beginTime', 'beginDate', 'fromDate']));
     const endsAt = portalTimestamp(portalScheduleField(item,
       ['endsAt', 'endTime', 'endDate', 'finishTime', 'finishDate', 'toDate']));
-    if (!title || !startsAt || !endsAt || endsAt < startsAt) {
+    if (!title || !startsAt || !endsAt || endsAt <= startsAt) {
       throw portalSourceError('PORTAL_RESPONSE_INVALID', 'calendar item schema is unsupported');
     }
     return {

--- a/desktop/lib/browser/session/browser-session-manager.js
+++ b/desktop/lib/browser/session/browser-session-manager.js
@@ -547,7 +547,7 @@ function portalScheduleField(item, names) {
   return portalField(item, names) || portalField(item?.schedule, names);
 }
 
-function portalTimestamp(value) {
+function portalTimestamp(value, localOffset = null) {
   if (Number.isFinite(value)) {
     const number = Number(value);
     return number > 10_000_000_000 ? Math.trunc(number) : Math.trunc(number * 1000);
@@ -562,7 +562,12 @@ function portalTimestamp(value) {
     if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 ||
         date.getUTCDate() !== day) return null;
   }
-  const parsed = Date.parse(source.replace(/^(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2})/u, '$1T$2'));
+  let normalized = source.replace(/^(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2})/u, '$1T$2');
+  if (localOffset && /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?)?$/u.test(normalized)) {
+    if (normalized.length === 10) normalized += 'T00:00:00';
+    normalized += localOffset;
+  }
+  const parsed = Date.parse(normalized);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 }
 
@@ -631,9 +636,9 @@ function scheduleProjection(payload, context) {
     const title = portalScheduleField(item,
       ['title', 'subject', 'name', 'summary', 'eventTitle', 'eventName']);
     const startsAt = portalTimestamp(portalScheduleField(item,
-      ['startsAt', 'startTime', 'startDate', 'beginTime', 'beginDate', 'fromDate']));
+      ['startsAt', 'startTime', 'startDate', 'beginTime', 'beginDate', 'fromDate']), '+08:00');
     const endsAt = portalTimestamp(portalScheduleField(item,
-      ['endsAt', 'endTime', 'endDate', 'finishTime', 'finishDate', 'toDate']));
+      ['endsAt', 'endTime', 'endDate', 'finishTime', 'finishDate', 'toDate']), '+08:00');
     if (!title || !startsAt || !endsAt || endsAt <= startsAt) {
       throw portalSourceError('PORTAL_RESPONSE_INVALID', 'calendar item schema is unsupported');
     }
@@ -679,12 +684,13 @@ const hkustMyPortalSources = Object.freeze({
   catalog: hkustPortalCatalogSource,
   schedule: Object.freeze({
     async read(context) {
-      const start = new Date(context.checkedAt);
-      start.setHours(0, 0, 0, 0);
-      start.setDate(start.getDate() - ((start.getDay() + 6) % 7));
-      const end = new Date(start);
-      end.setDate(end.getDate() + 7);
-      end.setMilliseconds(-1);
+      // Calendar weeks belong to the campus, independent of the host timezone.
+      const campusOffsetMs = 8 * 60 * 60 * 1000;
+      const campusDay = new Date(context.checkedAt + campusOffsetMs);
+      campusDay.setUTCHours(0, 0, 0, 0);
+      campusDay.setUTCDate(campusDay.getUTCDate() - ((campusDay.getUTCDay() + 6) % 7));
+      const start = new Date(campusDay.getTime() - campusOffsetMs);
+      const end = new Date(start.getTime() + 7 * 24 * 60 * 60 * 1000 - 1);
       const payload = await fetchPortalJsonp(context,
         '/calendar/mgr/api/hkust/calendarList.rst', {
           _p: 'YXM9MiZ0PTUmZD05NyZwPTEmZj0yMiZtPU4m',

--- a/desktop/test/unit/portal/myportal-data-runtime.test.js
+++ b/desktop/test/unit/portal/myportal-data-runtime.test.js
@@ -37,6 +37,37 @@ function headers(location = null) {
   return { get: (name) => name.toLowerCase() === 'location' ? location : null };
 }
 
+test('HKUST calendar local timestamps represent campus UTC+08 time on any host', async () => {
+  const original = process.env.TZ;
+  try {
+    for (const zone of ['UTC', 'America/Los_Angeles', 'Asia/Shanghai']) {
+      process.env.TZ = zone;
+      for (const [start, end] of [
+        ['2027-01-15 10:00:00', '2027-01-15 12:00:00'],
+        ['2027-01-15T10:00:00', '2027-01-15T12:00:00'],
+        ['2027-01-15T02:00:00Z', '2027-01-15T04:00:00Z'],
+        ['2027-01-15T03:00:00+01:00', '2027-01-15T05:00:00+01:00'],
+      ]) {
+        let requestUrl;
+        const value = await hkustMyPortalSources.schedule.read({
+          session: { fetch: async (url) => { requestUrl = new URL(url); return ({ status: 200, headers: headers(),
+            text: async () => JSON.stringify([{ title: 'Campus time fixture', startsAt: start, endsAt: end }]),
+          }); } },
+          portalUrl: 'https://myportal.hkust-gz.edu.cn/', sessionUrl: 'https://myportal.hkust-gz.edu.cn/',
+          checkedAt: Date.parse('2027-01-17T20:00:00Z'), timeoutMs: 500,
+        });
+        assert.equal(value.items[0].startsAt, Date.parse('2027-01-15T02:00:00Z'), zone);
+        assert.equal(value.items[0].endsAt, Date.parse('2027-01-15T04:00:00Z'), zone);
+        assert.equal(requestUrl.searchParams.get('fromDate'), '2027-01-17T16:00:00.000Z');
+        assert.equal(requestUrl.searchParams.get('endDate'), '2027-01-24T15:59:59.999Z');
+      }
+    }
+  } finally {
+    if (original === undefined) delete process.env.TZ;
+    else process.env.TZ = original;
+  }
+});
+
 test('schedule ingress rejects impossible and non-positive intervals before renderer projection', async () => {
   for (const [startsAt, endsAt] of [
     [1_800_000_000_000, 1_800_000_000_000],

--- a/desktop/test/unit/portal/myportal-data-runtime.test.js
+++ b/desktop/test/unit/portal/myportal-data-runtime.test.js
@@ -331,9 +331,10 @@ test('reviewed HKUST sources map bounded JSONP data without copying the page non
   assert.match(calendarUrl.href, /categoryIds=-3%2C-2%2C1%2C-4/u);
   const from = new Date(calendarUrl.searchParams.get('fromDate'));
   const through = new Date(calendarUrl.searchParams.get('endDate'));
-  assert.equal(from.getDay(), 1);
-  assert.equal(through.getDay(), 0);
-  assert.ok(through.getTime() - from.getTime() >= 6 * 86_400_000);
+  const campusWeekday = new Intl.DateTimeFormat('en', { weekday: 'short', timeZone: 'Asia/Shanghai' });
+  assert.equal(campusWeekday.format(from), 'Mon');
+  assert.equal(campusWeekday.format(through), 'Sun');
+  assert.equal(through.getTime() - from.getTime(), 7 * 86_400_000 - 1);
   assert.equal(sourceOptions.every(({ redirect, headers }) => (
     redirect === 'follow' && headers.Accept === '*/*'
   )), true);

--- a/desktop/test/unit/portal/myportal-data-runtime.test.js
+++ b/desktop/test/unit/portal/myportal-data-runtime.test.js
@@ -37,6 +37,51 @@ function headers(location = null) {
   return { get: (name) => name.toLowerCase() === 'location' ? location : null };
 }
 
+test('schedule ingress rejects impossible and non-positive intervals before renderer projection', async () => {
+  for (const [startsAt, endsAt] of [
+    [1_800_000_000_000, 1_800_000_000_000],
+    [1_800_000_000_001, 1_800_000_000_000],
+    [8_640_000_000_000_001, 8_640_000_000_000_002],
+  ]) {
+    const fixture = runtime({
+      response: { status: 200, url: 'https://myportal.hkust-gz.edu.cn/', headers: headers() },
+      source: { schedule: { read: async () => ({
+        state: 'ready', source: 'fixture', fetchedAt: 1_800_000_000_000, stale: false,
+        items: [{ id: 'invalid-event', title: 'Invalid fixture', startsAt, endsAt }],
+      }) } },
+    });
+    const snapshot = await fixture.subject.snapshot();
+    assert.equal(snapshot.modules.schedule.state, 'failed');
+    assert.deepEqual(snapshot.modules.schedule.items, []);
+    assert.equal(snapshot.sessionState, 'authenticated');
+    assert.equal(snapshot.modules.loans.state, 'source-unavailable');
+  }
+});
+
+test('reviewed calendar adapter rejects zero-length events instead of reporting ready', async () => {
+  await assert.rejects(hkustMyPortalSources.schedule.read({
+    session: { fetch: async () => ({ status: 200, headers: headers(),
+      text: async () => JSON.stringify([{ title: 'Invalid fixture',
+        startsAt: 1_800_000_000_000, endsAt: 1_800_000_000_000 }]),
+    }) },
+    portalUrl: 'https://myportal.hkust-gz.edu.cn/',
+    sessionUrl: 'https://myportal.hkust-gz.edu.cn/',
+    checkedAt: 1_800_000_000_000, timeoutMs: 500,
+  }), { code: 'PORTAL_RESPONSE_INVALID' });
+});
+
+test('calendar adapter rejects impossible calendar dates instead of rolling into another month', async () => {
+  await assert.rejects(hkustMyPortalSources.schedule.read({
+    session: { fetch: async () => ({ status: 200, headers: headers(),
+      text: async () => JSON.stringify([{ title: 'Invalid date fixture',
+        startsAt: '2027-02-30 10:00:00', endsAt: '2027-02-30 12:00:00' }]),
+    }) },
+    portalUrl: 'https://myportal.hkust-gz.edu.cn/',
+    sessionUrl: 'https://myportal.hkust-gz.edu.cn/',
+    checkedAt: 1_800_000_000_000, timeoutMs: 500,
+  }), { code: 'PORTAL_RESPONSE_INVALID' });
+});
+
 test('myPortal redirect produces an honest signed-out snapshot without reading APIs', async () => {
   let sourceReads = 0;
   const fixture = runtime({


### PR DESCRIPTION
Rejects invalid schedule intervals at the data boundary instead of publishing a ready module whose entries the Renderer silently drops. Zero-length or reversed intervals and timestamps outside JavaScript's Date range produce an isolated failed schedule module. The portal adapter also rejects impossible YYYY-MM-DD dates instead of allowing Date.parse to roll them into another month.

Regressions reproduced the previous behavior and now pass. HKUST schedule timestamps without an offset and the calendar query week now use campus UTC+08:00 instead of the host timezone. Explicit offsets remain authoritative. Fixtures under UTC, America/Los_Angeles and Asia/Shanghai verify identical instants and query boundaries, including when the campus has reached Monday while the host is still on Sunday. Other sources retain their previous timezone behavior.

Existing valid event mapping, session isolation and daily caching remain covered. No changes to credentials, Profile ownership or persistence. This behavior change is independent of the Renderer clock and calendar-layout PRs. Revert this PR to restore the previous parser behavior; no migration is needed. Renderer timezone presentation still needs a separate contract; live-campus verification has not been performed.

Local full Desktop suite after the timezone fix: 1242 tests, 1237 passed, 5 platform skips, zero failures. Architecture, staged secret and changed production-file syntax checks passed; the dependency install-script gate passed in the preceding validation. No merge, release or real-campus testing requested.
