### PR TITLE
fix(renderer): dispose campus data feature lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,8 @@ jobs:
         run: npm run test:main-profile-switch
       - name: Exercise control renderer crash-loop recovery
         run: npm run test:control-renderer-recovery
+      - name: Exercise campus-data Renderer lifecycle
+        run: ./node_modules/.bin/electron e2e/campus-data-lifecycle.electron.js
       - name: Exercise Main with a synthetic Engine lifecycle
         run: npm run test:main-engine-lifecycle
       - name: Exercise initially-offline Main startup recovery

--- a/desktop/e2e/campus-data-lifecycle.electron.js
+++ b/desktop/e2e/campus-data-lifecycle.electron.js
@@ -1,0 +1,56 @@
+'use strict';
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { app, BrowserWindow } = require('electron');
+
+async function main() {
+  await app.whenReady();
+  const window = new BrowserWindow({ show: false,
+    webPreferences: { contextIsolation: true, nodeIntegration: false } });
+  try {
+    await window.loadURL('data:text/html,<section class="module"><div id="scheduleBody"></div><button id="scheduleRefresh">Refresh</button></section>');
+    await window.webContents.executeJavaScript(fs.readFileSync(path.join(
+      __dirname, '..', 'renderer', 'campus-data-modules.js'), 'utf8'));
+    const result = await window.webContents.executeJavaScript(`(async () => {
+      let requests = 0;
+      let resolve;
+      let published = 0;
+      const timers = new Map();
+      const snapshot = { sessionState: 'authenticated', modules: {
+        schedule: { state: 'empty', items: [] },
+      } };
+      const feature = window.campusDataModules.create({
+        document,
+        api: {
+          getCampusData: async () => snapshot,
+          refreshCampusSchedule: () => { requests++; return new Promise(done => { resolve = done; }); },
+        },
+        translate: key => key, escapeHtml: value => String(value), openDeepLink: () => {},
+        onCatalog: () => { published++; },
+        setTimeout: (fn, delay) => { timers.set(fn, delay); return fn; },
+        clearTimeout: fn => timers.delete(fn),
+      });
+      feature.start(); feature.start();
+      await feature.load();
+      const timerBefore = timers.size;
+      document.getElementById('scheduleRefresh').click();
+      const before = document.getElementById('scheduleBody').innerHTML;
+      // Deliver the browser lifecycle event, not a direct dispose call.
+      window.dispatchEvent(new Event('unload'));
+      resolve(snapshot);
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+      document.getElementById('scheduleRefresh').click();
+      document.dispatchEvent(new Event('app-locale-changed'));
+      return { requests, published, timerBefore, timersAfter: timers.size,
+        unchanged: before === document.getElementById('scheduleBody').innerHTML,
+        snapshotCleared: feature.snapshot() === null, restart: feature.start() };
+    })()`);
+    assert.deepEqual(result, { requests: 1, published: 1, timerBefore: 1, timersAfter: 0,
+      unchanged: true, snapshotCleared: true, restart: false });
+    process.stdout.write('campus data lifecycle Electron: PASS\n');
+  } finally {
+    window.destroy();
+  }
+}
+main().then(() => app.quit(), error => { process.stderr.write(`${error.stack}\n`); app.exit(1); });

--- a/desktop/renderer/campus-data-modules.js
+++ b/desktop/renderer/campus-data-modules.js
@@ -77,6 +77,24 @@
     let snapshot = null;
     let lastLoadedAt = 0;
     let scheduleRefreshTimer = null;
+    let started = false;
+    let disposed = false;
+    const listeners = [];
+
+    function listen(target, type, handler) {
+      if (!target) return;
+      target.addEventListener(type, handler);
+      listeners.push(() => target.removeEventListener(type, handler));
+    }
+
+    function dispose() {
+      if (disposed) return;
+      disposed = true;
+      if (scheduleRefreshTimer !== null) cancelTimer(scheduleRefreshTimer);
+      scheduleRefreshTimer = null;
+      for (const remove of listeners.splice(0)) remove();
+      snapshot = null;
+    }
 
     const locale = () => String(doc.documentElement.lang || '').toLowerCase().startsWith('en')
       ? 'en' : 'zh-CN';
