### PR TITLE
fix(ui): compact connection metrics at narrow widths

### DIFF
--- a/desktop/e2e/control-shell-layout.electron.js
+++ b/desktop/e2e/control-shell-layout.electron.js
@@ -495,6 +495,27 @@ async function main() {
           `${label}: connection page unexpectedly requires scrolling`);
       }
       await capture(window, output, `${label}-connect`);
+      if (width === 440) {
+        const metrics = await window.webContents.executeJavaScript(`(() => {
+          const ip = document.getElementById('stIp');
+          const previous = ip.textContent;
+          ip.textContent = '255.255.255.255';
+          const cards = [...document.querySelectorAll('#statGrid .connection-metric')];
+          const rectangles = cards.map(el => {
+            const rect = el.getBoundingClientRect();
+            return { top: rect.top, bottom: rect.bottom, left: rect.left, right: rect.right };
+          });
+          const overflow = document.documentElement.scrollWidth - innerWidth;
+          const ipContained = ip.getBoundingClientRect().right <= rectangles[0].right;
+          ip.textContent = previous;
+          return { rectangles, overflow, ipContained };
+        })()`);
+        const [ip, latency, exit] = metrics.rectangles;
+        assert.equal(ip.top, latency.top, 'compact IP and latency must share one row');
+        assert.ok(exit.top >= Math.max(ip.bottom, latency.bottom));
+        assert.ok(Math.abs(exit.left - ip.left) <= 1 && Math.abs(exit.right - latency.right) <= 1);
+        assert.ok(metrics.overflow <= 0 && metrics.ipContained, 'long IP must stay contained');
+      }
 
       const browser = await shellSnapshot(window, 'browser');
       assert.equal(browser.workspaceTitle, '校园工作台', `${label}: the workspace title changed`);

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -1990,7 +1990,11 @@ button.week-event:hover { border-color: #86a9d3; background: #dceafa; }
   .network-tree-root-wrap::after { top: auto; right: auto; bottom: 0; left: 24px; width: 0; height: 16px; border-top: 0; border-left: 2px solid var(--tree-line); }
   .network-tree-compact > .network-underlay-branch::before { top: -16px; left: 24px; width: 0; height: 16px; border-top: 0; border-left: 2px solid var(--tree-line); }
   .connection-detail-grid { grid-template-columns: 1fr; }
-  .connection-metrics { grid-template-columns: 1fr; }
+  .page[data-page="connect"] .connection-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .page[data-page="connect"] .connection-metric { min-width: 0; }
+  .page[data-page="connect"] .exit-metric { grid-column: 1 / -1; }
+  .page[data-page="connect"] .metric-label,
+  .page[data-page="connect"] .metric-hint { overflow-wrap: anywhere; }
   .category-stack-grid[data-stack-columns="1"] .category-site-list { column-gap: 10px; }
   .notification-backdrop { left: 64px; }
   .notification-drawer { width: calc(100vw - 64px); }


### PR DESCRIPTION
At narrow window widths, show campus IP and gateway latency side by side while keeping the longer network-exit information full width. This removes one metric row from the 440px connection page and brings network controls higher into view.

Scoped CSS only on the connection page. No connection, routing, credential or storage behavior changes. Real Electron layout tests passed at 440/820/1024/1280/1440px, including a full IPv4 containment test; the 440px screenshot was visually inspected. Twenty-one relevant renderer/design contracts and the architecture check passed. A source-only revert restores the old layout.

Independent of the schedule and Renderer lifecycle PRs. No merge or release requested.
