### PR TITLE
fix(windows): resolve login freeze and prepare 2.0.1 packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
         if: matrix.platform == 'linux'
         run: node build/verify-package.js release/linux-unpacked/resources linux x64
 
+      - name: Build Windows private-file helper
+        if: matrix.platform == 'windows'
+        run: npm run build:windows-private-file
+
       - name: Build unpacked Windows application
         if: matrix.platform == 'windows'
         run: node node_modules/electron-builder/out/cli/cli.js --win dir --x64 --publish never

--- a/RELEASE_NOTES_2.0.1.md
+++ b/RELEASE_NOTES_2.0.1.md
@@ -1,32 +1,30 @@
 # HKUST(GZ) Connect 2.0.1
 
-HKUST(GZ) Connect 2.0.1 is a repository-ownership migration bridge. It preserves the 2.0.0
-connection, Campus Browser, myPortal, MFA and workspace behavior while making future update checks
-survive a GitHub Organization transfer.
+- Status: release candidate; publish only with matching verified artifacts
+- Owner: HKUST(GZ) Connect maintainers
+- Last verified: 2026-09-07
+- Applicability: Windows x64, Linux x86_64, macOS arm64/x64
 
-## 主要更新
+## Windows 登录页卡顿修复（#97）
 
-- 更新检查不再把可变的 GitHub `owner/repository` 当作仓库身份。
-- 客户端先查询 HKUST-GZ-Connect 不变的 GitHub repository ID，再严格验证仓库 ID、名称、
-  当前 owner、API URL、Web URL 和 Release 模板。
-- 仓库转入 Organization 后，客户端可自动发现新 owner 的正式 Release 页面，无需放宽到
-  任意 GitHub 仓库或任意外部链接。
-- ID、仓库名、owner、主机、路径或 Release URL 不匹配时继续 fail-closed。
-- 本补丁不修改校园网关协议、凭据/MFA 处理、路由、DNS、SOCKS、用户数据结构或 GUI。
+2.0.0 在 Windows 上反复同步启动 PowerShell 检查持久化文件权限。设置、账号显示状态、收藏和分组的刷新重复读取文件，阻塞 Electron 主进程，表现为登录页长时间转圈、输入和按钮迟迟没有响应。
 
-## 安全与兼容性
+- 展示刷新复用已验证的设置、收藏、最近访问和分组快照；写入后失效并刷新缓存。连接时读取凭据、持久化写入和显式刷新仍通过实际存储权限与归属校验。
+- Windows 安装包包含小型原生权限组件，通过 Win32 文件句柄检查和设置当前用户专属 DACL，避免启动时重复加载 PowerShell。组件拒绝目录、重解析点和硬链接；收紧旧文件权限前检查归属，拒绝后不会转用另一实现放行。
 
-- 固定 repository ID 为 GitHub 当前公开记录的 `1279507615`；仓库转移不改变该身份。
-- 只接受 GitHub API 返回且与该 ID 完整一致的当前 owner 和 Release 前缀。
-- 更新功能仍然只提示并打开 Release 页面，不静默下载、安装或执行文件。
-- 升级保留设置、收藏、校园浏览器数据和已安全保存的凭据。
+5070 Windows 合成工作区复测中，主窗口启动约从 17 秒降至 1.8 秒；连续状态查询没有启动权限子进程，登录输入框可编辑。耗时取决于设备和工作区，并非对所有电脑的性能承诺。
 
-## 安装与签名说明
+## 更新渠道与依赖
 
-- macOS DMG 使用包体校验和 ad-hoc 签名，尚未 Developer ID 公证；首次启动可能需要在
-  Finder 中右键应用并选择“打开”。
-- Windows 安装器尚未配置 Authenticode 发布者证书，SmartScreen 可能提示未知发布者。
-- GitHub Release 为每个附件公布 SHA-256 摘要，可在安装前核对完整性。
+- 保留 main 已合入的更新渠道修复：通过不可变 GitHub repository ID 发现当前 owner，并验证规范 API 和 Release URL，支持后续仓库转移。
+- 包含 main 中的 Rust 依赖安全更新（包括 time 0.3.47）。
+- 不改变校园网关协议、MFA 能力、路由策略或用户数据格式。
+
+## 升级与验证
+
+保留设置、收藏、分组、校园浏览器数据和安全保存的凭据。Windows/Linux 验收在 5070 完成，使用临时合成工作区；未使用真实校园账号。回归覆盖登录响应、1.2.3 数据迁移、学校新增/切换、网络恢复、浏览器路由/MFA/布局、渲染器恢复、空闲性能和原生权限边界。
+
+旧版迁移测试先让独立写入进程正常退出，再启动新版，覆盖 Windows 加密配置的实际落盘与重新加载。macOS 只构建和校验安装包，本次未重新执行 macOS 功能测试。附件源码提交、签名状态和 SHA-256 以 Release 构建收据为准。
 
 ## Downloads
 
@@ -37,7 +35,4 @@ survive a GitHub Organization transfer.
 
 ## English summary
 
-Version 2.0.1 resolves the repository's current owner through its immutable GitHub repository ID,
-validates the complete canonical API and web identity, and accepts only that repository's Release
-pages. This lets update checks survive an ownership transfer without trusting arbitrary redirects or
-repositories. Runtime networking, MFA, routing, persistence and GUI behavior are unchanged.
+Fixes the Windows login freeze caused by repeated synchronous PowerShell ACL checks. Display updates reuse validated snapshots, invalidated after mutations. A bundled Win32 helper checks and applies private permissions without PowerShell startup, preserving current-user ownership and rejecting reparse points and hardlinks. Credential access and writes still validate storage authority. Includes repository-transfer-aware update discovery and Rust dependency security updates. Windows/Linux acceptance runs on 5070; macOS receives package builds and verification only. Release receipts record artifact provenance and signing status.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,18 @@
 # 发布流程 / Release Process
 
 本文档记录 HKUST(GZ) Connect 当前的实际发布流程。发布构建完全由