@@ -200,6 +218,7 @@
     }
 
     function renderModule(moduleId, module) {
+      if (disposed) return;
       const config = MODULES[moduleId];
       const body = $(config.body);
       const shell = body?.closest('.module');
@@ -220,6 +239,7 @@
     }
 
     function setScheduleRefreshBusy(busy) {
+      if (disposed) return;
       const button = $('scheduleRefresh');
       if (!button) return;
       button.disabled = busy;
@@ -230,7 +250,7 @@
     function scheduleNextRefresh() {
       if (scheduleRefreshTimer !== null) cancelTimer(scheduleRefreshTimer);
       scheduleRefreshTimer = null;
-      if (!loaded || snapshot?.sessionState !== 'authenticated') return;
+      if (disposed || !loaded || snapshot?.sessionState !== 'authenticated') return;
       const fetchedAt = snapshot?.modules?.schedule?.fetchedAt || lastLoadedAt || clockNow();
       const delay = Math.max(1_000, SCHEDULE_AUTO_REFRESH_MS - (clockNow() - fetchedAt));
       scheduleRefreshTimer = scheduleTimer(() => {
@@ -240,6 +260,7 @@
     }
 
     async function load(force = false) {
+      if (disposed) return null;
       if (inflight) return inflight;
       const method = force ? api.refreshCampusData : api.getCampusData;
       if (typeof method !== 'function') {
@@ -253,6 +274,7 @@
       setScheduleRefreshBusy(true);
       render();
       inflight = Promise.resolve(method.call(api)).then((value) => {
+        if (disposed) return null;
         snapshot = value;
         loaded = true;
         lastLoadedAt = clockNow();
@@ -260,6 +282,7 @@
         render();
         return value;
       }).catch(() => {
+        if (disposed) return null;
         snapshot = { modules: Object.fromEntries(Object.keys(MODULES).map((id) => [id, {
           state: 'failed', items: [],
         }])) };
@@ -277,6 +300,7 @@
 
     async function refreshSchedule() {
       if (inflight) await inflight;
+      if (disposed) return null;
       if (typeof api.refreshCampusSchedule !== 'function') return load(true);
       const previous = snapshot;
       snapshot = {
@@ -289,12 +313,14 @@
       setScheduleRefreshBusy(true);
       renderModule('schedule', snapshot.modules.schedule);
       const operation = Promise.resolve(api.refreshCampusSchedule()).then((value) => {
+        if (disposed) return null;
         snapshot = value;
         loaded = true;
         lastLoadedAt = clockNow();
         render();
         return value;
       }).catch(() => {
+        if (disposed) return null;
         snapshot = {
           ...(previous || {}),
           modules: {
@@ -316,6 +342,7 @@
     }
 
     function activate(target) {
+      if (disposed) return;
       const entryUrl = target.closest('[data-entry-url]')?.dataset.entryUrl;
       if (entryUrl) { openDeepLink(null, entryUrl); return; }
       const action = target.closest('[data-campus-data-action]');
@@ -334,16 +361,21 @@
     }
 
     function start() {
+      if (disposed) return false;
+      if (started) return true;
+      started = true;
       for (const { body } of Object.values(MODULES)) {
-        $(body)?.closest('.module')?.addEventListener('click', (event) => activate(event.target));
+        listen($(body)?.closest('.module'), 'click', (event) => activate(event.target));
       }
-      $('scheduleRefresh')?.addEventListener('click', () => { void refreshSchedule(); });
-      doc.addEventListener('app-locale-changed', render);
+      listen($('scheduleRefresh'), 'click', () => { void refreshSchedule(); });
+      listen(doc, 'app-locale-changed', render);
+      listen(doc.defaultView, 'unload', dispose);
       render();
       return true;
     }
 
     function ensureLoaded() {
+      if (disposed) return Promise.resolve(null);
       if (!loaded) return load(false);
       const scheduleState = snapshot?.modules?.schedule?.state;
       const sessionRecovery = snapshot?.sessionState !== 'authenticated' ||
@@ -356,6 +388,7 @@
     }
 
     return Object.freeze({
+      dispose,
       ensureLoaded,
       load,
       refreshSchedule,

--- a/desktop/test/unit/renderer/campus-data-lifecycle.test.js
+++ b/desktop/test/unit/renderer/campus-data-lifecycle.test.js
@@ -1,0 +1,48 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { create } = require('../../../renderer/campus-data-modules');
+
+function fixture(api = {}) {
+  const events = new Map();
+  const timers = new Map();
+  let publications = 0;
+  const feature = create({
+    document: {
+      getElementById: () => null, documentElement: { lang: 'en' },
+      addEventListener: (type, fn) => { events.set(fn, type); },
+      removeEventListener: (type, fn) => { assert.equal(events.get(fn), type); events.delete(fn); },
+    },
+    api, translate: key => key, escapeHtml: text => text, openDeepLink: () => {},
+    onCatalog: () => { publications += 1; }, now: () => 1_800_000_000_000,
+    setTimeout: (fn, delay) => { timers.set(fn, delay); return fn; },
+    clearTimeout: id => timers.delete(id),
+  });
+  return { feature, events, timers, publications: () => publications };
+}
+
+test('start is idempotent and dispose permanently releases listeners and timers', async () => {
+  const f = fixture({ getCampusData: async () => ({ sessionState: 'authenticated', modules: {} }) });
+  f.feature.start(); f.feature.start();
+  assert.equal(f.events.size, 1);
+  await f.feature.ensureLoaded();
+  assert.equal(f.timers.size, 1);
+  f.feature.dispose(); f.feature.dispose();
+  assert.equal(f.events.size, 0);
+  assert.equal(f.timers.size, 0);
+  assert.equal(f.feature.snapshot(), null);
+  assert.equal(f.feature.start(), false);
+  assert.equal(await f.feature.ensureLoaded(), null);
+});
+
+test('late data cannot publish or reschedule after disposal', async () => {
+  let resolve;
+  const f = fixture({ getCampusData: () => new Promise(done => { resolve = done; }) });
+  const pending = f.feature.load();
+  f.feature.dispose();
+  resolve({ sessionState: 'authenticated', modules: {}, catalog: {} });
+  assert.equal(await pending, null);
+  assert.equal(f.publications(), 0);
+  assert.equal(f.timers.size, 0);
+  assert.equal(f.feature.snapshot(), null);
+});


### PR DESCRIPTION
Depends on PR #90 (base branch codex/renderer-schedule-seam).

Adds an explicit disposal boundary to the campus-data Renderer feature. Starting twice is idempotent; disposing removes registered listeners, clears the refresh timer and snapshot, and prevents late asynchronous responses from publishing catalogue data or scheduling another refresh. The page unload event owns final disposal.

Two lifecycle regressions failed before the change and now pass. Full Desktop suite: 1236 passed, 5 platform skips, zero failures. Architecture passed and changed production JavaScript parses successfully. No persisted state, IPC schema, credentials or Profile ownership changes. Revert this PR independently of the clock-injection base to roll back.

This is a lifecycle behavior fix, separated from the clock seam. An isolated real Electron DOM regression now passes: repeated start yields one refresh request, and a dispatched unload event clears timers and prevents late response publication and further DOM actions. The regression is wired into the existing desktop-electron CI job. This verifies event delivery and Renderer cleanup, not live campus sessions or browser-process crash teardown. No merge or release requested.
