### PR TITLE
test(windows): reproduce native configuration export workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,8 @@ jobs:
           test/windows-platform-smoke.test.js
       - name: Verify current-user-only helper credential DACL
         run: node --test test/unit/integrations/external-proxy-config.test.js
+      - name: Verify native configuration export roundtrip
+        run: node --test test/unit/integrations/native-export-roundtrip.test.js
 
   engine:
     timeout-minutes: 20

--- a/desktop/test/unit/integrations/native-export-roundtrip.test.js
+++ b/desktop/test/unit/integrations/native-export-roundtrip.test.js
@@ -1,0 +1,61 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { createIntegrationCenterRuntime } = require('../../../lib/integrations/integration-center-runtime');
+const { createIntegrationBinding } = require('../../../lib/integrations/integration-schema');
+const { createProfileNetworkRules } = require('../../../lib/integrations/profile-network-rules');
+const { ensureProxyCredentialSidecar } = require('../../../lib/integrations/external-proxy-config');
+const { validateGenericExportPayload } = require('../../../lib/integrations/generic-export-adapters');
+const { verifyWindowsFileOwnerOnly } = require('../../../lib/platform/storage/windows-private-file');
+const profile = require('../../../assets/profiles/hkustgz/school-profile.json');
+
+test('native export roundtrip supports spaced Unicode paths for YAML and SSH', async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-export-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const directory = path.join(root, '学生 config');
+  fs.mkdirSync(directory, { mode: 0o700 });
+  const credentialFile = path.join(directory, 'proxy-credential');
+  const target = path.join(directory, '校园配置.yaml');
+  const helper = path.join(directory, `ec-proxy-command${process.platform === 'win32' ? '.exe' : ''}`);
+  const rules = createProfileNetworkRules({ profileDocument: profile });
+  const credential = { withStrings: fn => fn('A'.repeat(32), 'B'.repeat(32)) };
+  let copied = '';
+  const runtime = createIntegrationCenterRuntime({
+    helperPath: helper, credentialFile,
+    selectTarget: async () => target,
+    ensureSidecar: () => ensureProxyCredentialSidecar({ filePath: credentialFile, port: 6180,
+      credential, profileId: 'hkustgz' }),
+    writeClipboard: text => { copied = text; return true; },
+    getContext: adapterId => ({ networkRules: rules, port: 6180, credential,
+      bindingFor: () => createIntegrationBinding({
+        adapterId, adapterVersion: 1, recordRevision: 1,
+        profileId: rules.profileId, profileRevision: rules.profileRevision,
+        profileCredentialBindingRevision: rules.profileCredentialBindingRevision,
+        accountKey: `account-${'a'.repeat(32)}`, accountRevision: 1, accountCredentialRevision: 1,
+        workspaceKey: `workspace-${'b'.repeat(32)}`, activeContextEpoch: 1,
+        listenerKind: 'socks5-optional-authentication', loopbackHost: '127.0.0.1', loopbackPort: 6180,
+        proxySecurityRevision: 3, credentialRef: `credential-${'c'.repeat(32)}`,
+        networkRulesDigest: rules.rulesDigest, pacDigest: 'd'.repeat(64), engineGeneration: 1,
+      }),
+    }),
+  });
+  for (const [adapterId, action] of [['clash_mihomo_yaml', 'copy'], ['clash_mihomo_yaml', 'save'],
+    ['vscode_remote_ssh', 'copy']]) {
+    const preview = await runtime.prepare({ adapterId, action });
+    const result = await runtime.confirm({ confirmationHandle: preview.confirmationHandle });
+    assert.equal(result.ok, true, `${adapterId}/${action}`);
+    const payload = action === 'save' ? fs.readFileSync(target) : Buffer.from(copied);
+    assert.equal(validateGenericExportPayload(adapterId, payload), true);
+    if (adapterId === 'vscode_remote_ssh') {
+      assert.ok(fs.existsSync(credentialFile));
+      assert.ok(!copied.includes('B'.repeat(32)));
+    }
+  }
+  if (process.platform === 'win32') {
+    assert.equal(verifyWindowsFileOwnerOnly(target), true);
+    assert.equal(verifyWindowsFileOwnerOnly(credentialFile), true);
+  }
+});


### PR DESCRIPTION
Adds the missing native configuration export regression for Windows reports. It exercises prepare and confirm for YAML copy/save and SSH-template copy, using paths with spaces and Chinese characters and the real atomic writer/credential-sidecar owner. Windows verifies actual owner-only ACLs for both output files. Clipboard is a local capture stub; Electron clipboard/dialog behavior is not covered yet.

Local native test passes on macOS. Windows CI is the next evidence gate; this PR does not yet claim the reported failure is fixed. The Remote-SSH binary-stream buffering defect is separately fixed and tested on Windows in PR #88.

Tests and CI wiring only, no runtime behavior changes or credentials from users. No merge or release requested.