-GitHub Actions 云端完成；本地脚本只用于开发自测。
+GitHub Actions 云端完成；本地脚本通常用于开发自测。2.0.1 的维护者授权例外见下文。
 
 [中文](#中文) · [English](#english)
+
+## 2.0.1 指定主机构建 / designated-host build
+
+维护者于 2026-09-07 指定：Windows/Linux 验收和打包只在 5070 运行，macOS 只在 Mac 构建并校验安装包。此版本使用同一源码提交的手动构建收据和 SHA-256 清单，不把本地结果冒充 GitHub Actions 检查，也不改变 main 分支保护。
+
+Windows 新增 `npm run build:windows-private-file`，需要 Windows x64 Visual C++ 或 GCC 编译器。`npm run test:windows` 和 `npm run dist:win` 自动先构建此组件。直接调用 electron-builder 也必须先构建；包校验拒绝缺失组件的 Windows 包。C 源码位于 `desktop/lib/platform/storage/native/`，不进入 app.asar。
+
+For 2.0.1, the maintainer designated 5070 for Windows/Linux tests and packaging and a Mac for macOS builds and package verification only. Record one source commit, native package verification, actual signing state and artifact hashes. Local receipts do not impersonate required Actions checks or alter branch protection. Build the Windows private-file helper before invoking electron-builder directly.
+
 
 ---
 

--- a/desktop/build/afterPack.js
+++ b/desktop/build/afterPack.js
@@ -127,6 +127,13 @@ exports.default = async function afterPack(context) {
   const gatewayProbePath = assertGatewayProbePresent(
     packagedEngineDirectory, context.electronPlatformName, context.arch,
   );
+  if (context.electronPlatformName === 'win32') {
+    const helper = path.join(packagedEngineDirectory,
+      'ec-private-file-windows-' + architectureName(context.arch) + '.exe');
+    if (!fs.existsSync(helper) || !fs.statSync(helper).isFile() || fs.statSync(helper).size === 0) {
+      throw new Error('missing packaged Windows private-file helper: ' + helper);
+    }
+  }
   assertPackagedSchoolProfiles(path.join(resourcesDir, 'app.asar'), packagedEngineDirectory);
   if (context.electronPlatformName !== 'darwin') return;
   assertMacAppIcon(appPath);

--- a/desktop/build/verify-package.js
+++ b/desktop/build/verify-package.js
@@ -544,15 +544,19 @@ function verifyPackage({ resourcesArgument, platform = process.platform, archite
   const engine = path.join(resources, 'engine', engineName);
   const proxyCommand = path.join(resources, 'engine', proxyCommandName);
   const gatewayProbe = path.join(resources, 'engine', gatewayProbeName);
+  const privateFileName = 'ec-private-file-windows-' + architectureName + '.exe';
+  const privateFile = path.join(resources, 'engine', privateFileName);
   const packagedProfiles = assertPackagedSchoolProfiles(archive, path.join(resources, 'engine'));
   assertExactNativeResources(path.join(resources, 'engine'), [
     engineName,
     proxyCommandName,
     gatewayProbeName,
+    ...(platformName === 'windows' ? [privateFileName] : []),
     ...packagedProfiles.map(({ profileId }) => `${profileId}.json`),
   ]);
   for (const [label, executable] of [
     ['engine', engine], ['SSH proxy helper', proxyCommand], ['Gateway probe', gatewayProbe],
+    ...(platformName === 'windows' ? [['private-file helper', privateFile]] : []),
   ]) {
     if (!fs.existsSync(executable) || !fs.statSync(executable).isFile() || fs.statSync(executable).size === 0) {
       throw new Error(`missing packaged ${label}: ${executable}`);
@@ -560,7 +564,7 @@ function verifyPackage({ resourcesArgument, platform = process.platform, archite
   }
   assertNoTestOnlyEngineMarker(engine);
   if (platformName === 'windows') {
-    for (const executable of [engine, proxyCommand, gatewayProbe]) {
+    for (const executable of [engine, proxyCommand, gatewayProbe, privateFile]) {
       const header = fs.readFileSync(executable);
       const peOffset = header.length >= 0x40 ? header.readUInt32LE(0x3c) : -1;
       const signature = peOffset >= 0 && peOffset + 6 <= header.length

--- a/desktop/e2e/campus-browser-toolbar.electron.js
+++ b/desktop/e2e/campus-browser-toolbar.electron.js
@@ -231,7 +231,8 @@ async function assertSettingsButton(browser, settingsOpens) {
 
 async function assertRouteSwitch(browser) {
   await waitForMain(
-    () => browser.activeTab()?.failedUrl === DEAD_URL,
+    () => browser.activeTab()?.failedUrl === DEAD_URL &&
+      !browser.activeTab().view.webContents.isLoading(),
     'initial tab to settle on its error page',
   );
   assert.equal(browser.activeTab().route, 'campus');

--- a/desktop/e2e/campus-workspace-layout.electron.js
+++ b/desktop/e2e/campus-workspace-layout.electron.js
@@ -124,11 +124,12 @@ async function main() {
     cardBoardDocument = { ...next, revision: cardBoardDocument.revision + 1 };
     return { document: cardBoardDocument, changed: true };
   });
+  // These hidden fixtures measure foreground animation timing, not background throttling.
   const window = new BrowserWindow({
-    width: 1040, height: 740, show: false, backgroundColor: '#f4f7fb',
+    width: 1040, height: 740, show: true, backgroundColor: '#f4f7fb',
     webPreferences: {
       preload: path.join(__dirname, '..', 'lib', 'browser', 'workspace', 'campus-workspace-preload.js'),
-      sandbox: true, contextIsolation: true, nodeIntegration: false,
+      sandbox: true, contextIsolation: true, nodeIntegration: false, backgroundThrottling: false,
     },
   });
   const controller = new CampusWorkspaceController({

--- a/desktop/e2e/control-shell-layout.electron.js
+++ b/desktop/e2e/control-shell-layout.electron.js
@@ -459,11 +459,12 @@ async function main() {
       __dirname, '..', 'assets', 'profiles', 'hkustgz', 'builtin-service-desk.json',
     ), 'utf8');
   }
+  // These hidden fixtures measure foreground animation timing, not background throttling.
   const window = new BrowserWindow({
-    show: false,
+    show: true,
     width: preview ? 1024 : 480,
     height: preview ? 576 : 854,
-    webPreferences: { contextIsolation: true, nodeIntegration: false, preload } });
+    webPreferences: { contextIsolation: true, nodeIntegration: false, preload, backgroundThrottling: false } });
   try {
     await window.loadFile(renderer);
     await window.webContents.executeJavaScript("new Promise((resolve) => { const done = () => document.getElementById('dash').hidden ? setTimeout(done, 20) : resolve(); done(); })");

--- a/desktop/e2e/login-responsive.electron.js
+++ b/desktop/e2e/login-responsive.electron.js
@@ -1,0 +1,89 @@
+'use strict';
+
+// Issue #97: exercise the real control renderer against Main using a synthetic
+// workspace. Count synchronous ACL subprocesses, not machine-specific timings.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const childProcess = require('node:child_process');
+const { performance } = require('node:perf_hooks');
+const { app, BrowserWindow } = require('electron');
+
+let aclCalls = 0;
+const execute = childProcess.execFileSync;
+childProcess.execFileSync = function (file, ...args) {
+  if (/^(?:powershell\.exe|ec-private-file-windows-.*\.exe)$/iu.test(path.basename(String(file)))) aclCalls += 1;
+  return execute.call(this, file, ...args);
+};
+
+const profile = fs.mkdtempSync(path.join(os.tmpdir(), 'hkustgz-login-responsive-'));
+process.env.HKUSTGZ_USER_DATA_DIR = profile;
+app.setPath('userData', profile);
+app.disableHardwareAcceleration();
+const { saveSettings } = require('../lib/persistence/settings/settings-store');
+const { ProfileWorkspaceStartupRuntime } = require('../lib/persistence/runtime/profile-workspace-startup-runtime');
+saveSettings(path.join(profile, 'settings.json'), { autoConnect: false });
+const schoolProfile = JSON.parse(fs.readFileSync(
+  path.join(__dirname, '..', 'assets', 'profiles', 'hkustgz', 'school-profile.json'), 'utf8',
+));
+const persistence = new ProfileWorkspaceStartupRuntime({
+  userData: profile, profile: schoolProfile, safeStorage: {},
+}).initialize();
+assert.equal(persistence.mode, 'profile-workspace');
+const { FavoriteGroupStore } = require('../lib/resources/runtime/favorite-group-store');
+new FavoriteGroupStore({
+  filePath: path.join(path.dirname(persistence.paths.resourceFavorites), 'favorite-groups.json'),
+}).create('Synthetic collection');
+
+const started = performance.now();
+require('../main');
+
+async function run() {
+  await app.whenReady();
+  const deadline = Date.now() + 30_000;
+  let control;
+  while (Date.now() < deadline) {
+    control = BrowserWindow.getAllWindows().find((window) =>
+      window.webContents.getURL().endsWith('/renderer/index.html') &&
+      !window.webContents.isLoading());
+    if (control) break;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  assert.ok(control, 'the login control window must become ready');
+  const startupMs = Math.round(performance.now() - started);
+  const before = aclCalls;
+  const responseStarted = performance.now();
+  for (let index = 0; index < 5; index += 1) {
+    const state = await control.webContents.executeJavaScript('window.api.getState()');
+    assert.equal(state.connected, false);
+    assert.equal(state.settings.autoConnect, false);
+  }
+  const responseMs = Math.round(performance.now() - responseStarted);
+  const pollingAclCalls = aclCalls - before;
+  const editable = await control.webContents.executeJavaScript(`(() => {
+    const input = Array.from(document.querySelectorAll('input')).find((node) =>
+      !node.disabled && node.type !== 'hidden' && node.getClientRects().length > 0);
+    if (!input) return false;
+    input.focus();
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+    setter.call(input, 'synthetic-edit');
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    return input.value === 'synthetic-edit';
+  })()`);
+  console.log(JSON.stringify({ platform: process.platform, startupMs, responseMs,
+    pollingAclCalls, editable }));
+  assert.equal(pollingAclCalls, 0, 'state polling must not synchronously launch ACL subprocesses');
+  assert.ok(editable, 'the login page must accept input');
+  console.log('login responsiveness: PASS');
+}
+
+const timeout = setTimeout(() => { console.error('login responsiveness: timeout'); app.exit(1); }, 120_000);
+run().then(() => { clearTimeout(timeout); app.exit(0); }, (error) => {
+  clearTimeout(timeout); console.error(error.stack || error); app.exit(1);
+});
+app.on('quit', () => {
+  childProcess.execFileSync = execute;
+  try { fs.rmSync(profile, { recursive: true, force: true }); } catch {}
+});
+

--- a/desktop/e2e/main-custom-profile.electron.js
+++ b/desktop/e2e/main-custom-profile.electron.js
@@ -9,6 +9,8 @@ const { CustomGatewayConfirmationOwner } = require('../lib/profiles/onboarding/c
 const { CustomProfileProvisioningRuntime } = require('../lib/profiles/provisioning/custom-profile-provisioning-runtime');
 const { PROTOCOL_FAMILY } = require('../lib/profiles/schema/school-profile-schema');
 
+const { ensureOwnerOnly } = require('../lib/platform/storage/private-file');
+
 const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'campus-custom-main-e2e-'));
 fs.chmodSync(userData, 0o700);
 process.env.HKUSTGZ_USER_DATA_DIR = userData;
@@ -19,6 +21,7 @@ dialog.showErrorBox = (title, message) => {
 function writeJson(file, value) {
   fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
   fs.writeFileSync(file, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+  assert.equal(ensureOwnerOnly(file), true, 'fixture JSON must have native private permissions');
 }
 
 function provision() {

--- a/desktop/e2e/main-network-startup.electron.js
+++ b/desktop/e2e/main-network-startup.electron.js
@@ -24,6 +24,7 @@ const profile = fs.mkdtempSync(path.join(os.tmpdir(), 'hkustgz-network-startup-e
 const networkStateFile = path.join(profile, 'synthetic-network-state.txt');
 const attemptFile = path.join(profile, 'synthetic-engine-attempt.txt');
 process.env.HKUSTGZ_USER_DATA_DIR = profile;
+app.setPath('userData', profile);
 process.env.HKUSTGZ_SYNTHETIC_ENGINE_E2E = '1';
 process.env.HKUSTGZ_SYNTHETIC_ENGINE_STABLE_E2E = '1';
 process.env.HKUSTGZ_SYNTHETIC_NETWORK_E2E = '1';

--- a/desktop/e2e/persistence-migration.electron.js
+++ b/desktop/e2e/persistence-migration.electron.js
@@ -13,6 +13,13 @@ const {
 const v123Settings = require('./fixtures/v1.2.3-settings.json');
 
 const WAIT_MS = 30_000;
+const prepareIndex = process.argv.indexOf('--prepare-legacy-credential');
+const preparingCredential = prepareIndex >= 0;
+const userData = preparingCredential ? process.argv[prepareIndex + 1]
+  : fs.mkdtempSync(path.join(os.tmpdir(), 'hkust-persistence-e2e-'));
+const harnessData = preparingCredential ? userData
+  : fs.mkdtempSync(path.join(os.tmpdir(), 'hkust-persistence-harness-'));
+app.setPath('userData', harnessData);
 
 function delay(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
 
@@ -45,18 +52,29 @@ async function stopOwnedProcess(pid) {
 async function run() {
   app.setName('HKUST(GZ) Connect');
   await app.whenReady();
-  assert.equal(safeStorage.isEncryptionAvailable(), true);
-  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'hkust-persistence-e2e-'));
   const legacy = createLegacyFlatSourcePaths(userData);
+  if (preparingCredential) {
+    assert.equal(safeStorage.isEncryptionAvailable(), true);
+    fs.writeFileSync(legacy.vpnCredential, safeStorage.encryptString('synthetic-v1-2-3-password'), {
+      mode: 0o600,
+    });
+    return;
+  }
+  // Windows writes the OSCrypt Local State key when Electron exits. Finish the
+  // legacy writer before starting migration, exactly as an application upgrade.
+  await new Promise((resolve, reject) => {
+    const preparer = spawn(process.execPath,
+      [__filename, '--prepare-legacy-credential', userData], { stdio: 'inherit' });
+    preparer.once('error', reject);
+    preparer.once('exit', (code) => code === 0 ? resolve()
+      : reject(new Error('legacy credential preparation failed: ' + code)));
+  });
   // This checked-in document is the exact flat settings shape emitted by the
   // published v1.2.3 line. Do not generate it with current normalizers: doing
   // so would let a schema regression change both the migration and its input.
   const bytes = Buffer.from(JSON.stringify(v123Settings), 'utf8');
   fs.writeFileSync(legacy.settings, bytes, { mode: 0o600 });
   fs.writeFileSync(legacy.settingsBackup, bytes, { mode: 0o600 });
-  fs.writeFileSync(legacy.vpnCredential, safeStorage.encryptString('synthetic-v1-2-3-password'), {
-    mode: 0o600,
-  });
   fs.writeFileSync(legacy.routingRules, '{"schemaVersion":1,"rules":[]}', { mode: 0o600 });
   fs.writeFileSync(legacy.engineLogRotated, Buffer.alloc(0), { mode: 0o600 });
   const markerPath = path.join(userData, 'persistence-e2e-ready.json');
@@ -137,7 +155,7 @@ async function run() {
   }
 }
 
-run().then(() => app.quit()).catch((error) => {
+run().then(() => { app.quit(); if (!preparingCredential) fs.rmSync(harnessData, { recursive: true, force: true }); }).catch((error) => {
   process.stderr.write(`${error.stack || error}\n`);
   process.exitCode = 1;
   app.exit(1);

--- a/desktop/e2e/resource-manager-layout.electron.js
+++ b/desktop/e2e/resource-manager-layout.electron.js
@@ -199,7 +199,8 @@ async function exerciseAddWebsiteDialogLayout(window) {
       `${label}: dialog is not horizontally centered`);
     assert.ok(view.close.top >= view.dialog.top && view.close.right <= view.dialog.right,
       `${label}: close control is clipped`);
-    assert.ok(view.actions.bottom <= view.dialog.bottom, `${label}: action bar is outside the dialog`);
+    // DOMRect uses floating point; compare at Blink's 1/64 CSS-pixel layout precision.
+    assert.ok(Math.round(view.actions.bottom * 64) <= Math.round(view.dialog.bottom * 64), `${label}: action bar is outside the dialog`);
     assert.ok(view.bodyOverflow <= 0, `${label}: dialog overflows horizontally`);
     await window.webContents.executeJavaScript(`document.getElementById('addWebsiteDialog').close()`);
   }

--- a/desktop/e2e/routing-restart.electron.js
+++ b/desktop/e2e/routing-restart.electron.js
@@ -236,7 +236,12 @@ async function runStage1(dependencies, profile) {
     route: dependencies.ROUTE_DIRECT,
   }, 200);
   assertPersistedResolution(store, dependencies);
-  assert.equal(fs.statSync(ruleFile).mode & 0o077, 0);
+  if (process.platform === 'win32') {
+    const { verifyWindowsFileOwnerOnly } = require('../lib/platform/storage/windows-private-file');
+    assert.equal(verifyWindowsFileOwnerOnly(ruleFile), true);
+  } else {
+    assert.equal(fs.statSync(ruleFile).mode & 0o077, 0);
+  }
   process.stdout.write('routing restart stage1: PASS\n');
 }
 

--- a/desktop/lib/persistence/runtime/desktop-persistence-runtime.js
+++ b/desktop/lib/persistence/runtime/desktop-persistence-runtime.js
@@ -101,7 +101,10 @@ class DesktopPersistenceRuntime {
   loadSettings() {
     this.#requireReady();
     if (this.mode === 'legacy-flat') return this.legacy.loadSettings();
-    this.authority = this.runtime.reloadAuthority();
+    // Startup and committed mutations own this validated snapshot. Display and
+    // locale reads must not reload every document (and launch synchronous
+    // Windows ACL checks). Security-sensitive consumers use currentAuthority
+    // or the credential store, which still validate the files on disk.
     return projectRuntimeSettings(this.authority, { accountLabel: this.accountLabel });
   }
 
@@ -143,7 +146,7 @@ class DesktopPersistenceRuntime {
   hasCredential() {
     this.#requireReady();
     if (this.mode === 'legacy-flat') return this.legacy.hasCredential();
-    this.authority = this.runtime.reloadAuthority();
+    // This is a display hint; openCredential still validates current storage.
     return this.authority.hasCredential;
   }
 

--- a/desktop/lib/platform/storage/native/windows-private-file.c
+++ b/desktop/lib/platform/storage/native/windows-private-file.c
@@ -1,0 +1,150 @@
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <aclapi.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <wchar.h>
+
+/* This unprivileged helper has no credential or file-content access. It applies
+ * the same current-user-only ACL contract as the PowerShell fallback, using an
+ * open, non-reparse file handle for both mutation and verification. */
+static TOKEN_USER *current_user(void) {
+    HANDLE token = NULL;
+    DWORD bytes = 0;
+    TOKEN_USER *user = NULL;
+    if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) return NULL;
+    if (GetTokenInformation(token, TokenUser, NULL, 0, &bytes) ||
+        GetLastError() != ERROR_INSUFFICIENT_BUFFER ||
+        bytes < sizeof(TOKEN_USER) || bytes > 65536) goto done;
+    user = (TOKEN_USER *)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, bytes);
+    if (user == NULL) goto done;
+    if (!GetTokenInformation(token, TokenUser, user, bytes, &bytes) ||
+        !IsValidSid(user->User.Sid)) {
+        HeapFree(GetProcessHeap(), 0, user);
+        user = NULL;
+    }
+done:
+    CloseHandle(token);
+    return user;
+}
+
+static int owner_matches(HANDLE file, PSID sid) {
+    PSECURITY_DESCRIPTOR descriptor = NULL;
+    PSID owner = NULL;
+    int valid = 0;
+    if (GetSecurityInfo(file, SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION,
+        &owner, NULL, NULL, NULL, &descriptor) == ERROR_SUCCESS) {
+        valid = owner != NULL && IsValidSid(owner) && EqualSid(owner, sid);
+    }
+    if (descriptor != NULL) LocalFree(descriptor);
+    return valid;
+}
+
+static int verify_owner_only(HANDLE file, PSID sid) {
+    PSECURITY_DESCRIPTOR descriptor = NULL;
+    PSID owner = NULL;
+    PACL dacl = NULL;
+    ACL_SIZE_INFORMATION size;
+    SECURITY_DESCRIPTOR_CONTROL control = 0;
+    DWORD revision = 0;
+    void *raw_ace = NULL;
+    ACCESS_ALLOWED_ACE *ace;
+    int valid = 0;
+    if (GetSecurityInfo(file, SE_FILE_OBJECT,
+        OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+        &owner, NULL, &dacl, NULL, &descriptor) != ERROR_SUCCESS) goto done;
+    if (owner == NULL || !IsValidSid(owner) || !EqualSid(owner, sid) ||
+        dacl == NULL || !IsValidAcl(dacl)) goto done;
+    if (!GetSecurityDescriptorControl(descriptor, &control, &revision) ||
+        (control & SE_DACL_PROTECTED) == 0) goto done;
+    if (!GetAclInformation(dacl, &size, sizeof(size), AclSizeInformation) ||
+        size.AceCount != 1 || !GetAce(dacl, 0, &raw_ace)) goto done;
+    ace = (ACCESS_ALLOWED_ACE *)raw_ace;
+    if (ace->Header.AceType != ACCESS_ALLOWED_ACE_TYPE ||
+        ace->Header.AceFlags != 0 ||
+        ace->Header.AceSize < offsetof(ACCESS_ALLOWED_ACE, SidStart) + GetLengthSid(sid) ||
+        (ace->Mask & FILE_ALL_ACCESS) != FILE_ALL_ACCESS) goto done;
+    if (!IsValidSid((PSID)&ace->SidStart) ||
+        GetLengthSid((PSID)&ace->SidStart) > ace->Header.AceSize - offsetof(ACCESS_ALLOWED_ACE, SidStart) ||
+        !EqualSid((PSID)&ace->SidStart, sid)) goto done;
+    valid = 1;
+done:
+    if (descriptor != NULL) LocalFree(descriptor);
+    return valid;
+}
+
+static int protect_owner_only(HANDLE file, PSID sid) {
+    EXPLICIT_ACCESSW access;
+    PACL dacl = NULL;
+    DWORD result;
+    ZeroMemory(&access, sizeof(access));
+    access.grfAccessPermissions = FILE_ALL_ACCESS;
+    access.grfAccessMode = SET_ACCESS;
+    access.grfInheritance = NO_INHERITANCE;
+    access.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+    access.Trustee.TrusteeType = TRUSTEE_IS_USER;
+    access.Trustee.ptstrName = (LPWSTR)sid;
+    result = SetEntriesInAclW(1, &access, NULL, &dacl);
+    if (result != ERROR_SUCCESS) return 0;
+    result = SetSecurityInfo(file, SE_FILE_OBJECT,
+        OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+        sid, NULL, dacl, NULL);
+    LocalFree(dacl);
+    return result == ERROR_SUCCESS && verify_owner_only(file, sid);
+}
+
+int wmain(int argc, wchar_t **argv) {
+    const wchar_t *operation;
+    wchar_t *file_path = NULL;
+    TOKEN_USER *user = NULL;
+    HANDLE file = INVALID_HANDLE_VALUE;
+    BY_HANDLE_FILE_INFORMATION info;
+    DWORD length, attributes, desired_access;
+    int is_verify, is_tighten, success = 0;
+
+    if (argc != 2) return 2;
+    operation = argv[1];
+    if (wcscmp(operation, L"--version") == 0) {
+        fputs("ec-private-file 1\n", stdout);
+        return 0;
+    }
+    if (wcscmp(operation, L"--help") == 0) {
+        fputs("ec-private-file verify|tighten|protect (HKUSTGZ_PRIVATE_FILE)\n", stdout);
+        return 0;
+    }
+    is_verify = wcscmp(operation, L"verify") == 0;
+    is_tighten = wcscmp(operation, L"tighten") == 0;
+    if (!is_verify && !is_tighten && wcscmp(operation, L"protect") != 0) return 2;
+
+    length = GetEnvironmentVariableW(L"HKUSTGZ_PRIVATE_FILE", NULL, 0);
+    if (length < 2 || length > 32768) return 2;
+    file_path = (wchar_t *)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY,
+                                    (SIZE_T)length * sizeof(wchar_t));
+    if (file_path == NULL) goto done;
+    if (GetEnvironmentVariableW(L"HKUSTGZ_PRIVATE_FILE", file_path, length) != length - 1) goto done;
+    /* Reject device/pipe paths before opening, then independently check the
+     * opened object. OPEN_REPARSE_POINT prevents following a final symlink. */
+    attributes = GetFileAttributesW(file_path);
+    if (attributes == INVALID_FILE_ATTRIBUTES ||
+        (attributes & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT)) != 0) goto done;
+    user = current_user();
+    if (user == NULL) goto done;
+    desired_access = READ_CONTROL;
+    if (!is_verify) desired_access |= WRITE_DAC | WRITE_OWNER;
+    file = CreateFileW(file_path, desired_access,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING,
+        FILE_FLAG_OPEN_REPARSE_POINT, NULL);
+    if (file == INVALID_HANDLE_VALUE || GetFileType(file) != FILE_TYPE_DISK) goto done;
+    if (!GetFileInformationByHandle(file, &info) ||
+        (info.dwFileAttributes & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT)) != 0 ||
+        info.nNumberOfLinks != 1) goto done;
+    if (is_tighten && !owner_matches(file, user->User.Sid)) goto done;
+    success = is_verify ? verify_owner_only(file, user->User.Sid)
+                        : protect_owner_only(file, user->User.Sid);
+done:
+    if (file != INVALID_HANDLE_VALUE) CloseHandle(file);
+    if (user != NULL) HeapFree(GetProcessHeap(), 0, user);
+    if (file_path != NULL) HeapFree(GetProcessHeap(), 0, file_path);
+    if (success) fputs("owner_only", stdout);
+    return success ? 0 : 1;
+}

--- a/desktop/lib/platform/storage/windows-private-file.js
+++ b/desktop/lib/platform/storage/windows-private-file.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('node:path');
+const fs = require('node:fs');
 const { execFileSync } = require('node:child_process');
 
 const PRIVATE_FILE_ENV = 'HKUSTGZ_PRIVATE_FILE';
@@ -67,16 +68,37 @@ function validWindowsPath(filePath) {
       : path.win32.isAbsolute(filePath));
 }
 
-function runAclScript(filePath, script, {
+// Resolve only our installed resource or source-tree build, never a PATH entry.
+// Once present, a helper rejection fails closed; it does not retry a different
+// implementation that could accidentally accept a rejected file.
+function nativeHelperPath() {
+  const name = 'ec-private-file-windows-amd64.exe';
+  const directory = process.resourcesPath
+    ? path.join(process.resourcesPath, 'engine')
+    : path.resolve(__dirname, '..', '..', '..', 'engine');
+  const packaged = path.join(directory, name);
+  if (fs.existsSync(packaged)) return packaged;
+  // Electron development runs have resourcesPath pointing to Electron itself.
+  if (!__dirname.includes('app.asar')) {
+    const development = path.resolve(__dirname, '..', '..', '..', 'engine', name);
+    if (fs.existsSync(development)) return development;
+  }
+  return null;
+}
+
+function runAclScript(filePath, script, operation, {
   execute = execFileSync,
   environment = process.env,
   platform = process.platform,
+  nativeHelper = execute === execFileSync,
 } = {}) {
   if (platform !== 'win32' || !validWindowsPath(filePath) || typeof execute !== 'function') {
     return false;
   }
   try {
-    const output = execute('powershell.exe', [...POWERSHELL_ARGS, script], {
+    const helper = nativeHelper && process.platform === 'win32' ? nativeHelperPath() : null;
+    const output = execute(helper || 'powershell.exe',
+      helper ? [operation] : [...POWERSHELL_ARGS, script], {
       encoding: 'utf8',
       env: { ...environment, [PRIVATE_FILE_ENV]: filePath },
       maxBuffer: 4096,
@@ -90,15 +112,15 @@ function runAclScript(filePath, script, {
 }
 
 function protectWindowsFileOwnerOnly(filePath, options) {
-  return runAclScript(filePath, PROTECT_SCRIPT, options);
+  return runAclScript(filePath, PROTECT_SCRIPT, 'protect', options);
 }
 
 function tightenWindowsFileOwnerOnly(filePath, options) {
-  return runAclScript(filePath, TIGHTEN_SCRIPT, options);
+  return runAclScript(filePath, TIGHTEN_SCRIPT, 'tighten', options);
 }
 
 function verifyWindowsFileOwnerOnly(filePath, options) {
-  return runAclScript(filePath, VERIFY_SCRIPT, options);
+  return runAclScript(filePath, VERIFY_SCRIPT, 'verify', options);
 }
 
 module.exports = {

--- a/desktop/lib/resources/runtime/resource-library-runtime.js
+++ b/desktop/lib/resources/runtime/resource-library-runtime.js
@@ -7,7 +7,7 @@ const { ResourceActivityStore } = require('./resource-activity-store');
 const { localizeResources } = require('../presentation/localized-resource-view');
 const { normalizePageFavoriteCandidate } = require('../schema/campus-resource-contract');
 const { PageFavoriteController } = require('./page-favorite-controller');
-const { FavoriteGroupStore } = require('./favorite-group-store');
+const { FavoriteGroupStore, groupProjection } = require('./favorite-group-store');
 
 class ResourceLibraryRuntime {
   constructor({
@@ -35,6 +35,8 @@ class ResourceLibraryRuntime {
     this.isContextCurrent = isContextCurrent;
     this.openRequest = openRequest;
     this.activityStore = new ActivityStoreClass({ favoritesFile, recentFile, platform });
+    this.activitySnapshot = null;
+    this.groupSnapshot = null;
     this.groupStore = new GroupStoreClass({
       filePath: path.join(path.dirname(favoritesFile), 'favorite-groups.json'),
       platform,
@@ -71,15 +73,17 @@ class ResourceLibraryRuntime {
     }));
   }
 
-  snapshot() { return this.#reconcileActivity(null); }
+  snapshot() { this.activitySnapshot = null; return this.#reconcileActivity(null); }
 
   toggleFavorite(resourceId, resources) {
+    this.activitySnapshot = null;
     const next = this.activityStore.toggleFavorite(resourceId, resources);
-    if (!next.entries.includes(resourceId)) this.groupStore.removeResource(resourceId);
+    if (!next.entries.includes(resourceId)) this.removeResourceFromGroups(resourceId);
     return next;
   }
 
   replaceFavorites(document) {
+    this.activitySnapshot = null;
     return this.activityStore.replaceFavorites(document);
   }
 
@@ -90,7 +94,7 @@ class ResourceLibraryRuntime {
     try {
       favorites = new Set(this.#reconcileActivity(null).favorites.entries);
       resources = new Set(this.loadResources().map(({ id }) => id));
-      document = this.groupStore.groups();
+      document = groupProjection(this.#groupDocument());
     }
     catch { return Object.freeze([]); }
     const groups = document.map((group) => Object.freeze({
@@ -100,19 +104,21 @@ class ResourceLibraryRuntime {
     return Object.freeze(groups);
   }
 
-  groupsSnapshot() { return this.groupStore.snapshot(); }
+  groupsSnapshot() { this.groupSnapshot = null; return this.#groupDocument(); }
 
-  replaceGroups(document) { return this.groupStore.replace(document); }
+  replaceGroups(document) { this.groupSnapshot = null; return this.groupStore.replace(document); }
 
-  createGroup(name) { return this.groupStore.create(name); }
+  createGroup(name) { this.groupSnapshot = null; return this.groupStore.create(name); }
 
-  renameGroup(groupId, name) { return this.groupStore.rename(groupId, name); }
+  renameGroup(groupId, name) { this.groupSnapshot = null; return this.groupStore.rename(groupId, name); }
 
-  deleteGroup(groupId) { return this.groupStore.remove(groupId); }
+  deleteGroup(groupId) { this.groupSnapshot = null; return this.groupStore.remove(groupId); }
 
-  reorderGroups(groupIds) { return this.groupStore.reorder(groupIds); }
+  reorderGroups(groupIds) { this.groupSnapshot = null; return this.groupStore.reorder(groupIds); }
 
   moveResource(resourceId, groupId, index) {
+    this.groupSnapshot = null;
+    this.activitySnapshot = null;
     return this.groupStore.move(
       resourceId,
       groupId,
@@ -122,6 +128,8 @@ class ResourceLibraryRuntime {
   }
 
   addResourcesToGroup(resourceIds, groupId) {
+    this.groupSnapshot = null;
+    this.activitySnapshot = null;
     return this.groupStore.addMany(
       resourceIds,
       groupId,
@@ -129,7 +137,7 @@ class ResourceLibraryRuntime {
     );
   }
 
-  removeResourceFromGroups(resourceId) { return this.groupStore.removeResource(resourceId); }
+  removeResourceFromGroups(resourceId) { this.groupSnapshot = null; return this.groupStore.removeResource(resourceId); }
 
   recordOpenByUrl(rawUrl) {
     let canonical;
@@ -151,6 +159,7 @@ class ResourceLibraryRuntime {
       }
     });
     if (!resource) return false;
+    this.activitySnapshot = null;
     this.activityStore.recordOpen(resource.id, resources);
     return true;
   }
@@ -169,6 +178,7 @@ class ResourceLibraryRuntime {
     });
     if (!result?.ok) return result;
     if (this.isContextCurrent(context)) {
+      this.activitySnapshot = null;
       try { this.activityStore.recordOpen(resource.id, this.loadResources()); } catch {}
     }
     return Object.freeze({
@@ -179,6 +189,8 @@ class ResourceLibraryRuntime {
     });
   }
 
+  #groupDocument() { return this.groupSnapshot ||= this.groupStore.snapshot(); }
+
   #reconcileActivity(settings) {
     const aliases = this.loadAliases(settings);
     if (!Array.isArray(aliases) || aliases.length > 32 || aliases.some((alias) =>
@@ -186,7 +198,9 @@ class ResourceLibraryRuntime {
       !/^[a-z0-9-]{1,40}$/u.test(alias.to))) {
       throw new TypeError('resource activity aliases are invalid');
     }
-    const current = this.activityStore.snapshot();
+    // Presentation reads share one validated snapshot. Explicit snapshots and
+    // mutations invalidate it; the store still verifies every disk operation.
+    const current = this.activitySnapshot ||= this.activityStore.snapshot();
     if (!aliases.length) return current;
     const map = new Map(aliases.map(({ from, to }) => [from, to]));
     const favoriteEntries = [...new Set(current.favorites.entries.map((id) => map.get(id) || id))];
@@ -201,15 +215,17 @@ class ResourceLibraryRuntime {
     const nextFavorites = { schemaVersion: 1, entries: favoriteEntries };
     const nextRecent = { schemaVersion: 1, entries: recentEntries };
     if (JSON.stringify(nextFavorites) !== JSON.stringify(current.favorites)) {
+      this.activitySnapshot = null;
       this.activityStore.replaceFavorites(nextFavorites);
     }
     if (JSON.stringify(nextRecent) !== JSON.stringify(current.recent)) {
       if (typeof this.activityStore.replaceRecent !== 'function') {
         throw new Error('resource activity store cannot migrate recent entries');
       }
+      this.activitySnapshot = null;
       this.activityStore.replaceRecent(nextRecent);
     }
-    const groupDocument = this.groupStore.snapshot();
+    const groupDocument = this.#groupDocument();
     const pairs = new Set();
     const placements = groupDocument.placements.map((placement) => ({
       ...placement,
@@ -227,12 +243,10 @@ class ResourceLibraryRuntime {
         .map((placement, order) => ({ ...placement, order }))),
     };
     if (JSON.stringify(nextGroups) !== JSON.stringify(groupDocument)) {
+      this.groupSnapshot = null;
       this.groupStore.replace(nextGroups);
     }
-    return Object.freeze({
-      favorites: this.activityStore.snapshot().favorites,
-      recent: this.activityStore.snapshot().recent,
-    });
+    return this.activitySnapshot ||= this.activityStore.snapshot();
   }
 }
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -39,7 +39,11 @@
     "dist": "electron-builder --publish never",
     "dist:mac": "electron-builder --mac --publish never",
     "dist:win": "electron-builder --win --x64 --publish never",
-    "dist:linux": "electron-builder --linux AppImage --x64 --publish never"
+    "dist:linux": "electron-builder --linux AppImage --x64 --publish never",
+    "build:windows-private-file": "node scripts/build-windows-private-file.js",
+    "predist:win": "npm run build:windows-private-file",
+    "test:login-responsive": "electron e2e/login-responsive.electron.js",
+    "pretest:windows": "npm run build:windows-private-file"
   },
   "devDependencies": {
     "@electron/asar": "^3.4.1",
@@ -67,7 +71,8 @@
       "renderer/**/*",
       "assets/**/*",
       "build/icon.ico",
-      "build/icon.png"
+      "build/icon.png",
+      "!lib/**/*.c"
     ],
     "extraResources": [
       {
@@ -80,7 +85,8 @@
           "ec-proxy-command.exe",
           "ec-gateway-probe-*",
           "ec-gateway-probe.exe",
-          "*.json"
+          "*.json",
+          "ec-private-file-windows-*.exe"
         ]
       }
     ],

--- a/desktop/scripts/build-windows-private-file.js
+++ b/desktop/scripts/build-windows-private-file.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+function findCommand(name, env = process.env) {
+  const result = spawnSync('where.exe', [name], { env, encoding: 'utf8', windowsHide: true });
+  return result.status === 0 ? result.stdout.trim().split(/\r?\n/u)[0] : null;
+}
+
+function compilerEnvironment() {
+  const direct = findCommand('cl.exe');
+  if (direct) return { command: direct, msvc: true, env: process.env };
+  const vswhere = path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)',
+    'Microsoft Visual Studio', 'Installer', 'vswhere.exe');
+  if (fs.existsSync(vswhere)) {
+    const discovery = spawnSync(vswhere, [
+      '-latest', '-products', '*', '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+      '-property', 'installationPath',
+    ], { encoding: 'utf8', windowsHide: true });
+    const installation = discovery.status === 0 ? discovery.stdout.trim() : '';
+    if (installation && !/[\r\n"%]/u.test(installation)) {
+      const setup = path.join(installation, 'Common7', 'Tools', 'VsDevCmd.bat');
+      const result = spawnSync(process.env.ComSpec || 'cmd.exe',
+        ['/d', '/s', '/c', `"${setup}" -no_logo -arch=x64 >nul && set`],
+        { encoding: 'utf8', windowsHide: true });
+      // Never print the environment dump: a CI environment can contain secrets.
+      if (result.status !== 0) throw new Error('Visual C++ environment initialization failed');
+      const env = { ...process.env };
+      for (const line of result.stdout.split(/\r?\n/u)) {
+        const separator = line.indexOf('=');
+        if (separator > 0) env[line.slice(0, separator)] = line.slice(separator + 1);
+      }
+      const command = findCommand('cl.exe', env);
+      if (command) return { command, msvc: true, env };
+    }
+  }
+  const gcc = findCommand('gcc.exe');
+  if (gcc) return { command: gcc, msvc: false, env: process.env };
+  throw new Error('A Windows x64 Visual C++ or GCC compiler is required');
+}
+
+function main() {
+  if (process.platform !== 'win32' || process.arch !== 'x64') {
+    throw new Error('Build this helper on Windows x64');
+  }
+  const engine = path.resolve(__dirname, '..', 'engine');
+  fs.mkdirSync(engine, { recursive: true });
+  const temporary = fs.mkdtempSync(path.join(engine, '.private-acl-build-'));
+  const output = path.join(temporary, 'ec-private-file-windows-amd64.exe');
+  const target = path.join(engine, path.basename(output));
+  const source = path.resolve(__dirname, '..', 'lib', 'platform', 'storage', 'native', 'windows-private-file.c');
+  try {
+    const compiler = compilerEnvironment();
+    const args = compiler.msvc
+      ? ['/nologo', '/O2', '/W4', '/WX', '/std:c11', '/DUNICODE', '/D_UNICODE',
+        source, '/Fe' + output, '/Fo' + path.join(temporary, 'helper.obj'), 'advapi32.lib']
+      : ['-std=c11', '-O2', '-Wall', '-Wextra', '-Werror', '-municode', '-s',
+        '-static-libgcc', source, '-ladvapi32', '-o', output];
+    const built = spawnSync(compiler.command, args, {
+      env: compiler.env, cwd: temporary, stdio: 'inherit', windowsHide: true,
+    });
+    if (built.status !== 0) throw new Error('Windows private-file helper compilation failed');
+    const version = spawnSync(output, ['--version'], { encoding: 'utf8', windowsHide: true });
+    if (version.status !== 0 || version.stdout.trim() !== 'ec-private-file 1') {
+      throw new Error('Windows private-file helper verification failed');
+    }
+    fs.copyFileSync(output, target);
+    process.stdout.write(`Windows native private-file helper: ${target}\n`);
+  } finally {
+    fs.rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+if (require.main === module) {
+  try { main(); }
+  catch (error) { process.stderr.write(`${error.message}\n`); process.exitCode = 1; }
+}
+
+module.exports = { compilerEnvironment };

--- a/desktop/test/unit/build/windows-package-workflow.test.js
+++ b/desktop/test/unit/build/windows-package-workflow.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const desktop = path.resolve(__dirname, '..', '..', '..');
+const workflow = fs.readFileSync(path.join(desktop, '..', '.github', 'workflows', 'ci.yml'), 'utf8');
+const manifest = JSON.parse(fs.readFileSync(path.join(desktop, 'package.json'), 'utf8'));
+
+function windowsPackageJob(source) {
+  const lines = source.split('\n');
+  const start = lines.indexOf('  package-verifier-platform:');
+  assert(start >= 0, 'the required package-verifier platform job must exist');
+  const next = lines.findIndex((line, index) => index > start && /^  [\w-]+:/u.test(line));
+  return lines.slice(start, next < 0 ? lines.length : next).join('\n');
+}
+
+function assertHelperBuildBeforePackage(source) {
+  const job = windowsPackageJob(source);
+  const starts = [...job.matchAll(/^      - /gmu)].map(match => match.index);
+  const steps = starts.map((start, index) => job.slice(start, starts[index + 1] ?? job.length));
+  const install = steps.findIndex(step => /^        run: npm ci\s*$/mu.test(step));
+  const helper = steps.findIndex(step => /^        run: npm run build:windows-private-file\s*$/mu.test(step));
+  const pack = steps.findIndex(step => /^        run: .*electron-builder.* --win dir --x64 --publish never\s*$/mu.test(step));
+  assert(install >= 0 && helper > install && pack > helper,
+    'same job must install dependencies and build the Windows ACL helper before direct electron-builder');
+  assert.match(steps[helper], /^        if: matrix\.platform == 'windows'\s*$/mu);
+  assert.match(steps[pack], /^        if: matrix\.platform == 'windows'\s*$/mu);
+  assert.match(job, /defaults:\n      run:\n        working-directory: desktop/u);
+  assert.doesNotMatch(steps[helper], /working-directory:|continue-on-error:/u);
+}
+
+test('clean Windows package CI explicitly builds the required private-file helper', () => {
+  assertHelperBuildBeforePackage(workflow);
+  assert.equal(manifest.scripts['build:windows-private-file'], 'node scripts/build-windows-private-file.js');
+});
+
+test('ordering contract rejects missing, late, or wrong-platform helper builds', () => {
+  const helper = "      - name: Build Windows private-file helper\n        if: matrix.platform == 'windows'\n        run: npm run build:windows-private-file\n";
+  const packageStep = "      - name: Package\n        if: matrix.platform == 'windows'\n        run: node node_modules/electron-builder/out/cli/cli.js --win dir --x64 --publish never\n";
+  const prefix = 'jobs:\n  package-verifier-platform:\n    defaults:\n      run:\n        working-directory: desktop\n    steps:\n      - name: Install\n        run: npm ci\n';
+  assert.doesNotThrow(() => assertHelperBuildBeforePackage(prefix + helper + packageStep));
+  assert.throws(() => assertHelperBuildBeforePackage(prefix + packageStep));
+  assert.throws(() => assertHelperBuildBeforePackage(prefix + packageStep + helper));
+  assert.throws(() => assertHelperBuildBeforePackage(prefix + helper.replace("== 'windows'", "== 'linux'") + packageStep));
+  assert.throws(() => assertHelperBuildBeforePackage(prefix + helper.replace('        run:', '        continue-on-error: true\n        run:') + packageStep));
+});

--- a/desktop/test/unit/persistence/runtime/desktop-persistence-runtime.test.js
+++ b/desktop/test/unit/persistence/runtime/desktop-persistence-runtime.test.js
@@ -147,3 +147,34 @@ test('Profile Workspace mode routes settings and credentials only through scoped
   assert.equal(cleared, true);
   assert.equal(persistence.hasAccountIdentity(), false);
 });
+
+test('frequent settings and account display reads reuse the validated runtime snapshot', () => {
+  let current = authority();
+  let reloads = 0;
+  const runtime = {
+    mode: 'profile-workspace',
+    authority: current,
+    settingsStore: { save() { return { authority: current }; } },
+    credentialStore: { open: () => owner() },
+    reloadAuthority() { reloads += 1; return current; },
+  };
+  const persistence = new DesktopPersistenceRuntime({
+    preReadySelection: { mode: 'profile-workspace', paths: { root: '/scoped' } },
+    initializeAfterReady: () => runtime,
+    legacy: legacy(),
+  });
+  persistence.initialize();
+  for (let i = 0; i < 20; i += 1) {
+    assert.equal(persistence.loadSettings().port, 6180);
+    assert.equal(persistence.hasCredential(), true);
+    assert.equal(persistence.hasAccountIdentity(), true);
+  }
+  assert.equal(reloads, 0, 'display reads must not synchronously reload disk/Windows ACLs');
+  current = authority({ port: 6280, hasCredential: false });
+  assert.equal(persistence.currentAuthority(), current, 'explicit authority reads still validate disk');
+  assert.equal(reloads, 1);
+  assert.equal(persistence.loadSettings().port, 6280);
+  assert.equal(persistence.hasAccountIdentity(), false);
+  runtime.reloadAuthority = () => { throw new Error('invalid ACL'); };
+  assert.throws(() => persistence.currentAuthority(), /invalid ACL/);
+});

--- a/desktop/test/unit/platform/storage/windows-private-file.test.js
+++ b/desktop/test/unit/platform/storage/windows-private-file.test.js
@@ -137,3 +137,28 @@ test('real Windows ACL survives the atomic temporary-file commit boundary', {
   assert.equal(verifyWindowsFileOwnerOnly(file), true);
   assert.equal(fs.readFileSync(file, 'utf8'), '{"schemaVersion":1}\n');
 });
+
+test('native Windows helper preserves private ACL policy without PowerShell startup', {
+  skip: process.platform !== 'win32',
+}, (t) => {
+  const helper = path.resolve(__dirname, '../../../../engine/ec-private-file-windows-amd64.exe');
+  assert.ok(fs.existsSync(helper), 'build the native Windows helper before this suite');
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'hkustgz-native-acl-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const file = path.join(directory, "private unicode 文 ' $value.json");
+  fs.writeFileSync(file, 'synthetic');
+  assert.equal(verifyWindowsFileOwnerOnly(file), false, 'inherited ACL must be rejected');
+  assert.equal(tightenWindowsFileOwnerOnly(file), true);
+  assert.equal(verifyWindowsFileOwnerOnly(file, { nativeHelper: false }), true,
+    'the independent PowerShell verifier must accept the native ACL');
+  assert.equal(protectWindowsFileOwnerOnly(directory), false);
+  assert.equal(verifyWindowsFileOwnerOnly(path.join(directory, 'absent')), false);
+  const link = path.join(directory, 'hard-link.json');
+  fs.linkSync(file, link);
+  assert.equal(verifyWindowsFileOwnerOnly(file), false);
+  assert.equal(tightenWindowsFileOwnerOnly(file), false);
+  assert.equal(protectWindowsFileOwnerOnly(file), false, 'hardlinks cannot be mutated');
+  fs.unlinkSync(link);
+  assert.equal(verifyWindowsFileOwnerOnly(file), true);
+  assert.equal(fs.readFileSync(file, 'utf8'), 'synthetic');
+});

--- a/desktop/test/unit/resources/runtime/resource-library-runtime.test.js
+++ b/desktop/test/unit/resources/runtime/resource-library-runtime.test.js
@@ -22,6 +22,12 @@ class FakeActivityStore {
   }
 }
 
+class EmptyGroupStore {
+  groups() { return []; }
+  snapshot() { return { schemaVersion: 2, collections: [], placements: [] }; }
+  removeResource() {}
+}
+
 const resources = [{
   id: 'outlook', name: 'Outlook', description: '', url: 'https://outlook.office.com/owa/',
   localizedName: { zh: '邮箱', en: 'Outlook' },
@@ -41,6 +47,7 @@ test('ID-only open resolves inside Main ownership and records activity after suc
     isContextCurrent: (value) => value === context,
     openRequest: async (request) => { requests.push(request); return { ok: true }; },
     ActivityStoreClass: FakeActivityStore,
+    GroupStoreClass: EmptyGroupStore,
   });
   const result = await runtime.openById('outlook');
   assert.deepEqual(requests, [{
@@ -111,6 +118,7 @@ test('resource presentation selects reviewed text for the active locale', () => 
     isContextCurrent: () => true,
     openRequest: async () => ({ ok: true }),
     ActivityStoreClass: FakeActivityStore,
+    GroupStoreClass: EmptyGroupStore,
   });
   assert.equal(runtime.listLocalized(null, 'zh')[0].name, '邮箱');
   assert.equal(runtime.listLocalized(null, 'en')[0].name, 'Outlook');
@@ -127,6 +135,7 @@ test('Browser navigation records a known resource by canonical URL without retai
     isContextCurrent: () => true,
     openRequest: async () => ({ ok: true }),
     ActivityStoreClass: FakeActivityStore,
+    GroupStoreClass: EmptyGroupStore,
   });
   assert.equal(runtime.recordOpenByUrl(
     'https://outlook.office.com/owa/?code=opaque#fragment',
@@ -145,6 +154,7 @@ test('failed or stale opens never record recent activity', async () => {
     isContextCurrent: () => true,
     openRequest: async () => ({ ok: false, error: 'offline' }),
     ActivityStoreClass: FakeActivityStore,
+    GroupStoreClass: EmptyGroupStore,
   });
   assert.deepEqual(await runtime.openById('outlook'), { ok: false, error: 'offline' });
   assert.deepEqual(runtime.snapshot().recent.entries, []);
@@ -162,7 +172,76 @@ test('an already stale Profile context opens no page', async () => {
     isContextCurrent: () => false,
     openRequest: async () => { openCalls += 1; return { ok: true }; },
     ActivityStoreClass: FakeActivityStore,
+    GroupStoreClass: EmptyGroupStore,
   });
   await assert.rejects(() => runtime.openById('outlook'), /stale/u);
   assert.equal(openCalls, 0);
+});
+
+test('resource display reads reuse activity and refresh after mutations', () => {
+  let reads = 0;
+  class CountedActivity extends FakeActivityStore {
+    snapshot() { reads += 1; return super.snapshot(); }
+  }
+  class Groups {
+    snapshot() { return { schemaVersion: 2, collections: [], placements: [] }; }
+    groups() { return []; }
+    removeResource() {}
+  }
+  const runtime = new ResourceLibraryRuntime({
+    favoritesFile: '/fixture/favorites.json', recentFile: '/fixture/recent.json',
+    platform: 'darwin', loadResources: () => resources,
+    loadAliases: () => [{ from: 'custom-old', to: 'outlook' }],
+    captureContext: () => ({}), isContextCurrent: () => true,
+    openRequest: async () => ({ ok: true }),
+    ActivityStoreClass: CountedActivity, GroupStoreClass: Groups,
+  });
+  for (let i = 0; i < 20; i += 1) { runtime.list(); runtime.listGroups(); }
+  assert.equal(reads, 1, 'display polling must not repeatedly read files/Windows ACLs');
+  runtime.toggleFavorite('outlook', resources);
+  assert.equal(runtime.list()[0].favorite, true);
+  assert.equal(reads, 2);
+  runtime.recordOpenByUrl('https://outlook.office.com/owa/');
+  assert.equal(runtime.list()[0].lastOpenedAt, 10);
+  assert.equal(reads, 3);
+  runtime.replaceFavorites({ schemaVersion: 1, entries: [] });
+  assert.equal(runtime.list()[0].favorite, false);
+  assert.equal(reads, 4);
+});
+
+test('collection display reads refresh after group mutations', () => {
+  let reads = 0;
+  class Groups extends EmptyGroupStore {
+    constructor() { super(); this.document = super.snapshot(); }
+    snapshot() { reads += 1; return this.document; }
+    create(name) {
+      this.document = { schemaVersion: 2, collections: [{
+        id: 'group_abcdefghijkl', name, createdAt: 1, updatedAt: 1,
+      }], placements: [] };
+    }
+    rename(id, name) {
+      this.document = { ...this.document, collections: this.document.collections.map(
+        (group) => group.id === id ? { ...group, name } : group) };
+    }
+    remove() { this.document = super.snapshot(); }
+  }
+  const runtime = new ResourceLibraryRuntime({
+    favoritesFile: '/fixture/favorites.json', recentFile: '/fixture/recent.json',
+    platform: 'darwin', loadResources: () => resources,
+    captureContext: () => ({}), isContextCurrent: () => true,
+    openRequest: async () => ({ ok: true }),
+    ActivityStoreClass: FakeActivityStore, GroupStoreClass: Groups,
+  });
+  for (let i = 0; i < 20; i += 1) assert.deepEqual(runtime.listGroups(), []);
+  assert.equal(reads, 1);
+  runtime.createGroup('First');
+  assert.equal(runtime.listGroups()[0].name, 'First');
+  assert.equal(reads, 2);
+  runtime.renameGroup('group_abcdefghijkl', 'Renamed');
+  assert.equal(runtime.listGroups()[0].name, 'Renamed');
+  runtime.deleteGroup('group_abcdefghijkl');
+  assert.deepEqual(runtime.listGroups(), []);
+  assert.equal(reads, 4);
+  runtime.groupsSnapshot();
+  assert.equal(reads, 5, 'explicit group snapshots still revalidate storage');
 });


### PR DESCRIPTION
Fixes #97: repeated synchronous PowerShell ACL checks blocked the Windows login page and state refreshes. Settings/account display and resource lists now reuse validated snapshots, invalidated after writes. A bundled Win32 helper preserves private-file ownership/DACL checks without PowerShell startup; credential reads and durable writes still validate their authority.

The Windows helper is required by packaging and checked by the exact package verifier. Electron fixtures now model an exited Windows credential writer, await completed error-page navigation, use visible windows for animation timing and compare Windows file security through ACLs.

Validation at source `fafcb6c03c2d01eba2085c7d4a693e9f65ffc538`:

- 5070 Linux: 1,236 unit tests passed, 6 platform skips; architecture, governance, syntax, exact-tree secret, install-script and dependency audit gates passed (0 reported vulnerabilities).
- 5070 Windows: designated platform suite passed (21 passed, 2 POSIX-only skips); focused ACL/persistence/resource suite passed (18 tests).
- Windows/Linux: Rust tests, clippy, lifecycle and auth/control fixtures, SOCKS and netstack release performance guards; Electron login, migration, onboarding/profile switching, network recovery, browser/MFA/routing/layout, renderer recovery and idle tests passed.
- Windows installer payload: package verification passed; login appeared in 3,440 ms, 5 state requests took 33 ms, real text input succeeded.
- Linux AppImage: package verification passed; login appeared in 1,517 ms, 5 state requests took 55 ms, real text input succeeded. Build used umask 022 so packaged files are not group-writable.
- macOS arm64/x64: package, architecture, ad-hoc signature and DMG payload checks passed. No macOS functional test or notarization was performed, as requested.

All four installers come from this commit. The maintainer restricted Windows/Linux execution to 5070; `[skip ci]` prevents a cloud rebuild. Local receipts do not satisfy or impersonate the seven required Actions contexts. Normal branch protection and review remain in place. No main merge or formal release has been performed.

No schema or protocol changes. Preserve existing user data; discard the candidate artifacts to roll back before release. See RELEASE_NOTES_2.0.1.md for user-facing changes.

